### PR TITLE
associative -> commutative

### DIFF
--- a/featuretools/primitives/aggregation_primitive_base.py
+++ b/featuretools/primitives/aggregation_primitive_base.py
@@ -80,7 +80,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_exclude=None, base_of=None,
                        base_of_exclude=None, description='A custom primitive',
                        cls_attributes=None, uses_calc_time=False,
-                       associative=False):
+                       commutative=False):
     '''Returns a new aggregation primitive class
 
     Args:
@@ -116,7 +116,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
             calculated at will be passed to the function as the keyword
             argument 'time'.
 
-        associative (bool): If True, will only make one feature per unique set
+        commutative (bool): If True, will only make one feature per unique set
             of base features
 
     Example:
@@ -151,7 +151,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
     new_class.stack_on_self = stack_on_self
     new_class.base_of = base_of
     new_class.base_of_exclude = base_of_exclude
-    new_class.associative = associative
+    new_class.commutative = commutative
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/primitives/binary_transform.py
+++ b/featuretools/primitives/binary_transform.py
@@ -175,7 +175,7 @@ class ArithmeticFeature(BinaryFeature):
 class Add(ArithmeticFeature):
     """Creates a transform feature that adds two features"""
     operator = ArithmeticFeature._ADD
-    associative = True
+    commutative = True
     input_types = [[Numeric, Numeric],
                    [Numeric],
                    [TimeIndex],
@@ -208,7 +208,7 @@ class Subtract(ArithmeticFeature):
 class Multiply(ArithmeticFeature):
     """Creates a transform feature that multplies two features"""
     operator = ArithmeticFeature._MUL
-    associative = True
+    commutative = True
 
 
 class Divide(ArithmeticFeature):
@@ -282,13 +282,13 @@ class Compare(BinaryFeature):
 
 class Equals(Compare):
     """For each value, determine if it is equal to another value"""
-    associative = True
+    commutative = True
     operator = '='
 
 
 class NotEquals(Compare):
     """For each value, determine if it is not equal to another value"""
-    associative = True
+    commutative = True
     operator = '!='
 
 
@@ -317,7 +317,7 @@ class And(TransformPrimitive):
     name = "and"
     input_types = [Boolean, Boolean]
     return_type = Boolean
-    associative = True
+    commutative = True
 
     def get_function(self):
         return lambda left, right: np.logical_and(left, right)
@@ -328,7 +328,7 @@ class Or(TransformPrimitive):
     name = "or"
     input_types = [Boolean, Boolean]
     return_type = Boolean
-    associative = True
+    commutative = True
 
     def get_function(self):
         return lambda left, right: np.logical_or(left, right)

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -55,7 +55,7 @@ class PrimitiveBase(FTBase):
     # blacklist of primitives can have this primitive in input_types
     base_of_exclude = None
     # (bool) If True will only make one feature per unique set of base features
-    associative = False
+    commutative = False
 
     def __init__(self, entity, base_features, **kwargs):
         assert all(isinstance(f, PrimitiveBase) for f in base_features), \

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -59,7 +59,7 @@ class TransformPrimitive(PrimitiveBase):
 def make_trans_primitive(function, input_types, return_type, name=None,
                          description='A custom transform primitive',
                          cls_attributes=None, uses_calc_time=False,
-                         associative=False):
+                         commutative=False):
     '''Returns a new transform primitive class
 
     Args:
@@ -80,7 +80,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
             calculated at will be passed to the function as the keyword
             argument 'time'.
 
-        associative (bool): If True, will only make one feature per unique set
+        commutative (bool): If True, will only make one feature per unique set
             of base features
 
     Example:
@@ -119,7 +119,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
     new_class.name = name
     new_class.input_types = input_types
     new_class.return_type = return_type
-    new_class.associative = associative
+    new_class.commutative = commutative
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -531,7 +531,7 @@ class DeepFeatureSynthesis(object):
                                               max_depth=new_max_depth)
 
             matching_inputs = match(input_types, features,
-                                    associative=trans_prim.associative)
+                                    commutative=trans_prim.commutative)
 
             for matching_input in matching_inputs:
                 new_f = trans_prim(*matching_input)
@@ -601,7 +601,7 @@ class DeepFeatureSynthesis(object):
 
             features = [f for f in features if not self._feature_in_relationship_path(relationship_path, f)]
             matching_inputs = match(input_types, features,
-                                    associative=agg_prim.associative)
+                                    commutative=agg_prim.commutative)
             wheres = list(self.where_clauses[child_entity.id])
 
             for matching_input in matching_inputs:
@@ -744,7 +744,7 @@ def match_by_type(features, t):
     return matches
 
 
-def match(input_types, features, replace=False, associative=False):
+def match(input_types, features, replace=False, commutative=False):
     to_match = input_types[0]
     matches = match_by_type(features, to_match)
 
@@ -763,9 +763,9 @@ def match(input_types, features, replace=False, associative=False):
         for r in rest:
             new_match = [m] + list(r)
 
-            # associative uses frozenset instead of tuple because it doesn't
+            # commutative uses frozenset instead of tuple because it doesn't
             # want multiple orderings of the same input
-            if associative:
+            if commutative:
                 new_match = frozenset(new_match)
             else:
                 new_match = tuple(new_match)

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -640,7 +640,7 @@ def test_pickle_features_with_custom_primitive(es):
     os.remove(es_filepath)
 
 
-def test_associative(es):
+def test_commutative(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='log',
                                    entityset=es,
                                    filters=[],


### PR DESCRIPTION
Change the primitive attribute [associative](https://en.wikipedia.org/wiki/Associative_property) to the more accurate word [commutative](https://en.wikipedia.org/wiki/Commutative_property).