### PR TITLE
Entity Normalization Preserves Types of Copy & Additional Variables

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1,19 +1,17 @@
+import pandas as pd
 import copy
-import itertools
-import logging
-
 import dask.dataframe as dd
 import numpy as np
-import pandas as pd
-
-from .base_entityset import BaseEntitySet
-from .entity import Entity
-from .relationship import Relationship
-from .serialization import read_pickle, to_pickle
-
 import featuretools.variable_types.variable as vtypes
-from featuretools.utils.gen_utils import make_tqdm_iterator
+from .relationship import Relationship
+from .entity import Entity
 from featuretools.utils.wrangle import _check_variable_list
+from .base_entityset import BaseEntitySet
+from .serialization import to_pickle, read_pickle
+from featuretools.utils.gen_utils import make_tqdm_iterator
+import itertools
+import sys
+import logging
 
 pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')
@@ -26,7 +24,6 @@ class EntitySet(BaseEntitySet):
     Attributes:
         entity_stores
     """
-
     def __init__(self, id, entities=None, relationships=None, verbose=False):
         """Creates EntitySet
 
@@ -572,7 +569,7 @@ class EntitySet(BaseEntitySet):
         if index is None:
             assert not make_index, "Must specify an index name if make_index is True"
             logger.warning(("Using first column as index. ",
-                            "To change this, specify the index parameter"))
+                           "To change this, specify the index parameter"))
         else:
             if index not in variable_types:
                 variable_types[index] = vtypes.Index
@@ -948,7 +945,7 @@ class EntitySet(BaseEntitySet):
             other_variable_ids = [o_variable.id for o_variable in
                                   other[entity.id].variables]
             assert (all([variable.id in other_variable_ids
-                         for variable in self[entity.id].variables])), assert_string
+                    for variable in self[entity.id].variables])), assert_string
 
         if inplace:
             combined_es = self

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -609,6 +609,18 @@ class TestNormalizeEntity(object):
         assert 'device_name' not in entityset['sessions'].df.columns
         assert 'device_type' in entityset['device_types'].df.columns
 
+    def test_normalize_entity_copies_variable_types(self, entityset):
+        entityset.normalize_entity('log', 'values_2', 'value_2',
+                                   additional_variables=['priority_level'],
+                                   make_time_index=False)
+
+        assert len(entityset.get_forward_relationships('log')) == 3
+        assert entityset.get_forward_relationships('log')[2].parent_entity.id == 'values_2'
+        assert 'priority_level' in entityset['values_2'].df.columns
+        assert 'priority_level' not in entityset['log'].df.columns
+        assert 'value_2' in entityset['values_2'].df.columns
+        assert entityset['values_2'].variable_types['priority_level'] == variable_types.Ordinal
+
     def test_make_time_index_keeps_original_sorting(self):
         trips = {
             'trip_id': [999 - i for i in xrange(1000)],


### PR DESCRIPTION
This fixes a bug where variables with specific types (that are different from what would ordinarily be inferred) don't have their types carried over to a new entity upon normalization.

Say you have an entity with an Ordinal variable that is a numeric dtype under the hood, so the dataframe looks like {'ordered_values': [1,2,3]}. Then you normalize out an entity, flagging that variable to move or copy:

`es.normalize_entity(base_entity, new_entity, additional_vars=['ordered_values'])`
`es.normalize_entity(base_entity, new_entity, copy_vars=['ordered_values'])`

Before this fix, the `ordered_values` variable type in `new_entity` would be `Numeric` instead of `Ordinal`.