### PR TITLE
Relax numpy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.0
+numpy>=1.13.3
 scipy>=1.0.0
 pandas>=0.20.3
 s3fs>=0.1.2


### PR DESCRIPTION
Featuretools still passes all tests when dropped to numpy 1.13.3. The higher version was overwriting the numpy version in the Kaggle kernel (https://github.com/Kaggle/docker-python/pull/154) 