### PR TITLE
Use multiple cores to calculate feature matrix [WIP]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	find . -name '*~' -delete
 
 lint:
-	flake8 featuretools && isort --check-only --recursive featuretools
+	flake8 featuretools && isort --check-only --verbose --recursive featuretools
 
 test: lint
 	python $(TEST_CMD)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	find . -name '*~' -delete
 
 lint:
-	flake8 featuretools && isort --check-only --verbose --recursive featuretools
+	flake8 featuretools && isort --check-only --recursive featuretools
 
 test: lint
 	python $(TEST_CMD)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -186,9 +186,9 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
     for _, group in grouped:
         if group.shape[0] > num_per_chunk:
             for i in range(0, group.shape[0], num_per_chunk):
-                chunks.append((_, group.iloc[i:i + num_per_chunk]))
+                chunks.append(group.iloc[i:i + num_per_chunk])
         else:
-            chunks.append((_, group))
+            chunks.append(group)
 
     if njobs != 1:
         # put chunks in dask bag
@@ -229,7 +229,7 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
             iterator = chunks
 
         feature_matrix = []
-        for _, group in iterator:
+        for group in iterator:
             _feature_matrix = calculate_batch(features, group, approximate,
                                               entityset, backend_verbose,
                                               training_window, profile,

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -13,7 +13,8 @@ from ..testing_utils import make_ecommerce_entityset
 
 from featuretools import EntitySet, Timedelta, calculate_feature_matrix, dfs
 from featuretools.computational_backends.calculate_feature_matrix import (
-    bin_cutoff_times
+    bin_cutoff_times,
+    calc_num_per_chunk
 )
 from featuretools.primitives import (
     AggregationPrimitive,
@@ -490,3 +491,79 @@ def test_cutoff_time_naming(entityset):
 
     with pytest.raises(AttributeError):
         calculate_feature_matrix([dfeat], cutoff_time=cutoff_df_wrong_index_name)
+
+
+def test_calculating_number_per_chunk():
+    cutoff_df = pd.DataFrame({'time': [pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-08 10:30:00'),
+                                       pd.Timestamp('2011-04-09 10:30:06')],
+                              'instance_id': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]})
+
+    singleton = pd.DataFrame({'time': [pd.Timestamp('2011-04-08 10:30:00')],
+                              'instance_id': [0]})
+    shape = cutoff_df.shape
+    with pytest.raises(ValueError):
+        calc_num_per_chunk(-1, shape)
+
+    with pytest.raises(ValueError):
+        calc_num_per_chunk("test", shape)
+
+    with pytest.raises(ValueError):
+        calc_num_per_chunk(2.5, shape)
+
+    assert calc_num_per_chunk(11, shape) == 11
+    assert calc_num_per_chunk(.7, shape) == 7
+    assert calc_num_per_chunk(.65, shape) == 6
+    assert calc_num_per_chunk(None, shape) == 10
+    assert calc_num_per_chunk(1, shape) == 1
+    assert calc_num_per_chunk(.5, singleton.shape) == 1
+
+
+def test_calc_feature_matrix_in_chunks(entityset):
+    times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
+                 [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
+                 [datetime(2011, 4, 9, 10, 40, 0)] +
+                 [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
+                 [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
+                 [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
+    labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
+
+    property_feature = IdentityFeature(entityset['log']['value']) > 10
+
+    feature_matrix = calculate_feature_matrix([property_feature],
+                                              instance_ids=range(17),
+                                              cutoff_time=times,
+                                              verbose=True,
+                                              chunk_size=.13,
+                                              approximate='1 hour')
+
+    assert (feature_matrix == labels).values.all()
+
+
+def test_njobs(entityset):
+    times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
+                 [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
+                 [datetime(2011, 4, 9, 10, 40, 0)] +
+                 [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
+                 [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
+                 [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
+    labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
+
+    property_feature = IdentityFeature(entityset['log']['value']) > 10
+
+    feature_matrix = calculate_feature_matrix([property_feature],
+                                              instance_ids=range(17),
+                                              cutoff_time=times,
+                                              verbose=True,
+                                              chunk_size=.13,
+                                              njobs=2,
+                                              approximate='1 hour')
+
+    assert (feature_matrix == labels).values.all()

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -52,12 +52,12 @@ from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def es():
     return make_ecommerce_entityset()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def int_es():
     return make_ecommerce_entityset(with_integer_time_index=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml>=3.12
 cloudpickle>=0.4.0
 future>=0.16.0
 pympler>=0.5
+dask[complete]==0.15.4


### PR DESCRIPTION
This PR adds two more optional parameters to `calculate_feature_matrix`, `njobs` and `chunk_size`.  The `chunk_size` parameter sets the limit for how many rows of the feature matrix can be calculated at once, either as a percentage of the entire matrix or a finite number of rows.  Setting this parameter to `None` will remove this limit.  The `njobs` parameter sets the number of processes spawned to calculate the feature matrix.