### PR TITLE
Convert text variable to string before NumWords

### DIFF
--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -362,8 +362,7 @@ class NumWords(TransformPrimitive):
 
     def get_function(self):
         def word_counter(array):
-            array = pd.Series(array).fillna('')
-            return pd.Series([str(x).count(' ') + 1 for x in array])
+            return pd.Series(array).fillna('').str.count(' ') + 1
         return word_counter
 
 

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -361,7 +361,10 @@ class NumWords(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([str(x).count(" ") + 1 for x in array])
+        def word_counter(array):
+            array = pd.Series(array).fillna('')
+            return pd.Series([str(x).count(' ') + 1 for x in array])
+        return word_counter
 
 
 # class Like(TransformPrimitive):

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -361,7 +361,7 @@ class NumWords(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series([x.count(" ") + 1 for x in array])
+        return lambda array: pd.Series([str(x).count(" ") + 1 for x in array])
 
 
 # class Like(TransformPrimitive):


### PR DESCRIPTION
This fixes an error that NumWords gives if it encounters a float. This comes up often, as `np.NaN` is a float. An alternate solution would be to catch the NaNs directly and return 0 or NaN rather than 1.