### PR TITLE
Bug fix for dependencies of uses_full_entity features

### DIFF
--- a/featuretools/computational_backends/feature_tree.py
+++ b/featuretools/computational_backends/feature_tree.py
@@ -213,15 +213,20 @@ class FeatureTree(object):
 
     def uses_full_entity_differentiator(self, f):
         is_output = f.hash() in self.feature_hashes
+        normal_dependent_is_output = any([(not d.uses_full_entity and
+                                           d.hash() in self.feature_hashes)
+                                          for d in self.feature_dependents[f.hash()]])
+        need_selected_output = is_output or normal_dependent_is_output
         # If a dependent feature requires all the instance values
         # of the associated entity, then we need to calculate this
         # feature on all values
         # If the feature is one in which the user requested as
         # an output (meaning it's part of the input feature list
-        # to calculate_feature_matrix), then we also need
+        # to calculate_feature_matrix), or a normal, non-uses_full_entity dependent
+        # feature is an output, then we also need
         # to subselect the output based on the desired instance ids
         # and place in the return data frame.
-        if self._dependent_uses_full_entity(f) and is_output:
+        if self._dependent_uses_full_entity(f) and need_selected_output:
             return "dependent_and_output"
         elif self._dependent_uses_full_entity(f):
             return "dependent"

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -214,10 +214,10 @@ class PandasBackend(ComputationalBackend):
                         # in the output entity_frames
                         # We thus need to concatenate the existing frame with the result frame,
                         # making sure not to duplicate any columns
-                        result_frame = result_frame[[c for c in result_frame.columns
+                        _result_frame = result_frame[[c for c in result_frame.columns
                                                      if c not in frames[entity_id].columns]]
-                        result_frame = result_frame.reindex(index)
-                        frames[entity_id] = pd.concat([frames[entity_id], result_frame], axis=1)
+                        _result_frame = _result_frame.reindex(index)
+                        frames[entity_id] = pd.concat([frames[entity_id], _result_frame], axis=1)
 
                     if verbose:
                         pbar.update(1)

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -1151,6 +1151,29 @@ def test_percentile_with_cutoff(es):
         [2], pd.Timestamp('2011/04/09 10:30:13'))
     assert df[p.get_name()].tolist()[0] == 1.0
 
+
+def test_two_kinds_of_dependents(es):
+    v = Feature(es['log']['value'])
+    product = Feature(es['log']['product_id'])
+    agg = Sum(v, es['customers'], where=product=='coke zero')
+    p = Percentile(agg)
+    from featuretools.primitives import Absolute
+    g = Absolute(agg)
+    agg2 = Sum(v, es['sessions'], where=product=='coke zero')
+    # Adding this feature in tests line 218 in pandas_backend
+    # where we remove columns in result_frame that already exist
+    # in the output entity_frames in preparation for pd.concat
+    # In a prior version, this failed because we changed the result_frame
+    # variable itself, rather than making a new variable _result_frame.
+    # When len(output_frames) > 1, the second iteration won't have
+    # all the necessary columns because they were removed in the first
+    agg3 = Sum(agg2, es['customers'])
+    pandas_backend = PandasBackend(es, [p, g, agg3])
+    df = pandas_backend.calculate_all_features([0, 1], None)
+    assert df[p.get_name()].tolist() == [0.5, 1.0]
+    assert df[g.get_name()].tolist() == [15, 26]
+
+
 # P TODO: reimplement like
 # def test_like_feat(es):
 #     like = Like(es['log']['product_id'], "coke")


### PR DESCRIPTION
This PR fixes two bugs related to dependencies of uses_full_entity features.

Bug 1:

If:
 - a feature X *does not* have the `uses_full_entity` attribute
 - a dependent feature Y *does* have the `uses_full_entity` attribute
 - another dependent feature Z *does not* have the `uses_full_entity` attribute, and is one of the requested output features

Then the output frame as a result of computing this feature X should be placed in both `entity_frames`, and `large_entity_frames` in `pandas_backend.py`. However, we previously only check if the feature X itself is a requested output feature, not if it has a dependent that is an output feature (and not a `uses_full_entity` feature). This means the output of X was only placed in `large_entity_frames`. The computation of feature Z  then failed because it depended on X being in `entity_frames`.

Bug 2:
To make sure we don't have overlapping columns when we concatenate the output frame as a result of computing a feature with the existing entity_frames, we drop duplicated columns in feature computation output frame (called `result_frame` in the code). However, we removed these columns in-place, such that if we have to do 2 concats (placing the output frame in both `entity_frames` and `large_entity_frames`, it's possible that we remove some computed features that wouldn't get placed in the second output frame.

I wrote a test case that checks for both of these conditions.