### PR TITLE
Uses full entity update for dependencies of uses_full_entity features

### DIFF
--- a/featuretools/computational_backends/feature_tree.py
+++ b/featuretools/computational_backends/feature_tree.py
@@ -213,15 +213,20 @@ class FeatureTree(object):
 
     def uses_full_entity_differentiator(self, f):
         is_output = f.hash() in self.feature_hashes
+        normal_dependent_is_output = any([(not d.uses_full_entity and
+                                           d.hash() in self.feature_hashes)
+                                          for d in self.feature_dependents[f.hash()]])
+        need_selected_output = is_output or normal_dependent_is_output
         # If a dependent feature requires all the instance values
         # of the associated entity, then we need to calculate this
         # feature on all values
         # If the feature is one in which the user requested as
         # an output (meaning it's part of the input feature list
-        # to calculate_feature_matrix), then we also need
+        # to calculate_feature_matrix), or a normal, non-uses_full_entity dependent
+        # feature is an output, then we also need
         # to subselect the output based on the desired instance ids
         # and place in the return data frame.
-        if self._dependent_uses_full_entity(f) and is_output:
+        if self._dependent_uses_full_entity(f) and need_selected_output:
             return "dependent_and_output"
         elif self._dependent_uses_full_entity(f):
             return "dependent"

--- a/featuretools/computational_backends/feature_tree.py
+++ b/featuretools/computational_backends/feature_tree.py
@@ -218,29 +218,31 @@ class FeatureTree(object):
         # feature on all values
         if self.uses_full_entity(f):
             return 'full_entity_frames'
-        return 'normal_entity_frames'
+        return 'subset_entity_frames'
 
     def output_frames_type(self, f):
         is_output = f.hash() in self.feature_hashes
-        normal_dependent_is_output = any([(not d.uses_full_entity and
+        dependent_uses_full_entity = self._dependent_uses_full_entity(f)
+        dependent_has_subset_input = any([(not d.uses_full_entity and
                                            d.hash() in self.feature_hashes)
                                           for d in self.feature_dependents[f.hash()]])
-        need_selected_output = is_output or normal_dependent_is_output
         # If the feature is one in which the user requested as
         # an output (meaning it's part of the input feature list
-        # to calculate_feature_matrix), or a normal, non-uses_full_entity dependent
-        # feature is an output, then we need
+        # to calculate_feature_matrix), or a dependent feature
+        # takes the subset entity_frames as input, then we need
         # to subselect the output based on the desired instance ids
         # and place in the return data frame.
-        if self._dependent_uses_full_entity(f) and need_selected_output:
-            return 'full_and_normal_entity_frames'
-        elif self._dependent_uses_full_entity(f):
+        if dependent_uses_full_entity and is_output:
+            return 'full_and_subset_entity_frames'
+        elif dependent_uses_full_entity and dependent_has_subset_input:
+            return 'full_and_subset_entity_frames'
+        elif dependent_uses_full_entity:
             return 'full_entity_frames'
         # If the feature itself does not require all the instance values
         # or no dependent features do, then we
         # subselect the output
         # to only desired instances
-        return 'normal_entity_frames'
+        return 'subset_entity_frames'
 
 
 def _get_use_previous(f):

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -202,20 +202,20 @@ class PandasBackend(ComputationalBackend):
                         # in the output entity_frames
                         # We thus need to concatenate the existing frame with the result frame,
                         # making sure not to duplicate any columns
-                        _result_frame = result_frame[[c for c in result_frame.columns
-                                                     if c not in entity_frames[entity_id].columns]]
-                        _result_frame = _result_frame.reindex(index)
+                        _result_frame = result_frame.reindex(index)
+                        cols_to_keep = [c for c in _result_frame.columns
+                                        if c not in entity_frames[entity_id].columns]
                         entity_frames[entity_id] = pd.concat([entity_frames[entity_id],
-                                                              _result_frame],
+                                                              _result_frame[cols_to_keep]],
                                                              axis=1)
 
                     if output_frames_type in ['full_and_subset_entity_frames', 'full_entity_frames']:
                         index = large_entity_frames[entity_id].index
-                        _result_frame = result_frame[[c for c in result_frame.columns
-                                                     if c not in large_entity_frames[entity_id].columns]]
-                        _result_frame = _result_frame.reindex(index)
+                        _result_frame = result_frame.reindex(index)
+                        cols_to_keep = [c for c in _result_frame.columns
+                                        if c not in large_entity_frames[entity_id].columns]
                         large_entity_frames[entity_id] = pd.concat([large_entity_frames[entity_id],
-                                                                    _result_frame],
+                                                                    _result_frame[cols_to_keep]],
                                                                    axis=1)
 
                     if verbose:

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -214,10 +214,10 @@ class PandasBackend(ComputationalBackend):
                         # in the output entity_frames
                         # We thus need to concatenate the existing frame with the result frame,
                         # making sure not to duplicate any columns
-                        result_frame = result_frame[[c for c in result_frame.columns
+                        _result_frame = result_frame[[c for c in result_frame.columns
                                                      if c not in frames[entity_id].columns]]
-                        result_frame = result_frame.reindex(index)
-                        frames[entity_id] = pd.concat([frames[entity_id], result_frame], axis=1)
+                        _result_frame = _result_frame.reindex(index)
+                        frames[entity_id] = pd.concat([frames[entity_id], _result_frame], axis=1)
 
                     if verbose:
                         pbar.update(1)

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -187,14 +187,14 @@ class PandasBackend(ComputationalBackend):
                     input_frames_type = self.feature_tree.input_frames_type(test_feature)
 
                     input_frames = large_entity_frames
-                    if input_frames_type == "normal_entity_frames":
+                    if input_frames_type == "subset_entity_frames":
                         input_frames = entity_frames
 
                     handler = self._feature_type_handler(test_feature)
                     result_frame = handler(group, input_frames)
 
                     output_frames_type = self.feature_tree.output_frames_type(test_feature)
-                    if output_frames_type in ['full_and_normal_entity_frames', 'normal_entity_frames']:
+                    if output_frames_type in ['full_and_subset_entity_frames', 'subset_entity_frames']:
                         index = entity_frames[entity_id].index
                         # If result_frame came from a uses_full_entity feature,
                         # and the input was large_entity_frames,
@@ -209,7 +209,7 @@ class PandasBackend(ComputationalBackend):
                                                               _result_frame],
                                                              axis=1)
 
-                    if output_frames_type in ['full_and_normal_entity_frames', 'full_entity_frames']:
+                    if output_frames_type in ['full_and_subset_entity_frames', 'full_entity_frames']:
                         index = large_entity_frames[entity_id].index
                         _result_frame = result_frame[[c for c in result_frame.columns
                                                      if c not in large_entity_frames[entity_id].columns]]

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -7,6 +7,7 @@ from ..testing_utils import make_ecommerce_entityset
 from featuretools import Timedelta
 from featuretools.computational_backends import PandasBackend
 from featuretools.primitives import (
+    Absolute,
     Add,
     And,
     Compare,
@@ -52,7 +53,9 @@ from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 
 
-@pytest.fixture(scope='module')
+# some tests change the entityset values, so we have to create it fresh
+# for each test (rather than setting scope='module')
+@pytest.fixture
 def es():
     return make_ecommerce_entityset()
 
@@ -1157,7 +1160,6 @@ def test_two_kinds_of_dependents(es):
     product = Feature(es['log']['product_id'])
     agg = Sum(v, es['customers'], where=product=='coke zero')
     p = Percentile(agg)
-    from featuretools.primitives import Absolute
     g = Absolute(agg)
     agg2 = Sum(v, es['sessions'], where=product=='coke zero')
     # Adding this feature in tests line 218 in pandas_backend

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -1158,10 +1158,10 @@ def test_percentile_with_cutoff(es):
 def test_two_kinds_of_dependents(es):
     v = Feature(es['log']['value'])
     product = Feature(es['log']['product_id'])
-    agg = Sum(v, es['customers'], where=product=='coke zero')
+    agg = Sum(v, es['customers'], where=product == 'coke zero')
     p = Percentile(agg)
     g = Absolute(agg)
-    agg2 = Sum(v, es['sessions'], where=product=='coke zero')
+    agg2 = Sum(v, es['sessions'], where=product == 'coke zero')
     # Adding this feature in tests line 218 in pandas_backend
     # where we remove columns in result_frame that already exist
     # in the output entity_frames in preparation for pd.concat

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -1151,6 +1151,29 @@ def test_percentile_with_cutoff(es):
         [2], pd.Timestamp('2011/04/09 10:30:13'))
     assert df[p.get_name()].tolist()[0] == 1.0
 
+
+def test_two_kinds_of_dependents(es):
+    v = Feature(es['log']['value'])
+    product = Feature(es['log']['product_id'])
+    agg = Sum(v, es['customers'], where=product=='coke zero')
+    p = Percentile(agg)
+    from featuretools.primitives import Absolute
+    g = Absolute(agg)
+    agg2 = Sum(v, es['sessions'], where=product=='coke zero')
+    # Adding this feature in tests line 218 in pandas_backend
+    # where we remove columns in result_frame that already exist
+    # in the output entity_frames in preparation for pd.concat
+    # In a prior version, this failed because we changed the result_frame
+    # variable itself, rather than making a new variable _result_frame.
+    # When len(output_frames) > 1, the second iteration won't have
+    # all the necessary columns because they were removed in the first
+    agg3 = Sum(agg2, es['customers'])
+    pandas_backend = PandasBackend(es, [p, g, agg3])
+    df = pandas_backend.calculate_all_features([0, 1], None)
+    assert df[p.get_name()].tolist() == [0.5, 1.0]
+    assert df[g.get_name()].tolist() == [15, 26]
+
+
 # P TODO: reimplement like
 # def test_like_feat(es):
 #     like = Like(es['log']['product_id'], "coke")


### PR DESCRIPTION
This PR fixes two issues related to dependencies of uses_full_entity features.

Issue 1:

If:

a feature X does not have the uses_full_entity attribute
a dependent feature Y does have the uses_full_entity attribute
another dependent feature Z does not have the uses_full_entity attribute, and is one of the requested output features
Then the output frame as a result of computing this feature X should be placed in both entity_frames, and large_entity_frames in pandas_backend.py. However, we previously only check if the feature X itself is a requested output feature, not if it has a dependent that is an output feature (and not a uses_full_entity feature). This means the output of X was only placed in large_entity_frames. The computation of feature Z then failed because it depended on X being in entity_frames.

Issue 2:
To make sure we don't have overlapping columns when we concatenate the output frame as a result of computing a feature with the existing entity_frames, we drop duplicated columns in feature computation output frame (called result_frame in the code). However, we removed these columns in-place, such that if we have to do 2 concats (placing the output frame in both entity_frames and large_entity_frames, it's possible that we remove some computed features that wouldn't get placed in the second output frame.

It is much cleaner to explicitly label each feature with the input frame is should be given, and which output frames its result should be placed in. This fixes issue 2 nicely

I wrote a test case that checks for both of these conditions.