### PR TITLE
Infer expanding features using ListVariable type

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -170,7 +170,7 @@ Location Transform Primitives
 *****************************
 .. autosummary::
    :toctree generated/
-   
+
    Latitude
    Longitude
    Haversine
@@ -320,6 +320,8 @@ Variable types
     Boolean
     Text
     LatLong
+    ListDiscrete
+    ListNumeric
 
 
 Feature Selection

--- a/featuretools/primitives/aggregation_primitives.py
+++ b/featuretools/primitives/aggregation_primitives.py
@@ -16,8 +16,8 @@ from featuretools.variable_types import (
     Boolean,
     DatetimeTimeIndex,
     Discrete,
-    ListDiscrete,
     Index,
+    ListDiscrete,
     Numeric,
     Variable
 )

--- a/featuretools/primitives/aggregation_primitives.py
+++ b/featuretools/primitives/aggregation_primitives.py
@@ -16,6 +16,7 @@ from featuretools.variable_types import (
     Boolean,
     DatetimeTimeIndex,
     Discrete,
+    ListDiscrete,
     Index,
     Numeric,
     Variable
@@ -177,11 +178,10 @@ class NMostCommon(AggregationPrimitive):
     """Finds the N most common elements in a categorical feature"""
     name = "n_most_common"
     input_types = [Discrete]
-    return_type = Discrete
+    return_type = ListDiscrete
     # max_stack_depth = 1
     stack_on = []
     stack_on_exclude = []
-    expanding = True
 
     def __init__(self, base_feature, parent_entity, n=3):
         self.n = n

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -15,7 +15,7 @@ from featuretools.utils.wrangle import (
     _check_time_against_column,
     _check_timedelta
 )
-from featuretools.variable_types import Variable, ListVariable
+from featuretools.variable_types import ListVariable, Variable
 
 logger = logging.getLogger('featuretools')
 

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -15,7 +15,7 @@ from featuretools.utils.wrangle import (
     _check_time_against_column,
     _check_timedelta
 )
-from featuretools.variable_types import Variable
+from featuretools.variable_types import Variable, ListVariable
 
 logger = logging.getLogger('featuretools')
 
@@ -46,9 +46,7 @@ class PrimitiveBase(FTBase):
     # downward from this feature's base features.
     max_stack_depth = None
     rolling_function = False
-    #: (bool): If True, feature will expand into multiple values during
-    # calculation
-    expanding = False
+
     _name = None
     # whitelist of primitives can have this primitive in input_types
     base_of = None
@@ -126,6 +124,12 @@ class PrimitiveBase(FTBase):
             return_type = feature.return_type
 
         return return_type
+
+    @property
+    def expanding(self):
+        #: (bool): If True, feature will expand into multiple values during
+        # calculation
+        return issubclass(self.variable_type, ListVariable)
 
     @property
     def base_hashes(self):

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -40,8 +40,6 @@ class TransformPrimitive(PrimitiveBase):
         # Any edits made to this method should also be made to the
         # new_class_init method in make_trans_primitive
         self.base_features = [self._check_feature(f) for f in base_features]
-        if any(bf.expanding for bf in self.base_features):
-            self.expanding = True
         assert len(set([f.entity for f in self.base_features])) == 1, \
             "More than one entity for base features"
         super(TransformPrimitive, self).__init__(self.base_features[0].entity,
@@ -132,8 +130,6 @@ def make_trans_primitive(function, input_types, return_type, name=None,
         def new_class_init(self, *args, **kwargs):
             self.kwargs = copy.deepcopy(self.default_kwargs)
             self.base_features = [self._check_feature(f) for f in args]
-            if any(bf.expanding for bf in self.base_features):
-                self.expanding = True
             assert len(set([f.entity for f in self.base_features])) == 1, \
                 "More than one entity for base features"
             self.kwargs.update(kwargs)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -539,9 +539,6 @@ class DeepFeatureSynthesis(object):
 
             for matching_input in matching_inputs:
                 new_f = trans_prim(*matching_input)
-                if new_f.expanding:
-                    continue
-
                 self._handle_new_feature(all_features=all_features,
                                          new_feature=new_f)
 
@@ -573,11 +570,8 @@ class DeepFeatureSynthesis(object):
 
             new_f = DirectFeature(f, child_entity)
 
-            if f.expanding:
-                continue
-            else:
-                self._handle_new_feature(all_features=all_features,
-                                         new_feature=new_f)
+            self._handle_new_feature(all_features=all_features,
+                                     new_feature=new_f)
 
     def _build_agg_features(self, all_features,
                             parent_entity, child_entity, max_depth=0):

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -31,8 +31,7 @@ from featuretools.variable_types import (
     Index,
     Numeric,
     Variable,
-    ListDiscrete,
-    ListNumeric
+    ListDiscrete
 )
 
 

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -13,10 +13,10 @@ from featuretools.primitives import (
     Feature,
     Mean,
     Median,
+    NMostCommon,
     NumTrue,
     Sum,
     TimeSinceLast,
-    NMostCommon,
     get_aggregation_primitives,
     make_agg_primitive
 )
@@ -29,9 +29,9 @@ from featuretools.variable_types import (
     Datetime,
     DatetimeTimeIndex,
     Index,
+    ListDiscrete,
     Numeric,
-    Variable,
-    ListDiscrete
+    Variable
 )
 
 

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -328,6 +328,26 @@ class LatLong(Variable):
     _dtype_repr = "latlong"
 
 
+class ListVariable(Variable):
+    """Represents a list of values
+       This class is meant as an abstract base class
+       for ListDiscrete, ListNumeric, and other subclasses
+    """
+    _dtype_repr = "list_object"
+
+
+class ListDiscrete(ListVariable):
+    """Represents a list of discrete values
+    """
+    _dtype_repr = "list_discrete"
+
+
+class ListNumeric(ListVariable):
+    """Represents a list of numeric values
+    """
+    _dtype_repr = "list_numeric"
+
+
 ALL_VARIABLE_TYPES = [Datetime, Numeric, Timedelta,
                       Categorical, Text, Ordinal,
-                      Boolean, LatLong]
+                      Boolean, LatLong, ListDiscrete, ListNumeric]


### PR DESCRIPTION
Resolves #85 by introducing a new ListVariable type (as well as ListDiscrete and ListNumeric). Expanding features now must state these types as their `return_type`, and `PrimitiveBase` can now infer if a feature is expanding by checking the computed `variable_type` property.