### PR TITLE
Remove unused parameter verbose_desc from calculate_feature_matrix

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -32,7 +32,6 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
                              training_window=None, approximate=None,
                              save_progress=None, verbose=False,
                              backend_verbose=False,
-                             verbose_desc='calculate_feature_matrix',
                              profile=False):
     """Calculates a matrix for a given set of instance ids and calculation times.
 


### PR DESCRIPTION
The undocumented parameter `verbose_desc` is not used anywhere in `calculate_feature_matrix` and should be removed.