### PR TITLE
NumCharacters primitive handles nan 

### DIFF
--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -349,7 +349,7 @@ class NumCharacters(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series(array).str.len()
+        return lambda array: pd.Series(array).fillna('').str.len()
 
 
 class NumWords(TransformPrimitive):


### PR DESCRIPTION
Resolves an issue where `NumCharacters` would error if the string was a `NaN` (or could interpreted as a `Nan`) and would be unable to return the string length for the primitive. 