### PR TITLE
Forbid stacking of expanding features in DFS

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -736,6 +736,10 @@ def check_stacking(primitive, input_types):
         else:
             continue
         return False
+    # Don't stack on expanding features for now.
+    # pandas_backend can't handle them
+    if any([f.expanding for f in input_types]):
+        return False
 
     return True
 

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -20,12 +20,12 @@ from featuretools.primitives import (
     IdentityFeature,
     Last,
     Mean,
+    NMostCommon,
+    NUnique,
     Sum,
     TimeSincePrevious,
     TransformPrimitive,
-    make_agg_primitive,
-    NMostCommon,
-    NUnique
+    make_agg_primitive
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.utils.gen_utils import getsize

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -674,4 +674,3 @@ def test_no_stack_on_expanding(es):
     feats = dfs_obj.build_features()
     feat_names = [f.get_name() for f in feats]
     assert (NUnique(nmostcommon, es['customers']).get_name() not in feat_names)
-

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -23,7 +23,9 @@ from featuretools.primitives import (
     Sum,
     TimeSincePrevious,
     TransformPrimitive,
-    make_agg_primitive
+    make_agg_primitive,
+    NMostCommon,
+    NUnique
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.utils.gen_utils import getsize
@@ -660,3 +662,16 @@ def test_commutative(es):
 
     assert num_add_feats == 3
     assert num_add_as_base_feat == 9
+
+
+def test_no_stack_on_expanding(es):
+    nmostcommon = NMostCommon(es['log']['product_id'], es['sessions'])
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='customers',
+                                   entityset=es,
+                                   agg_primitives=[NUnique],
+                                   seed_features=[nmostcommon],
+                                   max_depth=2)
+    feats = dfs_obj.build_features()
+    feat_names = [f.get_name() for f in feats]
+    assert (NUnique(nmostcommon, es['customers']).get_name() not in feat_names)
+


### PR DESCRIPTION
This fixes #85 

Adds 2 lines to DFS to prevent stacking on top of expanding features, and provides a test to make sure this does not happen. See #85 for reasoning.