### PR TITLE
Change `normalize_entity` to update `secondary_time_index`

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -804,8 +804,8 @@ class EntitySet(BaseEntitySet):
 
         new_entity = self.entity_stores[new_entity_id]
         if make_secondary_time_index:
-            values = make_secondary_time_index.values()[0]
-            values.remove(make_secondary_time_index.keys()[0])
+            values = list(make_secondary_time_index.values()[0])
+            values.remove(list(make_secondary_time_index.keys())[0])
             new_dict = {secondary_time_index: values}
 
             new_entity.secondary_time_index = new_dict

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -804,7 +804,7 @@ class EntitySet(BaseEntitySet):
 
         new_entity = self.entity_stores[new_entity_id]
         if make_secondary_time_index:
-            values = list(make_secondary_time_index.values()[0])
+            values = list(make_secondary_time_index.values())[0]
             values.remove(list(make_secondary_time_index.keys())[0])
             new_dict = {secondary_time_index: values}
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -759,6 +759,7 @@ class EntitySet(BaseEntitySet):
             if new_entity_secondary_time_index:
                 secondary_df.rename(columns={secondary_time_index: new_entity_secondary_time_index},
                                     inplace=True)
+                secondary_time_index = new_entity_secondary_time_index
             else:
                 new_entity_secondary_time_index = secondary_time_index
             secondary_df.set_index(index, inplace=True)
@@ -801,6 +802,7 @@ class EntitySet(BaseEntitySet):
         self.delete_entity_variables(base_entity_id, additional_variables)
 
         new_entity = self.entity_stores[new_entity_id]
+        new_entity.secondary_time_index = {secondary_time_index: [secondary_time_index]}
 
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -802,7 +802,8 @@ class EntitySet(BaseEntitySet):
         self.delete_entity_variables(base_entity_id, additional_variables)
 
         new_entity = self.entity_stores[new_entity_id]
-        new_entity.secondary_time_index = {secondary_time_index: [secondary_time_index]}
+        if make_secondary_time_index:
+            new_entity.secondary_time_index = {secondary_time_index: [secondary_time_index]}
 
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -804,14 +804,11 @@ class EntitySet(BaseEntitySet):
 
         new_entity = self.entity_stores[new_entity_id]
         if make_secondary_time_index:
-            values = list(make_secondary_time_index.values())[0]
-            values.remove(list(make_secondary_time_index.keys())[0])
-            new_dict = {secondary_time_index: values}
-
+            old_ti_name = list(make_secondary_time_index.keys())[0]
+            ti_cols = list(make_secondary_time_index.values())[0]
+            ti_cols = [c if c != old_ti_name else secondary_time_index for c in ti_cols]
+            new_dict = {secondary_time_index: ti_cols}
             new_entity.secondary_time_index = new_dict
-            for ti, cols in new_entity.secondary_time_index.items():
-                if ti not in cols:
-                    cols.append(ti)
 
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -753,6 +753,7 @@ class EntitySet(BaseEntitySet):
 
             assert len(make_secondary_time_index) == 1, "Can only provide 1 secondary time index"
             secondary_time_index = list(make_secondary_time_index.keys())[0]
+
             secondary_variables = [index, secondary_time_index] + list(make_secondary_time_index.values())[0]
             secondary_df = new_entity_df. \
                 drop_duplicates(index, keep='last')[secondary_variables]
@@ -803,7 +804,14 @@ class EntitySet(BaseEntitySet):
 
         new_entity = self.entity_stores[new_entity_id]
         if make_secondary_time_index:
-            new_entity.secondary_time_index = {secondary_time_index: [secondary_time_index]}
+            values = make_secondary_time_index.values()[0]
+            values.remove(make_secondary_time_index.keys()[0])
+            new_dict = {secondary_time_index: values}
+
+            new_entity.secondary_time_index = new_dict
+            for ti, cols in new_entity.secondary_time_index.items():
+                if ti not in cols:
+                    cols.append(ti)
 
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
 

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -716,6 +716,17 @@ class TestNormalizeEntity(object):
         regions_lti = es["regions"].last_time_index.sort_index()
         assert (regions_lti == region_series.sort_index()).all()
 
+    def test_secondary_time_index(self, entityset):
+        es = entityset
+        es.normalize_entity('log', 'values', 'value',
+                            make_time_index=True,
+                            make_secondary_time_index={'datetime':[]},
+                            new_entity_time_index="value_time",
+                            new_entity_secondary_time_index='second_ti',
+                            convert_links_to_integers=True)
+        assert (isinstance(es['values'].df['second_ti'], pd.Series))
+        assert (es['values']['second_ti']._dtype_repr == 'datetime')
+        assert (es['values'].secondary_time_index == {'second_ti': ['second_ti']})
 
 def test_head_of_entity(entityset):
 

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -720,13 +720,14 @@ class TestNormalizeEntity(object):
         es = entityset
         es.normalize_entity('log', 'values', 'value',
                             make_time_index=True,
-                            make_secondary_time_index={'datetime': []},
+                            make_secondary_time_index={'datetime': ['comments']},
                             new_entity_time_index="value_time",
                             new_entity_secondary_time_index='second_ti',
                             convert_links_to_integers=True)
+
         assert (isinstance(es['values'].df['second_ti'], pd.Series))
         assert (es['values']['second_ti']._dtype_repr == 'datetime')
-        assert (es['values'].secondary_time_index == {'second_ti': ['second_ti']})
+        assert (es['values'].secondary_time_index == {'second_ti': ['comments', 'second_ti']})
 
 
 def test_head_of_entity(entityset):

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -720,13 +720,14 @@ class TestNormalizeEntity(object):
         es = entityset
         es.normalize_entity('log', 'values', 'value',
                             make_time_index=True,
-                            make_secondary_time_index={'datetime':[]},
+                            make_secondary_time_index={'datetime': []},
                             new_entity_time_index="value_time",
                             new_entity_secondary_time_index='second_ti',
                             convert_links_to_integers=True)
         assert (isinstance(es['values'].df['second_ti'], pd.Series))
         assert (es['values']['second_ti']._dtype_repr == 'datetime')
         assert (es['values'].secondary_time_index == {'second_ti': ['second_ti']})
+
 
 def test_head_of_entity(entityset):
 


### PR DESCRIPTION
For issue #58 the `secondary_time_index` attribute of an entityset isn't properly updated if it's set explicitly with `new_entity_secondary_tiime_index` in `normalize_entity`.  This is *a* fix but there might be a cleaner one.