### PR TITLE
Keep non-feature columns when encoding feature matrix

### DIFF
--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -118,7 +118,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
                                       unit="feature")
     for c in iterator:
         if c in extra_columns:
-            pass
+            continue
         try:
             new_X[c] = pd.to_numeric(new_X[c], errors='raise')
         except (TypeError, ValueError):

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -65,6 +65,8 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
         X = feature_matrix.copy()
 
     encoded = []
+    feature_names = [f.get_name() for f in features]
+    extra_columns = [col for col in X.columns if col not in feature_names]
 
     if verbose:
         iterator = make_tqdm_iterator(iterable=features,
@@ -107,15 +109,16 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
 
         X.drop(f.get_name(), axis=1, inplace=True)
 
-    new_X = X[[e.get_name() for e in encoded]]
+    new_X = X[[e.get_name() for e in encoded] + extra_columns]
     iterator = new_X.columns
     if verbose:
         iterator = make_tqdm_iterator(iterable=new_X.columns,
                                       total=len(new_X.columns),
                                       desc="Encoding pass 2",
                                       unit="feature")
-
     for c in iterator:
+        if c in extra_columns:
+            pass
         try:
             new_X[c] = pd.to_numeric(new_X[c], errors='raise')
         except (TypeError, ValueError):

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -79,6 +79,8 @@ def test_encode_features_handles_pass_columns(entityset):
                                columns=["instance_id", "time", "label"])
     feature_matrix = calculate_feature_matrix(features, cutoff_time)
 
+    assert 'label' in feature_matrix.columns
+
     feature_matrix_encoded, features_encoded = encode_features(feature_matrix, features)
     feature_matrix_encoded_shape = feature_matrix_encoded.shape
 


### PR DESCRIPTION
#78 added the option of including non-feature columns with the calculated feature matrix, but `encode_features`  was not including them when creating an encoded feature matrix.   This PR fixes `encode_features` so it includes non-feature columns in the encoded feature matrix.