### PR TITLE
fixed head printout and flight demo index

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -113,11 +113,11 @@ class EntitySet(BaseEntitySet):
         self.entity_stores = full_entities
         return sampled
 
-    def head(self, entity_id, n=10, variable_id=None, calc_time=None):
+    def head(self, entity_id, n=10, variable_id=None, cutoff_time=None):
         if variable_id is None:
-            return self.entity_stores[entity_id].head(n=n, calc_time=calc_time)
+            return self.entity_stores[entity_id].head(n, cutoff_time=cutoff_time)
         else:
-            return self.entity_stores[entity_id][variable_id].head(n=n, calc_time=calc_time)
+            return self.entity_stores[entity_id].head(n, cutoff_time=cutoff_time)[variable_id]
 
     def get_instance_data(self, entity_id, instance_ids):
         return self.entity_stores[entity_id].query_by_values(instance_ids)

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -171,7 +171,6 @@ class Variable(FTBase):
         if cutoff_time is None:
             series = self.entityset.head(entity_id=self.entity_id, n=n,
                                          variable_id=self.id)
-            return series.to_frame()
         else:
             from featuretools.computational_backends.calculate_feature_matrix import calculate_feature_matrix
             from featuretools.primitives import Feature
@@ -182,8 +181,8 @@ class Variable(FTBase):
             cutoff_time = pd.DataFrame({'instance_id': instance_ids})
             cutoff_time['time'] = cutoff_time
             cfm = calculate_feature_matrix([f], cutoff_time=cutoff_time)
-            series = cfm[[f.get_name()]]
-            return series
+            series = cfm[f.get_name()]
+        return series.to_frame()
 
     @property
     def series(self):


### PR DESCRIPTION
For the flight fix:
- added`storage_options={'anon': True}` to fix s3 issue with public files and dask
- `df = df.reset_index(drop=True)` is there because the dataframe is read in parallel with dask, and the index needs to be reset since these values are used to create the `trip_id`

For the head fix:
- there was a circular call in the `head` function of `entityset`. This is fixed by calling head on the `entity` which uses `self.df.head` to get the values. 
- `cutoff_time` for head is not implemented yet. 