### PR TITLE
Trend fix

### DIFF
--- a/featuretools/primitives/aggregation_primitives.py
+++ b/featuretools/primitives/aggregation_primitives.py
@@ -340,10 +340,10 @@ class Trend(AggregationPrimitive):
     input_types = [Numeric, DatetimeTimeIndex]
     return_type = Numeric
 
-    def __init__(self, value, time_index, parent_entity, **kwargs):
-        self.value = value
-        self.time_index = time_index
-        super(Trend, self).__init__([value, time_index],
+    def __init__(self, base_features, parent_entity, **kwargs):
+        self.value = base_features[0]
+        self.time_index = base_features[1]
+        super(Trend, self).__init__(base_features,
                                     parent_entity,
                                     **kwargs)
 

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -228,7 +228,7 @@ def test_init_and_name(es):
             if len(matching_types) == 0:
                 raise Exception("Agg Primitive %s not tested" % agg_prim.name)
             for t in matching_types:
-                instance = agg_prim(*t, parent_entity=session)
+                instance = agg_prim(t, parent_entity=session)
 
                 # try to get name and calculate
                 instance.get_name()


### PR DESCRIPTION
With the new custom primitives, any aggregation with two input types, needs to updated to reflect the new changes. The `Trend` primitive was one that was forgotten to be fixed. 
Furthermore, fixed an aggregation primitive test.