### PR TITLE
Remove defunct badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![PyPI version](https://badge.fury.io/py/featuretools.svg?maxAge=2592000)](https://badge.fury.io/py/featuretools)
 [![Circle CI](https://circleci.com/gh/Featuretools/featuretools.svg?maxAge=2592000&style=shield)](https://circleci.com/gh/Featuretools/featuretools)
-[![PyPI](https://img.shields.io/pypi/dm/featuretools.svg?maxAge=2592000)](https://pypi.python.org/pypi/featuretools)
 [![BSD License](https://img.shields.io/github/license/Featuretools/featuretools.svg)](https://github.com/Featuretools/featuretools/blob/master/LICENSE)
 
 [Featuretools](https://www.featuretools.com) is a python library for automated feature engineering. See the [documentation](https://docs.featuretools.com) for more information.


### PR DESCRIPTION
as per https://github.com/badges/shields/issues/716 and https://stackoverflow.com/questions/38102317/why-pypi-doesnt-show-download-stats-anymore