### PR TITLE
(WIP) Make trans_primitives stack in either order

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -523,7 +523,7 @@ class DeepFeatureSynthesis(object):
 
         self._add_identity_features(all_features, entity)
 
-        for trans_prim in self.trans_primitives:
+        for i, trans_prim in enumerate(self.trans_primitives):
             # if multiple input_types, only use first one for DFS
             input_types = trans_prim.input_types
             if type(input_types[0]) == list:
@@ -544,6 +544,10 @@ class DeepFeatureSynthesis(object):
 
                 self._handle_new_feature(all_features=all_features,
                                          new_feature=new_f)
+                for earlier_trans in self.trans_primitives[:i]:
+                    new_f = earlier_trans(*matching_input)
+                    self._handle_new_feature(all_features=all_features,
+                                             new_feature=new_f)
 
         # now that all transform features are added, build where clauses
         self._build_where_clauses(all_features, entity)


### PR DESCRIPTION
close #39 

Adds a for loop when making trans primitives that runs through previously used transform primitives.

If we have non-commutative transform primitives `Prim1`, `Prim2` and `Prim3`, `max_depth=3` and feature `f`, previous output could only build in order:
```
f, 
Prim1(f),
Prim2(f), Prim2(Prim1(f)),
Prim3(f), Prim3(Prim1(f)), Prim3(Prim2(f)), Prim3(Prim2(Prim1(f))) 
```


