### PR TITLE
Remove as_dir=False option from EntitySet.to_pickle()

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -91,8 +91,8 @@ class EntitySet(BaseEntitySet):
         """
         return [e.id for e in self.entities]
 
-    def to_pickle(self, path, as_dir=False):
-        to_pickle(self, path, as_dir=as_dir)
+    def to_pickle(self, path):
+        to_pickle(self, path)
         return self
 
     @classmethod
@@ -710,6 +710,8 @@ class EntitySet(BaseEntitySet):
 
         transfer_types = {}
         transfer_types[new_index] = type(base_entity[index])
+        for v in additional_variables + copy_variables:
+            transfer_types[v] = type(base_entity[v])
 
         # create and add new entity
         new_entity_df = self.get_dataframe(base_entity_id)
@@ -740,6 +742,7 @@ class EntitySet(BaseEntitySet):
         selected_variables = [index] +\
             [v for v in additional_variables] +\
             [v for v in copy_variables]
+
 
         new_entity_df2 = new_entity_df. \
             drop_duplicates(index, keep=time_index_reduce)[selected_variables]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -91,7 +91,7 @@ class EntitySet(BaseEntitySet):
         """
         return [e.id for e in self.entities]
 
-    def to_pickle(self, path):
+    def to_pickle(self, path)
         to_pickle(self, path)
         return self
 
@@ -710,8 +710,6 @@ class EntitySet(BaseEntitySet):
 
         transfer_types = {}
         transfer_types[new_index] = type(base_entity[index])
-        for v in additional_variables + copy_variables:
-            transfer_types[v] = type(base_entity[v])
 
         # create and add new entity
         new_entity_df = self.get_dataframe(base_entity_id)
@@ -742,7 +740,6 @@ class EntitySet(BaseEntitySet):
         selected_variables = [index] +\
             [v for v in additional_variables] +\
             [v for v in copy_variables]
-
 
         new_entity_df2 = new_entity_df. \
             drop_duplicates(index, keep=time_index_reduce)[selected_variables]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -91,7 +91,7 @@ class EntitySet(BaseEntitySet):
         """
         return [e.id for e in self.entities]
 
-    def to_pickle(self, path)
+    def to_pickle(self, path):
         to_pickle(self, path)
         return self
 

--- a/featuretools/entityset/serialization.py
+++ b/featuretools/entityset/serialization.py
@@ -14,18 +14,14 @@ logger = logging.getLogger('featuretools.entityset')
 _datetime_types = vtypes.PandasTypes._pandas_datetimes
 
 
-def to_pickle(entityset, path, as_dir=False):
+def to_pickle(entityset, path):
     """Save the entityset at the given path.
 
        Args:
            entityset (:class:`featuretools.BaseEntitySet`) : EntitySet to save
-           path : pathname of a pickle file or directory to save the entityset files.
-                if as_dir is False, this treats path as a pickle file to save the entire entityset to
-           as_dir (bool) : If True, each entity will be saved to a subfolder, with data saved as a
-               gzip-compressed CSV, index information saved as a pickle file and
-               metadata saved as a pickle file
-               Additional metadata about the entityset itself will be saved to a
-               pickle file.
+           path : pathname of a directory to save the entityset
+            (includes a CSV file for each entity, as well as a metadata
+            pickle file)
 
     """
     entityset_path = os.path.abspath(os.path.expanduser(path))
@@ -33,14 +29,7 @@ def to_pickle(entityset, path, as_dir=False):
         os.makedirs(entityset_path)
     except OSError:
         pass
-    if as_dir:
-        to_pickle_dir(entityset, entityset_path)
-    else:
-        pd_to_pickle(entityset, entityset_path)
-    os.chmod(entityset_path, 0o755)
 
-
-def to_pickle_dir(entityset, entityset_path):
     entity_store_dframes = {}
     entity_store_index_bys = {}
 
@@ -88,6 +77,7 @@ def to_pickle_dir(entityset, entityset_path):
     if os.path.exists(entityset_path):
         shutil.rmtree(entityset_path)
     shutil.move(temp_dir, entityset_path)
+    os.chmod(entityset_path, 0o755)
 
 
 def read_pickle(path):
@@ -99,9 +89,6 @@ def read_pickle(path):
         path (str): Path of directory where entityset is stored
     """
     entityset_path = os.path.abspath(os.path.expanduser(path))
-    if os.path.isfile(path):
-        return pd_read_pickle(path)
-
     entityset = pd_read_pickle(os.path.join(entityset_path, 'entityset.p'))
     for e_id, entity_store in entityset.entity_stores.items():
         entity_path = os.path.join(entityset_path, e_id)

--- a/featuretools/entityset/serialization.py
+++ b/featuretools/entityset/serialization.py
@@ -77,7 +77,6 @@ def to_pickle(entityset, path):
     if os.path.exists(entityset_path):
         shutil.rmtree(entityset_path)
     shutil.move(temp_dir, entityset_path)
-    os.chmod(entityset_path, 0o755)
 
 
 def read_pickle(path):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1,8 +1,10 @@
 import pytest
 
 from ..testing_utils import make_ecommerce_entityset
-
-from featuretools import Relationship, variable_types
+from featuretools.tests import integration_data
+from featuretools import Relationship, variable_types, EntitySet
+import os
+import shutil
 
 
 @pytest.fixture
@@ -149,3 +151,14 @@ def test_gzip_glob_entityset(es, gzip_glob_es):
     df_1 = es.entity_stores['log'].df
     df_2 = gzip_glob_es.entity_stores['log'].df
     assert df_1.equals(df_2)
+
+
+def test_serialization(es):
+    dirname = os.path.dirname(integration_data.__file__)
+    path = os.path.join(dirname, 'test_entityset.p')
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    es.to_pickle(path)
+    new_es = EntitySet.read_pickle(path)
+    assert es == new_es
+    shutil.rmtree(path)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -160,5 +160,5 @@ def test_serialization(es):
         shutil.rmtree(path)
     es.to_pickle(path)
     new_es = EntitySet.read_pickle(path)
-    assert es == new_es
+    assert es.__eq__(new_es, deep=True)
     shutil.rmtree(path)


### PR DESCRIPTION
`EntitySet` used to have two options for saving to disk

- `as_dir=False` was supposed to save to a single pickle file. This was broken.
- `as_dir=True` saved to a directory containing several pickle files of metadata about each `Entity`, and CSV files with the data for each `Entity`.

This PR removes the `as_dir=False` option.