### PR TITLE
modify ignore_variables docstring

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -84,7 +84,7 @@ class DeepFeatureSynthesis(object):
             ignore_entities (list[str], optional): List of entities to
                 blacklist when creating features. If None, use all entities.
 
-            ignore_variables (dict[str : str], optional): List of specific
+            ignore_variables (dict[str -> list[str]], optional): List of specific
                 variables within each entity to blacklist when creating features.
                 If None, use all variables.
 

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -92,7 +92,7 @@ def dfs(entities=None,
         ignore_entities (list[str], optional): List of entities to
             blacklist when creating features.
 
-        ignore_variables (dict[str -> str], optional): List of specific
+        ignore_variables (dict[str -> list[str]], optional): List of specific
             variables within each entity to blacklist when creating features.
 
         seed_features (list[:class:`.PrimitiveBase`]): List of manually defined


### PR DESCRIPTION
The value in the `ignore_variable` dict takes in a list, not a string. In particular, the loop in `DeepFeatureSynthesis`
```
for eid, vars in ignore_variables.items():
    self.ignore_variables[eid] = set(vars)
```
will take the dictionary `ignore_variables = {'hello': 'world'}` to `self.ignore_variables['hello'] = {'d', 'l', 'o', 'r', 'w'}`. This PR updates the docstring to reflect the correct input type.
