### PR TITLE
Fixed Diff primitive for rare nan case

### DIFF
--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -434,8 +434,7 @@ class Diff(TransformPrimitive):
     If it is a Datetime feature, compute the difference in seconds
     """
     name = "diff"
-    input_types = [[Numeric, Id],
-                   [Numeric, Index]]
+    input_types = [Numeric, Id]
     return_type = Numeric
 
     def __init__(self, base_feature, group_feature):
@@ -464,7 +463,7 @@ class Diff(TransformPrimitive):
             grouped_df = grouped_df.groupby(groupby).diff()
             try:
                 return grouped_df[bf_name]
-            except:
+            except KeyError:
                 return pd.Series([np.nan]*len(base_array))
         return pd_diff
 

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -14,6 +14,7 @@ from featuretools.variable_types import (
     DatetimeTimeIndex,
     Discrete,
     Id,
+    Index,
     Numeric,
     Ordinal,
     Timedelta,
@@ -433,7 +434,8 @@ class Diff(TransformPrimitive):
     If it is a Datetime feature, compute the difference in seconds
     """
     name = "diff"
-    input_types = [Numeric, Id]
+    input_types = [[Numeric, Id],
+                   [Numeric, Index]]
     return_type = Numeric
 
     def __init__(self, base_feature, group_feature):
@@ -460,7 +462,10 @@ class Diff(TransformPrimitive):
             grouped_df = pd.DataFrame.from_dict({bf_name: base_array,
                                                  groupby: group_array})
             grouped_df = grouped_df.groupby(groupby).diff()
-            return grouped_df[bf_name]
+            try:
+                return grouped_df[bf_name]
+            except:
+                return pd.Series([np.nan]*len(base_array))
         return pd_diff
 
 

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -72,30 +72,30 @@ def test_diff(es):
     customer_id_feat = \
         DirectFeature(es['sessions']['customer_id'],
                       child_entity=es['log'])
-    diff2 = Diff(value, es['log']['session_id'])
-    diff3 = Diff(value, customer_id_feat)
+    diff1 = Diff(value, es['log']['session_id'])
+    diff2 = Diff(value, customer_id_feat)
 
-    pandas_backend = PandasBackend(es, [diff2, diff3])
+    pandas_backend = PandasBackend(es, [diff1, diff2])
     df = pandas_backend.calculate_all_features(instance_ids=range(15),
                                                time_last=None)
 
+    val1 = df[diff1.get_name()].values.tolist()
     val2 = df[diff2.get_name()].values.tolist()
-    val3 = df[diff3.get_name()].values.tolist()
-    correct_vals2 = [
+    correct_vals1 = [
         np.nan, 5, 5, 5, 5, np.nan, 1, 1, 1, np.nan, np.nan, 5, np.nan, 7, 7
     ]
-    correct_vals3 = [np.nan, 5, 5, 5, 5, -20, 1, 1, 1, -3, np.nan, 5, -5, 7, 7]
-    for i, v in enumerate(val2):
+    correct_vals2 = [np.nan, 5, 5, 5, 5, -20, 1, 1, 1, -3, np.nan, 5, -5, 7, 7]
+    for i, v in enumerate(val1):
+        v1 = val1[i]
+        if np.isnan(v1):
+            assert (np.isnan(correct_vals1[i]))
+        else:
+            assert v1 == correct_vals1[i]
         v2 = val2[i]
         if np.isnan(v2):
             assert (np.isnan(correct_vals2[i]))
         else:
             assert v2 == correct_vals2[i]
-        v3 = val3[i]
-        if np.isnan(v3):
-            assert (np.isnan(correct_vals3[i]))
-        else:
-            assert v3 == correct_vals3[i]
 
 
 def test_diff_single_value(es):

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -98,6 +98,15 @@ def test_diff(es):
             assert v3 == correct_vals3[i]
 
 
+def test_diff_single_value(es):
+    diff = Diff(es['stores']['num_square_feet'], es['stores']['region_id'])
+    pandas_backend = PandasBackend(es, [diff])
+    df = pandas_backend.calculate_all_features(instance_ids=[5],
+                                               time_last=None)
+    assert df.shape[0] == 1
+    assert df[diff.get_name()].dropna().shape[0] == 0
+
+
 def test_compare_of_identity(es):
     to_test = [(Equals, [False, False, True, False]),
                (NotEquals, [True, True, False, True]),

--- a/featuretools/tests/integration_data/stores.csv
+++ b/featuretools/tests/integration_data/stores.csv
@@ -1,6 +1,7 @@
-id,region_id
-0,United States
-1,United States
-2,United States
-3,Mexico
-4,Mexico
+id,num_square_feet,region_id
+0,30000.0,United States
+1,36000.0,United States
+2,42000.0,United States
+3,48000.0,Mexico
+4,54000.0,Mexico
+5,,

--- a/featuretools/tests/integration_data/stores_int.csv
+++ b/featuretools/tests/integration_data/stores_int.csv
@@ -1,6 +1,7 @@
-id,region_id
-0,United States
-1,United States
-2,United States
-3,Mexico
-4,Mexico
+id,num_square_feet,region_id
+0,30000.0,United States
+1,36000.0,United States
+2,42000.0,United States
+3,48000.0,Mexico
+4,54000.0,Mexico
+5,,

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -27,8 +27,9 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
     region_df = pd.DataFrame({'id': ['United States', 'Mexico'],
                               'language': ['en', 'sp']})
 
-    store_df = pd.DataFrame({'id': range(5),
-                             'region_id': ['United States'] * 3 + ['Mexico'] * 2})
+    store_df = pd.DataFrame({'id': range(6),
+                             'region_id': ['United States'] * 3 + ['Mexico'] * 2 + [np.nan],
+                             'num_square_feet': range(30000, 60000, 6000) + [np.nan]})
 
     product_df = pd.DataFrame({'id': ['Haribo sugar-free gummy bears', 'car',
                                       'toothpaste', 'brown bag', 'coke zero',


### PR DESCRIPTION
I ran into a bug with the `Diff` primitive that occurs when for a single variable and cutoff time, all values of both the variable and the feature to group by are nan. The bug occurs because Pandas drops the column names of empty dataframes, so we get a KeyError. This fix required a new variable in the mock entityset because we needed both an Id variable to group on that had a nan value and a numeric variable that had a nan.