### PR TITLE
Custom primitive kwarg fix

### DIFF
--- a/docs/source/guides/advanced_custom_primitives.rst
+++ b/docs/source/guides/advanced_custom_primitives.rst
@@ -22,11 +22,11 @@ One caveat with the make\_primitive functions is that the required arguments of 
         counts = [element.lower().count(string) for element in column]
         return counts
 
-In order to have features defined using the primitive reflect what string is being counted, we define a custom ``get_name`` function.
+In order to have features defined using the primitive reflect what string is being counted, we define a custom ``generate_name`` function.
 
 .. ipython:: python
 
-    def string_count_get_name(self):
+    def string_count_generate_name(self):
         return u"STRING_COUNT(%s, %s)" % (self.base_features[0].get_name(),
                                           '"'+str(self.kwargs['string']+'"'))
 
@@ -38,7 +38,7 @@ Now that we have the function, we create the primitive using the ``make_trans_pr
     StringCount = make_trans_primitive(function=string_count,
                                        input_types=[Text],
                                        return_type=Numeric,
-                                       cls_attributes={"get_name": string_count_get_name})
+                                       cls_attributes={"generate_name": string_count_generate_name})
 
 Passing in ``string="test"`` as a keyword argument when creating a StringCount feature will make "test" the value used for string when ``string_count`` is called to calculate the feature values.  Now we use this primitive to create a feature and calculate the feature values.
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -416,8 +416,10 @@ class Entity(BaseEntity):
         return copied
 
     def add_interesting_values(self, max_values=5, verbose=False):
-        """Find interesting values for categorical variables, to be used to
+        """
+        Find interesting values for categorical variables, to be used to
             generate "where" clauses
+
         Args:
             max_values (int) : maximum number of values per variable to add
             verbose (bool) : If True, print summary of interesting values found

--- a/featuretools/primitives/aggregation_primitive_base.py
+++ b/featuretools/primitives/aggregation_primitive_base.py
@@ -1,4 +1,5 @@
 import functools
+import copy
 
 from .primitive_base import PrimitiveBase
 from .utils import inspect_function_args
@@ -151,12 +152,12 @@ def make_agg_primitive(function, input_types, return_type, name=None,
     new_class.base_of = base_of
     new_class.base_of_exclude = base_of_exclude
     new_class.associative = associative
-    new_class, kwargs = inspect_function_args(new_class,
-                                              function,
-                                              uses_calc_time)
+    new_class, default_kwargs = inspect_function_args(new_class,
+                                                      function,
+                                                      uses_calc_time)
 
-    if len(kwargs) > 0:
-        new_class.kwargs = kwargs
+    if len(default_kwargs) > 0:
+        new_class.default_kwargs = default_kwargs
 
         def new_class_init(self, base_features, parent_entity,
                            use_previous=None, where=None, **kwargs):
@@ -183,7 +184,8 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                     " doesn't have one")
 
             self.use_previous = use_previous
-            self.kwargs = kwargs
+            self.kwargs = copy.deepcopy(self.default_kwargs)
+            self.kwargs.update(kwargs)
             self.partial = functools.partial(function, **self.kwargs)
             super(AggregationPrimitive, self).__init__(parent_entity,
                                                        self.base_features)

--- a/featuretools/primitives/aggregation_primitive_base.py
+++ b/featuretools/primitives/aggregation_primitive_base.py
@@ -63,7 +63,7 @@ class AggregationPrimitive(PrimitiveBase):
         return u', ' \
             .join([bf.get_name() for bf in self.base_features])
 
-    def _get_name(self):
+    def generate_name(self):
         where_str = self._where_str()
         use_prev_str = self._use_prev_str()
 

--- a/featuretools/primitives/aggregation_primitives.py
+++ b/featuretools/primitives/aggregation_primitives.py
@@ -44,7 +44,7 @@ class Count(AggregationPrimitive):
             return values.count()
         return func
 
-    def _get_name(self):
+    def generate_name(self):
         where_str = self._where_str()
         use_prev_str = self._use_prev_str()
 

--- a/featuretools/primitives/binary_transform.py
+++ b/featuretools/primitives/binary_transform.py
@@ -76,7 +76,7 @@ class BinaryFeature(TransformPrimitive):
             return getattr(operator, self._get_op())(left_default_val,
                                                      right_default_val)
 
-    def _get_name(self):
+    def generate_name(self):
         return u"%s %s %s" % (self.left_str(),
                               self.operator, self.right_str())
 
@@ -227,7 +227,7 @@ class Negate(Subtract):
     def __init__(self, f):
         super(Negate, self).__init__(0, f)
 
-    def _get_name(self):
+    def generate_name(self):
         return u"-%s" % (self.right_str())
 
 

--- a/featuretools/primitives/cum_transform_feature.py
+++ b/featuretools/primitives/cum_transform_feature.py
@@ -61,7 +61,7 @@ class CumFeature(TransformPrimitive):
 
         super(CumFeature, self).__init__(*self.base_features)
 
-    def _get_name(self):
+    def generate_name(self):
         where_str = u""
         use_prev_str = u""
 

--- a/featuretools/primitives/direct_feature.py
+++ b/featuretools/primitives/direct_feature.py
@@ -30,6 +30,6 @@ class DirectFeature(PrimitiveBase):
     def default_value(self):
         return self.base_features[0].default_value
 
-    def _get_name(self):
+    def generate_name(self):
         return u"%s.%s" % (self.parent_entity.name,
                            self.base_features[0].get_name())

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -398,7 +398,7 @@ class PrimitiveBase(FTBase):
     def get_name(self):
         if self._name is not None:
             return self._name
-        return self._get_name()
+        return self.generate_name()
 
     def get_function(self):
         raise NotImplementedError("Implement in subclass")
@@ -484,7 +484,7 @@ class IdentityFeature(PrimitiveBase):
         self.base_feature = None
         super(IdentityFeature, self).__init__(variable.entity, [])
 
-    def _get_name(self):
+    def generate_name(self):
         return self.variable.name
 
     def get_depth(self, stop_at=None):

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 import os
+import copy
 
 import numpy as np
 import pandas as pd
@@ -117,14 +118,15 @@ def make_trans_primitive(function, input_types, return_type, name=None,
     new_class.input_types = input_types
     new_class.return_type = return_type
     new_class.associative = associative
-    new_class, kwargs = inspect_function_args(new_class,
-                                              function,
-                                              uses_calc_time)
+    new_class, default_kwargs = inspect_function_args(new_class,
+                                                      function,
+                                                      uses_calc_time)
 
-    if kwargs is not None:
-        new_class.kwargs = kwargs
+    if len(default_kwargs) > 0:
+        new_class.default_kwargs = default_kwargs
 
         def new_class_init(self, *args, **kwargs):
+            self.kwargs = copy.deepcopy(self.default_kwargs)
             self.base_features = [self._check_feature(f) for f in args]
             if any(bf.expanding for bf in self.base_features):
                 self.expanding = True

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -43,7 +43,7 @@ class TransformPrimitive(PrimitiveBase):
         super(TransformPrimitive, self).__init__(self.base_features[0].entity,
                                                  self.base_features)
 
-    def _get_name(self):
+    def generate_name(self):
         name = u"{}(".format(self.name.upper())
         name += u", ".join(f.get_name() for f in self.base_features)
         name += u")"
@@ -93,7 +93,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
                     list_of_outputs = []
                 return pd.Series(array).isin(list_of_outputs)
 
-            def isin_get_name(self):
+            def isin_generate_name(self):
                 return u"%s.isin(%s)" % (self.base_features[0].get_name(),
                                          str(self.kwargs['list_of_outputs']))
 
@@ -104,7 +104,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
                 name="is_in",
                 description="For each value of the base feature, checks "
                 "whether it is in a list that provided.",
-                cls_attributes={"_get_name": isin_get_name})
+                cls_attributes={"generate_name": isin_generate_name})
     '''
     # dictionary that holds attributes for class
     cls = {"__doc__": description}
@@ -187,7 +187,7 @@ class TimeSincePrevious(TransformPrimitive):
         self.group_feature = group_feature
         super(TimeSincePrevious, self).__init__(time_index, group_feature)
 
-    def _get_name(self):
+    def generate_name(self):
         return u"time_since_previous_by_%s" % self.group_feature.get_name()
 
     def get_function(self):
@@ -423,7 +423,7 @@ class IsIn(TransformPrimitive):
             return pd.Series(array).isin(list_of_outputs)
         return pd_is_in
 
-    def _get_name(self):
+    def generate_name(self):
         return u"%s.isin(%s)" % (self.base_features[0].get_name(),
                                  str(self.list_of_outputs))
 
@@ -451,7 +451,7 @@ class Diff(TransformPrimitive):
         self.group_feature = self._check_feature(group_feature)
         super(Diff, self).__init__(base_feature, group_feature)
 
-    def _get_name(self):
+    def generate_name(self):
         base_features_str = self.base_features[0].get_name() + u" by " + \
             self.group_feature.get_name()
         return u"%s(%s)" % (self.name.upper(), base_features_str)
@@ -478,7 +478,7 @@ class Not(TransformPrimitive):
     input_types = [Boolean]
     return_type = Boolean
 
-    def _get_name(self):
+    def generate_name(self):
         return u"NOT({})".format(self.base_features[0].get_name())
 
     def _get_op(self):

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -133,7 +133,7 @@ def test_count_null_and_make_agg_primitive(es):
 
         return values.count()
 
-    def count_get_name(self):
+    def count_generate_name(self):
         where_str = self._where_str()
         use_prev_str = self._use_prev_str()
         return u"COUNT(%s%s%s)" % (self.child_entity.name,
@@ -142,7 +142,7 @@ def test_count_null_and_make_agg_primitive(es):
 
     Count = make_agg_primitive(count_func, [[Index], [Variable]], Numeric,
                                name="count", stack_on_self=False,
-                               cls_attributes={"_get_name": count_get_name})
+                               cls_attributes={"generate_name": count_generate_name})
     count_null = Count(es['log']['value'], es['sessions'], count_null=True)
     feature_matrix = calculate_feature_matrix([count_null], entityset=es)
     values = [5, 4, 1, 2, 3, 2]

--- a/featuretools/tests/feature_function_tests/test_direct_features.py
+++ b/featuretools/tests/feature_function_tests/test_direct_features.py
@@ -40,5 +40,5 @@ def test_direct_rename(es):
     copy_feat = feat.rename("session_test")
     assert feat.hash() != copy_feat.hash()
     assert feat.get_name() != copy_feat.get_name()
-    assert feat.base_features[0]._get_name() == copy_feat.base_features[0]._get_name()
+    assert feat.base_features[0].generate_name() == copy_feat.base_features[0].generate_name()
     assert feat.entity == copy_feat.entity

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -890,7 +890,7 @@ def test_isin_feat_custom(es):
             list_of_outputs = []
         return pd.Series(array).isin(list_of_outputs)
 
-    def isin_get_name(self):
+    def isin_generate_name(self):
         return u"%s.isin(%s)" % (self.base_features[0].get_name(),
                                  str(self.kwargs['list_of_outputs']))
 
@@ -901,7 +901,7 @@ def test_isin_feat_custom(es):
         name="is_in",
         description="For each value of the base feature, checks whether it is "
         "in a list that is provided.",
-        cls_attributes={"_get_name": isin_get_name})
+        cls_attributes={"generate_name": isin_generate_name})
 
     isin = IsIn(es['log']['product_id'],
                 list_of_outputs=["toothpaste", "coke zero"])
@@ -1045,7 +1045,7 @@ def test_make_transform_sets_kwargs_correctly(es):
             list_of_outputs = []
         return pd.Series(array).isin(list_of_outputs)
 
-    def isin_get_name(self):
+    def isin_generate_name(self):
         return u"%s.isin(%s)" % (self.base_features[0].get_name(),
                                  str(self.kwargs['list_of_outputs']))
 
@@ -1056,7 +1056,7 @@ def test_make_transform_sets_kwargs_correctly(es):
         name="is_in",
         description="For each value of the base feature, checks whether it is "
         "in a list that is provided.",
-        cls_attributes={"_get_name": isin_get_name})
+        cls_attributes={"generate_name": isin_generate_name})
 
     isin_1_list = ["toothpaste", "coke_zero"]
     isin_1_base_f = Feature(es['log']['product_id'])

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -1037,3 +1037,34 @@ def test_make_transform_restricts_time_arg():
             Numeric,
             name="BadPrimitive",
             description="This primitive should erorr")
+
+
+def test_make_transform_sets_kwargs_correctly(es):
+    def pd_is_in(array, list_of_outputs=None):
+        if list_of_outputs is None:
+            list_of_outputs = []
+        return pd.Series(array).isin(list_of_outputs)
+
+    def isin_get_name(self):
+        return u"%s.isin(%s)" % (self.base_features[0].get_name(),
+                                 str(self.kwargs['list_of_outputs']))
+
+    IsIn = make_trans_primitive(
+        pd_is_in,
+        [Variable],
+        Boolean,
+        name="is_in",
+        description="For each value of the base feature, checks whether it is "
+        "in a list that is provided.",
+        cls_attributes={"_get_name": isin_get_name})
+
+    isin_1_list = ["toothpaste", "coke_zero"]
+    isin_1_base_f = Feature(es['log']['product_id'])
+    isin_1 = IsIn(isin_1_base_f, list_of_outputs=isin_1_list)
+    isin_2_list = ["coke_zero"]
+    isin_2_base_f = Feature(es['log']['session_id'])
+    isin_2 = IsIn(isin_2_base_f, list_of_outputs=isin_2_list)
+    assert isin_1_base_f == isin_1.base_features[0]
+    assert isin_1_list == isin_1.kwargs['list_of_outputs']
+    assert isin_2_base_f == isin_2.base_features[0]
+    assert isin_2_list == isin_2.kwargs['list_of_outputs']


### PR DESCRIPTION
Setting custom primitive function inputs via keyword arguments no longer changes keyword arguments for all instances of that custom primitive.  Also renamed `PrimitiveBase._get_name` to `PrimitiveBase.generate_name` to avoid confusiong with `PrimitiveBase.get_name`