### PR TITLE
Add associative attribute to primitives

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,9 @@
 Changelog
 ---------
 
+**v0.1.10** September XX, 2017
+    * Added ``associative`` property to some primitives.  If a feature is associative, DFS will only build one feature for each unique set of base features.
+
 **v0.1.9** September 8, 2017
     * Documentation improvements
     * New ``featuretools.demo.load_mock_customer`` function

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,9 +3,6 @@
 Changelog
 ---------
 
-**v0.1.10** September XX, 2017
-    * Added ``associative`` property to some primitives.  If a feature is associative, DFS will only build one feature for each unique set of base features.
-
 **v0.1.9** September 8, 2017
     * Documentation improvements
     * New ``featuretools.demo.load_mock_customer`` function

--- a/featuretools/primitives/aggregation_primitives.py
+++ b/featuretools/primitives/aggregation_primitives.py
@@ -13,7 +13,7 @@ from scipy.stats import skew
 class Count(AggregationPrimitive):
     """Counts the number of non null values."""
     name = "count"
-    input_types =  [[Index], [Variable]]
+    input_types = [[Index], [Variable]]
     return_type = Numeric
     stack_on_self = False
     default_value = 0
@@ -45,12 +45,12 @@ class Count(AggregationPrimitive):
         use_prev_str = self._use_prev_str()
 
         return u"COUNT(%s%s%s)" % (self.child_entity.name,
-                                  where_str, use_prev_str)
+                                   where_str, use_prev_str)
 
 
 class Sum(AggregationPrimitive):
     name = "sum"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
     stack_on_exclude = [Count]
@@ -64,7 +64,7 @@ class Sum(AggregationPrimitive):
 
 class Mean(AggregationPrimitive):
     name = "mean"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = Numeric
 
     # p todo: handle nulls
@@ -75,7 +75,7 @@ class Mean(AggregationPrimitive):
 class Mode(AggregationPrimitive):
     """Finds the most common element in a categorical feature."""
     name = "mode"
-    input_types =  [Discrete]
+    input_types = [Discrete]
     return_type = None
 
     def get_function(self):
@@ -89,7 +89,7 @@ class Mode(AggregationPrimitive):
 class Min(AggregationPrimitive):
     """Finds the minimum non-null value of a numeric feature."""
     name = "min"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = None
     # max_stack_depth = 1
     stack_on_self = False
@@ -101,7 +101,7 @@ class Min(AggregationPrimitive):
 class Max(AggregationPrimitive):
     """Finds the maximum non-null value of a numeric feature."""
     name = "max"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = None
     # max_stack_depth = 1
     stack_on_self = False
@@ -131,7 +131,7 @@ class PercentTrue(AggregationPrimitive):
     Finds the percent of 'True' values in a boolean feature.
     """
     name = "percent_true"
-    input_types =  [Boolean]
+    input_types = [Boolean]
     return_type = Numeric
     max_stack_depth = 1
     stack_on = []
@@ -148,7 +148,7 @@ class PercentTrue(AggregationPrimitive):
 class NMostCommon(AggregationPrimitive):
     """Finds the N most common elements in a categorical feature."""
     name = "n_most_common"
-    input_types =  [Discrete]
+    input_types = [Discrete]
     return_type = Discrete
     # max_stack_depth = 1
     stack_on = []
@@ -187,7 +187,7 @@ class AvgTimeBetween(AggregationPrimitive):
     # should then calculate the average of that trans_feat
     # which amounts to AvgTimeBetween
     name = "avg_time_between"
-    input_types =  [DatetimeTimeIndex]
+    input_types = [DatetimeTimeIndex]
     return_type = Numeric
     # max_stack_depth = 1
 
@@ -227,7 +227,7 @@ class AvgTimeBetween(AggregationPrimitive):
 class Median(AggregationPrimitive):
     """Finds the median value of any feature with well-ordered values."""
     name = "median"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = None
     # max_stack_depth = 2
 
@@ -243,7 +243,7 @@ class Skew(AggregationPrimitive):
     distribution.
     """
     name = "skew"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = Numeric
     stack_on = []
     stack_on_self = False
@@ -256,7 +256,7 @@ class Skew(AggregationPrimitive):
 class Std(AggregationPrimitive):
     """Finds the standard deviation of a numeric feature ignoring null values."""
     name = "std"
-    input_types =  [Numeric]
+    input_types = [Numeric]
     return_type = Numeric
     # max_stack_depth = 2
     stack_on_self = False
@@ -268,7 +268,7 @@ class Std(AggregationPrimitive):
 class Last(AggregationPrimitive):
     """Returns the last value"""
     name = "last"
-    input_types =  [Variable]
+    input_types = [Variable]
     return_type = None
     stack_on_self = False
     # max_stack_depth = 1
@@ -282,7 +282,7 @@ class Last(AggregationPrimitive):
 class Any(AggregationPrimitive):
     """Test if any value is True"""
     name = "any"
-    input_types =  [Boolean]
+    input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
 
@@ -293,7 +293,7 @@ class Any(AggregationPrimitive):
 class All(AggregationPrimitive):
     """Test if all values are True"""
     name = "all"
-    input_types =  [Boolean]
+    input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
 
@@ -304,7 +304,7 @@ class All(AggregationPrimitive):
 class TimeSinceLast(AggregationPrimitive):
     """Time since last related instance"""
     name = "time_since_last"
-    input_types =  [DatetimeTimeIndex]
+    input_types = [DatetimeTimeIndex]
     return_type = Numeric
     uses_calc_time = True
 
@@ -320,7 +320,7 @@ class TimeSinceLast(AggregationPrimitive):
 class Trend(AggregationPrimitive):
     """Calculates the slope of the linear trend of variable overtime"""
     name = "trend"
-    input_types =  [Numeric, DatetimeTimeIndex]
+    input_types = [Numeric, DatetimeTimeIndex]
     return_type = Numeric
 
     def __init__(self, value, time_index, parent_entity, **kwargs):

--- a/featuretools/primitives/binary_transform.py
+++ b/featuretools/primitives/binary_transform.py
@@ -65,7 +65,7 @@ class BinaryFeature(TransformPrimitive):
 
     def _get_name(self):
         return u"%s %s %s" % (self.left_str(),
-                             self.operator, self.right_str())
+                              self.operator, self.right_str())
 
     def _get_op(self):
         return self._operators[self.operator]
@@ -115,8 +115,8 @@ class ArithmeticFeature(BinaryFeature):
     }
 
     name = None
-    input_types =  [[Numeric, Numeric],
-                    [Numeric]]
+    input_types = [[Numeric, Numeric],
+                   [Numeric]]
     return_type = Numeric
     operator = None
 
@@ -161,37 +161,40 @@ class ArithmeticFeature(BinaryFeature):
 class Add(ArithmeticFeature):
     """Creates a transform feature that adds two features"""
     operator = ArithmeticFeature._ADD
-    input_types =  [[Numeric, Numeric],
-                    [Numeric],
-                    [TimeIndex],
-                    [Datetime],
-                    [Timedelta],
-                    [TimeIndex, Timedelta],
-                    [Timedelta, TimeIndex],
-                    [Timedelta, Timedelta],
-                    [Datetime, Timedelta],
-                    [Timedelta, Datetime],
-                    ]
+    associative = True
+    input_types = [[Numeric, Numeric],
+                   [Numeric],
+                   [TimeIndex],
+                   [Datetime],
+                   [Timedelta],
+                   [TimeIndex, Timedelta],
+                   [Timedelta, TimeIndex],
+                   [Timedelta, Timedelta],
+                   [Datetime, Timedelta],
+                   [Timedelta, Datetime],
+                   ]
+
 
 class Subtract(ArithmeticFeature):
     """Creates a transform feature that subtracts two features"""
     operator = ArithmeticFeature._SUB
-    input_types =  [[Numeric, Numeric],
-                    [Numeric],
-                    [TimeIndex],
-                    [Datetime],
-                    [Timedelta],
-                    [TimeIndex, Timedelta],
-                    [Timedelta, TimeIndex],
-                    [Timedelta, Timedelta],
-                    [Datetime, Timedelta],
-                    [Timedelta, Datetime],
-                    ]
+    input_types = [[Numeric, Numeric],
+                   [Numeric],
+                   [TimeIndex],
+                   [Datetime],
+                   [Timedelta],
+                   [TimeIndex, Timedelta],
+                   [Timedelta, TimeIndex],
+                   [Timedelta, Timedelta],
+                   [Datetime, Timedelta],
+                   [Timedelta, Datetime],
+                   ]
 
 
 class Multiply(ArithmeticFeature):
     """Creates a transform feature that multplies two features"""
     operator = ArithmeticFeature._MUL
+    associative = True
 
 
 class Divide(ArithmeticFeature):
@@ -206,7 +209,7 @@ class Mod(ArithmeticFeature):
 
 class Negate(Subtract):
     """Creates a transform feature that negates a feature"""
-    input_types =  [Numeric]
+    input_types = [Numeric]
 
     def __init__(self, f):
         super(Negate, self).__init__(0, f)
@@ -253,12 +256,13 @@ class Compare(BinaryFeature):
     }
 
     name = "compare"
-    input_types =  [[Variable], [Variable, Variable]]
+    input_types = [[Variable], [Variable, Variable]]
     return_type = Boolean
 
     def __init__(self, left, operator, right):
         self.operator = operator
-
+        if operator in ['=', '!=']:
+            self.associative = True
         super(Compare, self).__init__(left, right)
 
     def invert(self):
@@ -270,8 +274,9 @@ class Compare(BinaryFeature):
 
 class And(TransformPrimitive):
     name = "and"
-    input_types =  [Boolean, Boolean]
+    input_types = [Boolean, Boolean]
     return_type = Boolean
+    associative = True
 
     def get_function(self):
         return lambda left, right: np.logical_and(left, right)
@@ -279,8 +284,9 @@ class And(TransformPrimitive):
 
 class Or(TransformPrimitive):
     name = "or"
-    input_types =  [Boolean, Boolean]
+    input_types = [Boolean, Boolean]
     return_type = Boolean
+    associative = True
 
     def get_function(self):
         return lambda left, right: np.logical_or(left, right)

--- a/featuretools/primitives/binary_transform.py
+++ b/featuretools/primitives/binary_transform.py
@@ -259,17 +259,37 @@ class Compare(BinaryFeature):
     input_types = [[Variable], [Variable, Variable]]
     return_type = Boolean
 
-    def __init__(self, left, operator, right):
-        self.operator = operator
-        if operator in ['=', '!=']:
-            self.associative = True
-        super(Compare, self).__init__(left, right)
-
     def invert(self):
         self.operator = self._inv_operators[self.operator]
 
     def get_function(self):
         return self.pd_binary
+
+
+class Equals(Compare):
+    associative = True
+    operator = '='
+
+
+class NotEquals(Compare):
+    associative = True
+    operator = '!='
+
+
+class GreaterThan(Compare):
+    operator = '>'
+
+
+class GreaterThanEqualTo(Compare):
+    operator = '>='
+
+
+class LessThan(Compare):
+    operator = '<'
+
+
+class LessThanEqualTo(Compare):
+    operator = '<='
 
 
 class And(TransformPrimitive):

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -27,6 +27,7 @@ class PrimitiveBase(FTBase):
     _name = None
     base_of = None  # whitelist of primitives can have this primitive in input_types
     base_of_exclude = None  # blacklist of primitives can have this primitive in input_types
+    associative = False  # (bool) If True, will only make one feature per unique set of base features
 
     def __init__(self, entity, base_features, **kwargs):
         assert all(isinstance(f, PrimitiveBase) for f in base_features), \

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -70,7 +70,6 @@ class PrimitiveBase(FTBase):
             return pickled
         return self.__dict__
 
-
     def __setstate__(self, d):
         self.__dict__ = d
         if hasattr(ft, '_pickling') and ft._pickling:
@@ -161,8 +160,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.equal_to`
         """
-        from binary_transform import Compare
-        return Compare(self, "=", other_feature_or_val)
+        from binary_transform import Equals
+        return Equals(self, other_feature_or_val)
 
     def __ne__(self, other_feature_or_val):
         """Compares to other_feature_or_val by non-equality
@@ -170,8 +169,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.not_equal_to`
         """
-        from binary_transform import Compare
-        return Compare(self, "!=", other_feature_or_val)
+        from binary_transform import NotEquals
+        return NotEquals(self, other_feature_or_val)
 
     def __gt__(self, other_feature_or_val):
         """Compares if greater than other_feature_or_val
@@ -179,8 +178,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.GT`
         """
-        from binary_transform import Compare
-        return Compare(self, ">", other_feature_or_val)
+        from binary_transform import GreaterThan
+        return GreaterThan(self, other_feature_or_val)
 
     def __ge__(self, other_feature_or_val):
         """Compares if greater than or equal to other_feature_or_val
@@ -188,8 +187,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.greater_than_equal_to`
         """
-        from binary_transform import Compare
-        return Compare(self, ">=", other_feature_or_val)
+        from binary_transform import GreaterThanEqualTo
+        return GreaterThanEqualTo(self, other_feature_or_val)
 
     def __lt__(self, other_feature_or_val):
         """Compares if less than other_feature_or_val
@@ -197,8 +196,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.less_than`
         """
-        from binary_transform import Compare
-        return Compare(self, "<", other_feature_or_val)
+        from binary_transform import LessThan
+        return LessThan(self, other_feature_or_val)
 
     def __le__(self, other_feature_or_val):
         """Compares if less than or equal to other_feature_or_val
@@ -206,8 +205,8 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.less_than_equal_to`
         """
-        from binary_transform import Compare
-        return Compare(self, "<=", other_feature_or_val)
+        from binary_transform import LessThanEqualTo
+        return LessThanEqualTo(self, other_feature_or_val)
 
     def __add__(self, other_feature_or_val):
         """Add other_feature_or_val"""

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -254,7 +254,7 @@ class IsIn(TransformPrimitive):
     For each value of the base feature, checks whether it is in a list that is provided.
     """
     name = "isin"
-    input_types =  [Variable]
+    input_types = [Variable]
     return_type = Boolean
 
     def __init__(self, base_feature, list_of_outputs=None):
@@ -280,7 +280,7 @@ class Diff(TransformPrimitive):
     If it is a Datetime feature, compute the difference in seconds
     """
     name = "diff"
-    input_types =  [Numeric, Id]
+    input_types = [Numeric, Id]
     return_type = Numeric
 
     def __init__(self, base_feature, group_feature):
@@ -310,7 +310,7 @@ class Diff(TransformPrimitive):
 
 class Not(TransformPrimitive):
     name = "not"
-    input_types =  [Boolean]
+    input_types = [Boolean]
     return_type = Boolean
 
     def _get_name(self):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -5,7 +5,7 @@ from featuretools import variable_types
 from featuretools.variable_types import Categorical, Numeric, Boolean, Ordinal
 from featuretools.primitives.api import (IdentityFeature, BinaryFeature, Discrete,
                                          TimeSince, DirectFeature, Compare,
-                                         AggregationPrimitive)
+                                         AggregationPrimitive, Equals)
 import featuretools.primitives.api as ftypes
 from .dfs_filters import (TraverseUp, LimitModeUniques)
 
@@ -486,7 +486,7 @@ class DeepFeatureSynthesis(object):
                 continue
 
             for val in feat.variable.interesting_values:
-                self.where_clauses[entity.id].add(Compare(feat, Compare.EQ, val))
+                self.where_clauses[entity.id].add(Equals(feat, val))
 
     def _build_transform_features(self, all_features, entity, max_depth=0):
         """Creates trans_features for all the variables in an entity
@@ -734,9 +734,7 @@ def match(input_types, features, replace=False, associative=False):
     if len(input_types) == 1:
         return [(m,) for m in matches]
 
-    matching_inputs = []
-    if associative:
-        matching_inputs_sets = set([])
+    matching_inputs = set([])
 
     for m in matches:
         copy = features[:]
@@ -749,10 +747,11 @@ def match(input_types, features, replace=False, associative=False):
             new_match = [m] + list(r)
             if associative:
                 new_input_set = frozenset(new_match)
-                if new_input_set not in matching_inputs_sets:
-                    matching_inputs_sets.add(new_input_set)
+                if new_input_set not in matching_inputs:
+                    matching_inputs.add(new_input_set)
                 else:
                     continue
-            matching_inputs.append(new_match)
+            else:
+                matching_inputs.add(tuple(new_match))
 
     return set([tuple(s) for s in matching_inputs])

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -745,13 +745,13 @@ def match(input_types, features, replace=False, associative=False):
         rest = match(input_types[1:], copy, replace)
         for r in rest:
             new_match = [m] + list(r)
+
+            # associative uses frozenset instead of tuple because it doesn't
+            # want multiple orderings of the same input
             if associative:
-                new_input_set = frozenset(new_match)
-                if new_input_set not in matching_inputs:
-                    matching_inputs.add(new_input_set)
-                else:
-                    continue
+                new_match = frozenset(new_match)
             else:
-                matching_inputs.add(tuple(new_match))
+                new_match = tuple(new_match)
+            matching_inputs.add(new_match)
 
     return set([tuple(s) for s in matching_inputs])

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -2,7 +2,9 @@ import pytest
 from featuretools.computational_backends.pandas_backend import PandasBackend
 from featuretools.primitives import (IdentityFeature, DirectFeature, Sum,
                                      Count, Min, Mode, Compare, Mean, And,
-                                     NMostCommon)
+                                     NMostCommon, GreaterThan, LessThan,
+                                     GreaterThanEqualTo, LessThanEqualTo,
+                                     Equals, NotEquals)
 from featuretools import Timedelta
 from ..testing_utils import make_ecommerce_entityset
 from datetime import datetime
@@ -151,13 +153,13 @@ def test_make_agg_feat_multiple_dtypes(entityset, backend):
 
 def test_make_agg_feat_where_different_identity_feat(entityset, backend):
     feats = []
-    where_cmps = [Compare.LT, Compare.GT, Compare.LE, Compare.GE, Compare.EQ, Compare.NE]
+    where_cmps = [LessThan, GreaterThan, LessThanEqualTo,
+                  GreaterThanEqualTo, Equals, NotEquals]
     for where_cmp in where_cmps:
         feats.append(Count(entityset['log']['id'],
                            parent_entity=entityset['sessions'],
-                           where=Compare(entityset['log']['datetime'],
-                                         where_cmp,
-                                         datetime(2011, 4, 10, 10, 40, 1))))
+                           where=where_cmp(entityset['log']['datetime'],
+                                           datetime(2011, 4, 10, 10, 40, 1))))
 
     pandas_backend = backend(feats)
     df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2, 3],

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -4,7 +4,8 @@ import copy
 from featuretools.primitives import (Last, Count, Hour, IdentityFeature,
                                      TransformPrimitive, AggregationPrimitive,
                                      Feature, Max, Mean, Min, Sum, Diff,
-                                     TimeSincePrevious, CumMean, DirectFeature)
+                                     TimeSincePrevious, CumMean, DirectFeature,
+                                     Add)
 from ..testing_utils import make_ecommerce_entityset, feature_with_name
 import pandas as pd
 from featuretools.utils.gen_utils import getsize
@@ -504,3 +505,25 @@ def test_pickle_features(es):
     assert os.path.getsize(filepath) < os.path.getsize(es_filepath)
     os.remove(filepath)
     os.remove(es_filepath)
+
+
+def test_associative(es):
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='log',
+                                   entityset=es,
+                                   filters=[],
+                                   agg_primitives=[Sum],
+                                   trans_primitives=[Add],
+                                   max_depth=3)
+    feats = dfs_obj.build_features()
+    num_add_feats = 0
+    num_add_as_base_feat = 0
+
+    for feat in feats:
+        if isinstance(feat, Add):
+            num_add_feats += 1
+        for base_feat in feat.base_features:
+            if isinstance(base_feat, Add):
+                num_add_as_base_feat += 1
+
+    assert num_add_feats == 1
+    assert num_add_as_base_feat == 4

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -8,7 +8,9 @@ from featuretools.primitives import (Day, Hour, Diff, Compare, Not,
                                      Divide, CumSum, CumCount, CumMin, CumMax,
                                      CumMean, Mod, And, Or, Negate, Sum,
                                      IsIn, Feature, IsNull, get_transform_primitives,
-                                     Mode, Percentile)
+                                     Mode, Percentile, Equals, NotEquals,
+                                     GreaterThan, GreaterThanEqualTo, LessThan,
+                                     LessThanEqualTo)
 from featuretools import Timedelta
 from ..testing_utils import make_ecommerce_entityset
 import numpy as np
@@ -63,16 +65,16 @@ def test_diff(es):
 
 
 def test_compare_of_identity(es):
-    to_test = [(Compare.EQ, [False, False, True, False]),
-               (Compare.NE, [True, True, False, True]),
-               (Compare.LT, [True, True, False, False]),
-               (Compare.LE, [True, True, True, False]),
-               (Compare.GT, [False, False, False, True]),
-               (Compare.GE, [False, False, True, True])]
+    to_test = [(Equals, [False, False, True, False]),
+               (NotEquals, [True, True, False, True]),
+               (LessThan, [True, True, False, False]),
+               (LessThanEqualTo, [True, True, True, False]),
+               (GreaterThan, [False, False, False, True]),
+               (GreaterThanEqualTo, [False, False, True, True])]
 
     features = []
     for test in to_test:
-        features.append(Compare(es['log']['value'], test[0], 10))
+        features.append(test[0](es['log']['value'], 10))
 
     pandas_backend = PandasBackend(es, features)
     df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2, 3],
@@ -86,16 +88,16 @@ def test_compare_of_identity(es):
 def test_compare_of_direct(es):
     log_rating = DirectFeature(es['products']['rating'],
                                child_entity=es['log'])
-    to_test = [(Compare.EQ, [False, False, False, False]),
-               (Compare.NE, [True, True, True, True]),
-               (Compare.LT, [False, False, False, True]),
-               (Compare.LE, [False, False, False, True]),
-               (Compare.GT, [True, True, True, False]),
-               (Compare.GE, [True, True, True, False])]
+    to_test = [(Equals, [False, False, False, False]),
+               (NotEquals, [True, True, True, True]),
+               (LessThan, [False, False, False, True]),
+               (LessThanEqualTo, [False, False, False, True]),
+               (GreaterThan, [True, True, True, False]),
+               (GreaterThanEqualTo, [True, True, True, False])]
 
     features = []
     for test in to_test:
-        features.append(Compare(log_rating, test[0], 4.5))
+        features.append(test[0](log_rating, 4.5))
 
     pandas_backend = PandasBackend(es, features)
     df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2, 3],
@@ -108,16 +110,16 @@ def test_compare_of_direct(es):
 
 def test_compare_of_transform(es):
     day = Day(es['log']['datetime'])
-    to_test = [(Compare.EQ, [False, True]),
-               (Compare.NE, [True, False]),
-               (Compare.LT, [True, False]),
-               (Compare.LE, [True, True]),
-               (Compare.GT, [False, False]),
-               (Compare.GE, [False, True])]
+    to_test = [(Equals, [False, True]),
+               (NotEquals, [True, False]),
+               (LessThan, [True, False]),
+               (LessThanEqualTo, [True, True]),
+               (GreaterThan, [False, False]),
+               (GreaterThanEqualTo, [False, True])]
 
     features = []
     for test in to_test:
-        features.append(Compare(day, test[0], 10))
+        features.append(test[0](day, 10))
 
     pandas_backend = PandasBackend(es, features)
     df = pandas_backend.calculate_all_features(instance_ids=[0, 14],
@@ -132,16 +134,16 @@ def test_compare_of_agg(es):
     count_logs = Count(es['log']['id'],
                        parent_entity=es['sessions'])
 
-    to_test = [(Compare.EQ, [False, False, False, True]),
-               (Compare.NE, [True, True, True, False]),
-               (Compare.LT, [False, False, True, False]),
-               (Compare.LE, [False, False, True, True]),
-               (Compare.GT, [True, True, False, False]),
-               (Compare.GE, [True, True, False, True])]
+    to_test = [(Equals, [False, False, False, True]),
+               (NotEquals, [True, True, True, False]),
+               (LessThan, [False, False, True, False]),
+               (LessThanEqualTo, [False, False, True, True]),
+               (GreaterThan, [True, True, False, False]),
+               (GreaterThanEqualTo, [True, True, False, True])]
 
     features = []
     for test in to_test:
-        features.append(Compare(count_logs, test[0], 2))
+        features.append(test[0](count_logs, 2))
 
     pandas_backend = PandasBackend(es, features)
     df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2, 3],
@@ -399,7 +401,7 @@ def test_cum_sum_use_previous_integer_time(int_es):
 
 def test_cum_sum_where(es):
     log_value_feat = es['log']['value']
-    compare_feat = Compare(log_value_feat, '>', 3)
+    compare_feat = GreaterThan(log_value_feat, 3)
     dfeat = Feature(es['sessions']['customer_id'], es['log'])
     cum_sum = CumSum(log_value_feat, dfeat,
                      where=compare_feat)
@@ -420,7 +422,7 @@ def test_cum_sum_where(es):
 
 def test_cum_sum_use_previous_and_where(es):
     log_value_feat = es['log']['value']
-    compare_feat = Compare(log_value_feat, '>', 3)
+    compare_feat = GreaterThan(log_value_feat, 3)
     # todo should this be cummean?
     dfeat = Feature(es['sessions']['customer_id'], es['log'])
     cum_sum = CumSum(log_value_feat, dfeat,
@@ -499,7 +501,7 @@ def test_cum_sum_use_previous_group_on_nan(es):
 
 def test_cum_sum_use_previous_and_where_absolute(es):
     log_value_feat = es['log']['value']
-    compare_feat = Compare(log_value_feat, '>', 3)
+    compare_feat = GreaterThan(log_value_feat, 3)
     dfeat = Feature(es['sessions']['customer_id'], es['log'])
     cum_sum = CumSum(log_value_feat, dfeat, es["log"]["datetime"],
                      where=compare_feat,
@@ -549,7 +551,7 @@ def test_cum_mean_use_previous(es):
 
 def test_cum_mean_where(es):
     log_value_feat = es['log']['value']
-    compare_feat = Compare(log_value_feat, '>', 3)
+    compare_feat = GreaterThan(log_value_feat, 3)
     dfeat = Feature(es['sessions']['customer_id'], es['log'])
     cum_mean = CumMean(log_value_feat, dfeat,
                        where=compare_feat)
@@ -571,7 +573,7 @@ def test_cum_mean_where(es):
 
 def test_cum_mean_use_previous_and_where(es):
     log_value_feat = es['log']['value']
-    compare_feat = Compare(log_value_feat, '>', 3)
+    compare_feat = GreaterThan(log_value_feat, 3)
     # todo should this be cummean?
     dfeat = Feature(es['sessions']['customer_id'], es['log'])
     cum_mean = CumMean(log_value_feat, dfeat,
@@ -638,8 +640,8 @@ def test_overrides(es):
 
     feats = [Add, Subtract, Multiply, Divide,
              Mod, And, Or]
-    compare_ops = ['>', '<', '=', '!=',
-                   '>=', '<=']
+    compare_ops = [GreaterThan, LessThan, Equals, NotEquals,
+                   GreaterThanEqualTo, LessThanEqualTo]
     assert Negate(hour).hash() == (-hour).hash()
 
     compares = [(hour, hour),
@@ -698,7 +700,7 @@ def test_overrides(es):
             i += 1
 
         for compare_op in compare_ops:
-            f = Compare(left, compare_op, right)
+            f = compare_op(left, right)
             o = overrides[i]
             assert o.hash() == f.hash()
             i += 1
@@ -727,7 +729,7 @@ def test_overrides(es):
         2 >= day]
     i = 0
     for compare_op in compare_ops:
-        f = Compare(day, compare_op, 2)
+        f = compare_op(day, 2)
         o = python_reverse_overrides[i]
         assert o.hash() == f.hash()
         i += 1
@@ -737,8 +739,8 @@ def test_override_boolean(es):
     # P TODO:
     return
     count = Count(es['log']['value'], es['sessions'])
-    count_lo = Compare(count, '>', 1)
-    count_hi = Compare(count, '<', 10)
+    count_lo = GreaterThan(count, 1)
+    count_hi = LessThan(count, 10)
 
     to_test = [[True, True, True],
                [True, True, False],
@@ -852,11 +854,11 @@ def test_isnull_feat(es):
 
 def test_init_and_name(es):
     log = es['log']
-    features = [Feature(v) for v in log.variables] + [Compare(Feature(es["products"]["rating"], es["log"]), '>', 2.5)]
+    features = [Feature(v) for v in log.variables] + [GreaterThan(Feature(es["products"]["rating"], es["log"]), 2.5)]
     # Add Timedelta feature
     features.append(pd.Timestamp.now() - Feature(log['datetime']))
     for transform_prim in get_transform_primitives():
-        if transform_prim == Compare:
+        if issubclass(transform_prim, Compare):
             continue
         # use the input_types matching function from DFS
         input_types = transform_prim.input_types

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -873,6 +873,7 @@ def test_init_and_name(es):
             instance.get_name()
             instance.head()
 
+
 def test_percentile(es):
     v = Feature(es['log']['value'])
     p = Percentile(v)


### PR DESCRIPTION
Some primitives, given a set of base features, will give the same feature values regardless of order. 

 `Add(feature_A, feature_B)` functions the same as `Add(feature_b, feature_A)`.  

By flagging a primitive as associative, DeepFeatureSynthesis will only create one instance of that primitive per unique set of base features.

Also subclassed the `Compare` primitive into six primitives: `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanEqualTo`, `LessThan`, and `LessThanEqualTo`.