### PR TITLE
Last time index

### DIFF
--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -52,6 +52,7 @@ def load_flight(entity_id='flight_dataset', nrows=None, force=False):
                         additional_variables=["UNIQUE_CARRIER", "TAIL_NUM", "FL_NUM", "ORIGIN_AIRPORT_ID",
                                               "ORIGIN_CITY_MARKET_ID", "DEST_AIRPORT_ID", "DEST_CITY_MARKET_ID"],
                         make_time_index=True)
+    es.add_last_time_indexes()
     return es
 
 

--- a/featuretools/demo/mock_customer.py
+++ b/featuretools/demo/mock_customer.py
@@ -66,7 +66,7 @@ def load_mock_customer(n_customers=5, n_products=5, n_sessions=35, n_transaction
                 ft.Relationship(es["customers"]["customer_id"],
                                 es["sessions"]["customer_id"])]
         es = es.add_relationships(rels)
-
+        es.add_last_time_indexes()
         return es
 
     return {"customers": customers_df,

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -86,6 +86,7 @@ def load_retail(id='demo_retail_data', nrows=None):
                         base_entity_id="invoices",
                         index="CustomerID",
                         additional_variables=["Country"])
+    es.add_last_time_indexes()
 
     return es
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -598,7 +598,9 @@ class Entity(BaseEntity):
                         assert self.last_time_index is not None, "Last time "\
                             "indexes must be set if using training windows."
                         lti_slice = self.last_time_index[df.index]
-                        df = df[lti_slice >= time_last - training_window]
+                        lti_recent = df[lti_slice >= time_last - training_window]
+                        ti_recent = df[df[self.time_index] >= time_last - training_window]
+                        df = pd.concat([lti_recent, ti_recent]).drop_duplicates()
 
         for secondary_time_index in self.secondary_time_index:
                 # should we use ignore time last here?

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -597,17 +597,8 @@ class Entity(BaseEntity):
                     if training_window is not None:
                         assert self.last_time_index is not None, "Last time "\
                             "indexes must be set if using training windows."
-
-                        # iterate to find an unused column name
-                        i = 0
-                        while i >= 0:
-                            if i in df.columns:
-                                i += 1
-                            else:
-                                df[i] = self.last_time_index
-                                df = df[df[i] >= time_last - training_window]
-                                df.drop(i, axis=1, inplace=True)
-                                i = -1
+                        lti_slice = self.last_time_index[df.index]
+                        df = df[lti_slice >= time_last - training_window]
 
         for secondary_time_index in self.secondary_time_index:
                 # should we use ignore time last here?

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -598,9 +598,10 @@ class Entity(BaseEntity):
                         assert self.last_time_index is not None, "Last time "\
                             "indexes must be set if using training windows."
                         lti_slice = self.last_time_index[df.index]
-                        lti_recent = df[lti_slice >= time_last - training_window]
-                        ti_recent = df[df[self.time_index] >= time_last - training_window]
-                        df = pd.concat([lti_recent, ti_recent]).drop_duplicates()
+                        df = df[
+                            (df[self.time_index] >= time_last - training_window) |
+                            (lti_slice >= time_last - training_window)
+                        ]
 
         for secondary_time_index in self.secondary_time_index:
                 # should we use ignore time last here?

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -27,8 +27,8 @@ class Entity(BaseEntity):
 
     def __init__(self, id, df, entityset, variable_types=None, name=None,
                  index=None, time_index=None, secondary_time_index=None,
-                 encoding=None, relationships=None, already_sorted=False,
-                 created_index=None, verbose=False):
+                 last_time_index=None, encoding=None, relationships=None,
+                 already_sorted=False, created_index=None, verbose=False):
         """ Create Entity
 
         Args:
@@ -45,6 +45,8 @@ class Entity(BaseEntity):
             time_index (str): name of time column in the dataframe
             secondary_time_index (dict[str->str]): dictionary mapping columns
                 in the dataframe to the time index column they are associated with
+            last_time_index (pd.Series): time index of the last event for each
+                instance across all child entities
             encoding (Optional(str)) : If None, will use 'ascii'. Another option is 'utf-8',
                 or any encoding supported by pandas. Passed into underlying
                 pandas.read_csv() and pandas.to_csv() calls, so see Pandas documentation
@@ -61,6 +63,7 @@ class Entity(BaseEntity):
         self.created_index = created_index
         self.convert_variable_types(variable_types)
         self.attempt_cast_index_to_int(index)
+        self.last_time_index = last_time_index
         super(Entity, self).__init__(id, entityset, variable_types, name, index,
                                      time_index, secondary_time_index, relationships, already_sorted)
 
@@ -544,6 +547,9 @@ class Entity(BaseEntity):
         self.convert_variable_type(variable_id, vtypes.Index, convert_data=False)
 
         super(Entity, self).set_index(variable_id)
+
+    def set_last_time_index(self, last_time_index):
+            self.last_time_index = last_time_index
 
     def _vals_to_series(self, instance_vals, variable_id):
         """

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -595,7 +595,17 @@ class Entity(BaseEntity):
                 else:
                     df = df[df[self.time_index] <= time_last]
                     if training_window is not None:
-                        df = df[df[self.time_index] >= time_last - training_window]
+                        assert self.last_time_index is not None, "Last time "\
+                            "indexes must be set if using training windows."
+                        i = 0
+                        while i >= 0:
+                            if i in df.columns:
+                                i += 1
+                            else:
+                                df[i] = self.last_time_index
+                                df = df[df[i] >= time_last - training_window]
+                                df.drop(i, axis=1, inplace=True)
+                                i = -1
 
         for secondary_time_index in self.secondary_time_index:
                 # should we use ignore time last here?

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -597,6 +597,8 @@ class Entity(BaseEntity):
                     if training_window is not None:
                         assert self.last_time_index is not None, "Last time "\
                             "indexes must be set if using training windows."
+
+                        # iterate to find an unused column name
                         i = 0
                         while i >= 0:
                             if i in df.columns:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -720,7 +720,6 @@ class EntitySet(BaseEntitySet):
         if isinstance(make_time_index, (str, unicode)):
             base_time_index = make_time_index
             new_entity_time_index = base_entity[make_time_index].id
-            # TODO: handle LTI for this case
         elif make_time_index:
             base_time_index = base_entity.time_index
             if new_entity_time_index is None:
@@ -744,11 +743,9 @@ class EntitySet(BaseEntitySet):
 
         new_entity_df2 = new_entity_df. \
             drop_duplicates(index, keep=time_index_reduce)[selected_variables]
-        lti_df = new_entity_df.drop_duplicates(index, keep='last')[selected_variables]
 
         if make_time_index:
             new_entity_df2.rename(columns={base_time_index: new_entity_time_index}, inplace=True)
-            lti_df.rename(columns={base_time_index: new_entity_time_index}, inplace=True)
         if make_secondary_time_index:
             time_index_reduce = 'first'
 
@@ -781,11 +778,6 @@ class EntitySet(BaseEntitySet):
             old_entity_df.loc[:, index] = id_as_int.values
 
             base_entity.update_data(old_entity_df)
-            lti_df = lti_df[[new_entity_time_index]].merge(old_entity_df[[index]],
-                                                           left_index=True,
-                                                           right_index=True,
-                                                           how='left')
-            lti_df = lti_df.set_index(lti_df[index], drop=False)
             index = link_variable_id
 
         # TODO dfs: do i need this?
@@ -1027,7 +1019,6 @@ class EntitySet(BaseEntitySet):
             else:
                 child_entities = children[entity.id]
                 if not set([e.id for e in child_entities]).issubset(explored):
-                    # TODO: handling broken graphs
                     queue.append(entity)
                 else:
                     for child_e in child_entities:

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -200,7 +200,7 @@ def test_cutoff_time_binning(entityset):
         assert binned_cutoff_times['time'][i] == labels[i]
 
 
-def test_handles_training_window_correctly(entityset):
+def test_training_window(entityset):
     property_feature = Count(entityset['log']['id'], entityset['customers'])
     top_level_agg = Count(entityset['customers']['id'], entityset['regions'])
 
@@ -219,8 +219,17 @@ def test_handles_training_window_correctly(entityset):
                                                   training_window='2 hours')
 
     entityset.add_last_time_indexes()
+
+    with pytest.raises(AssertionError):
+        feature_matrix = calculate_feature_matrix([property_feature],
+                                                  instance_ids=[0, 1, 2],
+                                                  cutoff_time=[datetime(2011, 4, 9, 12, 31),
+                                                               datetime(2011, 4, 10, 11),
+                                                               datetime(2011, 4, 10, 13, 10, 1)],
+                                                  training_window=Timedelta(2, 'observations', entity='log'))
+
     feature_matrix = calculate_feature_matrix([property_feature, dagg],
-                                              instance_ids=[0, 1, 2],
+                                              instance_ids=[0, 1, 2, 4],
                                               cutoff_time=[datetime(2011, 4, 9, 12, 31),
                                                            datetime(2011, 4, 10, 11),
                                                            datetime(2011, 4, 10, 13, 10, 1)],
@@ -230,13 +239,47 @@ def test_handles_training_window_correctly(entityset):
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
-    with pytest.raises(AssertionError):
-        feature_matrix = calculate_feature_matrix([property_feature],
-                                                  instance_ids=[0, 1, 2],
-                                                  cutoff_time=[datetime(2011, 4, 9, 12, 31),
-                                                               datetime(2011, 4, 10, 11),
-                                                               datetime(2011, 4, 10, 13, 10, 1)],
-                                                  training_window=Timedelta(2, 'observations', entity='log'))
+
+def test_training_window_recent_time_index(entityset):
+    # customer with no sessions
+    row = {
+        'id': [3],
+        'age': [73],
+        'region_id': ['United States'],
+        'cohort': [1],
+        'cohort_name': ["Late Adopters"],
+        'loves_ice_cream': [True],
+        'favorite_quote': ["Who is John Galt?"],
+        'signup_date': [datetime(2011, 4, 10)],
+        'upgrade_date': [datetime(2011, 4, 12)],
+        'cancel_date': [datetime(2011, 5, 13)],
+        'date_of_birth': [datetime(1938, 2, 1)],
+        'engagement_level': [2],
+    }
+    df = pd.DataFrame(row)
+    df.index = xrange(3, 4)
+    df = entityset['customers'].df.append(df)
+    entityset['customers'].update_data(df)
+    entityset.add_last_time_indexes()
+
+    property_feature = Count(entityset['log']['id'], entityset['customers'])
+    top_level_agg = Count(entityset['customers']['id'], entityset['regions'])
+    dagg = DirectFeature(top_level_agg, entityset['customers'])
+
+    feature_matrix = calculate_feature_matrix(
+        [property_feature, dagg],
+        instance_ids=[0, 1, 2, 3],
+        cutoff_time=[datetime(2011, 4, 9, 12, 31),
+                     datetime(2011, 4, 10, 11),
+                     datetime(2011, 4, 10, 13, 10, 1),
+                     datetime(2011, 4, 10, 1, 59, 59)],
+        training_window='2 hours'
+    )
+    prop_values = [5, 5, 1, 0]
+    dagg_values = [3, 2, 1, 2]
+    feature_matrix.sort_index(inplace=True)
+    assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
+    assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
 
 def test_approximate_multiple_instances_per_cutoff_time(entityset):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -209,14 +209,13 @@ def test_training_window(entityset):
     # and we go through the loop to pull data with a training_window param more than once
     dagg = DirectFeature(top_level_agg, entityset['customers'])
 
-    # for now, raises error if last_time_index not present
-    with pytest.raises(AssertionError):
-        feature_matrix = calculate_feature_matrix([property_feature, dagg],
-                                                  instance_ids=[0, 1, 2],
-                                                  cutoff_time=[datetime(2011, 4, 9, 12, 31),
-                                                               datetime(2011, 4, 10, 11),
-                                                               datetime(2011, 4, 10, 13, 10, 1)],
-                                                  training_window='2 hours')
+    # for now, warns if last_time_index not present
+    feature_matrix = calculate_feature_matrix([property_feature, dagg],
+                                              instance_ids=[0, 1, 2],
+                                              cutoff_time=[datetime(2011, 4, 9, 12, 31),
+                                                           datetime(2011, 4, 10, 11),
+                                                           datetime(2011, 4, 10, 13, 10, 1)],
+                                              training_window='2 hours')
 
     entityset.add_last_time_indexes()
 

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -640,6 +640,38 @@ class TestNormalizeEntity(object):
         assert 'value_time' in entityset['values'].df.columns
         assert len(entityset['values'].df.columns) == 3
 
+    def test_last_time_index(self, entityset):
+        entityset.normalize_entity('log', 'values', 'value',
+                                   make_time_index=True,
+                                   new_entity_time_index="value_time",
+                                   convert_links_to_integers=True)
+        entityset.add_last_time_indexes()
+        assert entityset["values"].last_time_index is not None
+        times = {
+            'values': [
+                datetime(2011, 4, 10, 10, 41, 0),
+                datetime(2011, 4, 10, 10, 40, 1),
+                datetime(2011, 4, 9, 10, 30, 12),
+                datetime(2011, 4, 9, 10, 30, 18),
+                datetime(2011, 4, 9, 10, 30, 24),
+                datetime(2011, 4, 9, 10, 31, 9),
+                datetime(2011, 4, 9, 10, 31, 18),
+                datetime(2011, 4, 9, 10, 31, 27),
+                datetime(2011, 4, 10, 10, 41, 3),
+                datetime(2011, 4, 10, 10, 41, 6),
+                datetime(2011, 4, 10, 11, 10, 03),
+            ],
+            'customers': [
+                datetime(2011, 4, 9, 10, 40, 0),
+                datetime(2011, 4, 10, 10, 41, 6),
+                datetime(2011, 4, 10, 11, 10, 03),
+            ]
+        }
+        region_series = pd.Series({'United States': datetime(2011, 4, 10, 11, 10, 03)})
+        assert (entityset["values"].last_time_index.sort_index() == pd.Series(times['values'])).all()
+        assert (entityset["customers"].last_time_index.sort_index() == pd.Series(times['customers'])).all()
+        assert (entityset["regions"].last_time_index.sort_index() == region_series).all()
+
 
 def test_head_of_entity(entityset):
 


### PR DESCRIPTION
Adds `last_time_index` property to `Entity`. For each instance in the entity, the last time index refers to the most recent event associated with that instance.  For entities without child entities, this would be the time index of that entity.  For an instance of an entity with children, it would be the most recent `last_time_index` among associated instances on the child entities.  When using training windows while calculating a feature matrix, instances with `last_time_indexes` that are not as recent as the edge of the training window will excluded from the data.