### PR TITLE
(WIP) LatLong type

### DIFF
--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -516,7 +516,7 @@ class Latitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series(array[0])
+        return lambda array: pd.Series([x[0] for x in array] )
 
 
 class Longitude(TransformPrimitive):
@@ -529,4 +529,4 @@ class Longitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series(array[1])
+        return lambda array: pd.Series([x[1] for x in array])

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -14,7 +14,6 @@ from featuretools.variable_types import (
     DatetimeTimeIndex,
     Discrete,
     Id,
-    Index,
     Numeric,
     Ordinal,
     Timedelta,
@@ -506,12 +505,6 @@ def pd_time_unit(time_unit):
     return inner
 
 
-def latlong_unstringify(latlong):
-    lat = float(latlong.split(", ")[0].replace("(", ""))
-    lon = float(latlong.split(", ")[1].replace(")", ""))
-    return (lat, lon)
-
-
 class Latitude(TransformPrimitive):
     """
     Returns the first value of the tuple base feature. For
@@ -522,7 +515,7 @@ class Latitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([latlong_unstringify(x)[0] for x in array])
+        return lambda array: pd.Series([x[0] for x in array])
 
 
 class Longitude(TransformPrimitive):
@@ -535,4 +528,4 @@ class Longitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([latlong_unstringify(x)[1] for x in array])
+        return lambda array: pd.Series([x[1] for x in array])

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -505,6 +505,11 @@ def pd_time_unit(time_unit):
         return getattr(pd_index, time_unit).values
     return inner
 
+def latlong_unstringify(latlong):
+    lat = float(latlong.split(", ")[0].replace("(",""))
+    lon = float(latlong.split(", ")[1].replace(")",""))
+    return (lat, lon)
+
 
 class Latitude(TransformPrimitive):
     """
@@ -516,7 +521,7 @@ class Latitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([x[0] for x in array] )
+        return lambda array: pd.Series([latlong_unstringify(x)[0] for x in array])
 
 
 class Longitude(TransformPrimitive):
@@ -529,4 +534,4 @@ class Longitude(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([x[1] for x in array])
+        return lambda array: pd.Series([latlong_unstringify(x)[1] for x in array])

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -465,7 +465,7 @@ class Diff(TransformPrimitive):
             try:
                 return grouped_df[bf_name]
             except KeyError:
-                return pd.Series([np.nan]*len(base_array))
+                return pd.Series([np.nan] * len(base_array))
         return pd_diff
 
 
@@ -505,9 +505,10 @@ def pd_time_unit(time_unit):
         return getattr(pd_index, time_unit).values
     return inner
 
+
 def latlong_unstringify(latlong):
-    lat = float(latlong.split(", ")[0].replace("(",""))
-    lon = float(latlong.split(", ")[1].replace(")",""))
+    lat = float(latlong.split(", ")[0].replace("(", ""))
+    lon = float(latlong.split(", ")[1].replace(")", ""))
     return (lat, lon)
 
 

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -18,7 +18,8 @@ from featuretools.variable_types import (
     Numeric,
     Ordinal,
     Timedelta,
-    Variable
+    Variable,
+    LatLong
 )
 
 current_path = os.path.dirname(os.path.realpath(__file__))
@@ -503,3 +504,29 @@ def pd_time_unit(time_unit):
     def inner(pd_index):
         return getattr(pd_index, time_unit).values
     return inner
+
+
+class Latitude(TransformPrimitive):
+    """
+    Returns the first value of the tuple base feature. For
+    use with the LatLong variable type.
+    """
+    name = 'latitude'
+    input_types = [LatLong]
+    return_type = Numeric
+
+    def get_function(self):
+        return lambda array: pd.Series(array[0])
+
+
+class Longitude(TransformPrimitive):
+    """
+    Returns the second value on the tuple base feature. For
+    use with the LatLong variable type.
+    """
+    name = 'longitude'
+    input_types = [LatLong]
+    return_type = Numeric
+
+    def get_function(self):
+        return lambda array: pd.Series(array[1])

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -723,19 +723,19 @@ def test_head_of_entity(entityset):
     assert(isinstance(entity.head(3), pd.DataFrame))
     assert(isinstance(entity['product_id'].head(3), pd.DataFrame))
 
-    assert(entity.head(n=5).shape == (5, 9))
+    assert(entity.head(n=5).shape == (5, 10))
 
     timestamp1 = pd.to_datetime("2011-04-09 10:30:10")
     timestamp2 = pd.to_datetime("2011-04-09 10:30:18")
     datetime1 = datetime(2011, 4, 9, 10, 30, 18)
 
-    assert(entity.head(5, cutoff_time=timestamp1).shape == (2, 9))
-    assert(entity.head(5, cutoff_time=timestamp2).shape == (3, 9))
-    assert(entity.head(5, cutoff_time=datetime1).shape == (3, 9))
+    assert(entity.head(5, cutoff_time=timestamp1).shape == (2, 10))
+    assert(entity.head(5, cutoff_time=timestamp2).shape == (3, 10))
+    assert(entity.head(5, cutoff_time=datetime1).shape == (3, 10))
 
     time_list = [timestamp2] * 3 + [timestamp1] * 2
     cutoff_times = pd.DataFrame(zip(range(5), time_list))
 
-    assert(entityset.head('log', 5, cutoff_time=cutoff_times).shape == (3, 9))
-    assert(entity.head(5, cutoff_time=cutoff_times).shape == (3, 9))
+    assert(entityset.head('log', 5, cutoff_time=cutoff_times).shape == (3, 10))
+    assert(entity.head(5, cutoff_time=cutoff_times).shape == (3, 10))
     assert(entity['product_id'].head(5, cutoff_time=cutoff_times).shape == (3, 1))

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -375,12 +375,12 @@ def test_latlong(es):
     lonvalues = df[longitude.get_name()].values
     assert len(latvalues) == 15
     assert len(lonvalues) == 15
-    real_lats = [0, 5, 15, 30, 50, 0, 1, 3, 6, 0, 0, 5, 0, 7, 21]
+    real_lats = [0, 5, 10, 15, 20, 0, 1, 2, 3, 0, 0, 5, 0, 7, 14]
     real_lons = [0, 2, 4, 6, 8, 0, 1, 2, 3, 0, 0, 2, 0, 3, 6]
-    # for i, v, in enumerate(real_lats):
-    #     assert v == latvalues[i]
-    # for i, v, in enumerate(real_lons):
-    #     assert v == lonvalues[i]
+    for i, v, in enumerate(real_lats):
+        assert v == latvalues[i]
+    for i, v, in enumerate(real_lons):
+        assert v == lonvalues[i]
 
 def test_cum_sum(es):
     log_value_feat = es['log']['value']

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -364,6 +364,13 @@ def test_arithmetic_of_agg(es):
         assert v == test[1]
 
 
+# TODO latlong is a string in entityset. Asserts in test_latlong fail
+# def latlong_unstringify(latlong):
+#     lat = float(latlong.split(", ")[0].replace("(", ""))
+#     lon = float(latlong.split(", ")[1].replace(")", ""))
+#     return (lat, lon)
+
+
 def test_latlong(es):
     log_latlong_feat = es['log']['latlong']
     latitude = Latitude(log_latlong_feat)
@@ -376,12 +383,12 @@ def test_latlong(es):
     lonvalues = df[longitude.get_name()].values
     assert len(latvalues) == 15
     assert len(lonvalues) == 15
-    real_lats = [0, 5, 10, 15, 20, 0, 1, 2, 3, 0, 0, 5, 0, 7, 14]
-    real_lons = [0, 2, 4, 6, 8, 0, 1, 2, 3, 0, 0, 2, 0, 3, 6]
-    for i, v, in enumerate(real_lats):
-        assert v == latvalues[i]
-    for i, v, in enumerate(real_lons):
-        assert v == lonvalues[i]
+#     real_lats = [0, 5, 10, 15, 20, 0, 1, 2, 3, 0, 0, 5, 0, 7, 14]
+#     real_lons = [0, 2, 4, 6, 8, 0, 1, 2, 3, 0, 0, 2, 0, 3, 6]
+#     for i, v, in enumerate(real_lats):
+#         assert v == latvalues[i]
+#     for i, v, in enumerate(real_lons):
+#         assert v == lonvalues[i]
 
 
 def test_cum_sum(es):

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -363,6 +363,7 @@ def test_arithmetic_of_agg(es):
         v = df[features[i].get_name()].values.tolist()
         assert v == test[1]
 
+
 def test_latlong(es):
     log_latlong_feat = es['log']['latlong']
     latitude = Latitude(log_latlong_feat)
@@ -381,6 +382,7 @@ def test_latlong(es):
         assert v == latvalues[i]
     for i, v, in enumerate(real_lons):
         assert v == lonvalues[i]
+
 
 def test_cum_sum(es):
     log_value_feat = es['log']['value']

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -28,8 +28,10 @@ from featuretools.primitives import (
     IdentityFeature,
     IsIn,
     IsNull,
+    Latitude,
     LessThan,
     LessThanEqualTo,
+    Longitude,
     Mod,
     Mode,
     Multiply,
@@ -361,6 +363,24 @@ def test_arithmetic_of_agg(es):
         v = df[features[i].get_name()].values.tolist()
         assert v == test[1]
 
+def test_latlong(es):
+    log_latlong_feat = es['log']['latlong']
+    latitude = Latitude(log_latlong_feat)
+    longitude = Longitude(log_latlong_feat)
+    features = [latitude, longitude]
+    pandas_backend = PandasBackend(es, features)
+    df = pandas_backend.calculate_all_features(instance_ids=range(15),
+                                               time_last=None)
+    latvalues = df[latitude.get_name()].values
+    lonvalues = df[longitude.get_name()].values
+    assert len(latvalues) == 15
+    assert len(lonvalues) == 15
+    real_lats = [0, 5, 15, 30, 50, 0, 1, 3, 6, 0, 0, 5, 0, 7, 21]
+    real_lons = [0, 2, 4, 6, 8, 0, 1, 2, 3, 0, 0, 2, 0, 3, 6]
+    # for i, v, in enumerate(real_lats):
+    #     assert v == latvalues[i]
+    # for i, v, in enumerate(real_lons):
+    #     assert v == lonvalues[i]
 
 def test_cum_sum(es):
     log_value_feat = es['log']['value']

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -88,6 +88,8 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
                     [i * 3 for i in range(3)] +
                     [np.nan] * 2)
 
+    latlong = list([(values[i], values_2[i]) for i, _ in enumerate(values)])
+
     log_df = pd.DataFrame({
         'id': range(17),
         'session_id': [0] * 5 + [1] * 4 + [2] * 1 + [3] * 2 + [4] * 3 + [5] * 2,
@@ -97,6 +99,7 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
         'datetime': times,
         'value': values,
         'value_2': values_2,
+        'latlong': latlong,
         'priority_level': [0] * 2 + [1] * 5 + [0] * 6 + [2] * 2 + [1] * 2,
         'purchased': [True] * 11 + [False] * 4 + [True, False],
         'comments': [coke_zero_review()] + ['I loved it'] * 2 +
@@ -227,6 +230,7 @@ def make_variable_types(with_integer_time_index=False):
         'datetime': variable_types.Datetime,
         'value': variable_types.Numeric,
         'value_2': variable_types.Numeric,
+        'latlong': variable_types.LatLong,
         'priority_level': variable_types.Ordinal,
         'purchased': variable_types.Boolean,
         'comments': variable_types.Text

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -314,4 +314,10 @@ class PandasTypes:
                         'float16', 'float32', 'float64']
 
 
-ALL_VARIABLE_TYPES = [Datetime, Numeric, Timedelta, Categorical, Text, Ordinal, Boolean]
+class LatLong(Variable):
+    _dtype_repr = "latlong"
+
+
+ALL_VARIABLE_TYPES = [Datetime, Numeric, Timedelta,
+                      Categorical, Text, Ordinal,
+                      Boolean, LatLong]


### PR DESCRIPTION
The issue in testing comes from `mock_ds.py` where the mock retail entityset is made with `es.entity_from_csv(entity, ` (line 292). This makes the latlong type in that entityset a string rather than a tuple. The options as I understand them are:

1. Modify `Latitude` and `Longitude` to check if the latlong is a string
2. Modify `entity_from_csv` to convert certain strings to tuples
3. Change the test to do the pandas `_from_csv`, modify the dataframe and then make `entity_from_dataframe`.
4. Leave `Latitude` and `Longitude` with no real tests for now.

My gut is to go with 3. Do you have a preference @kmax12?

