### PR TITLE
Update repr to show all entities and display to row/col counts

### DIFF
--- a/featuretools/entityset/base_entity.py
+++ b/featuretools/entityset/base_entity.py
@@ -93,14 +93,12 @@ class BaseEntity(FTBase):
     def __repr__(self):
         repr_out = "Entity: {}\n".format(self.name)
         repr_out += "  Variables:"
-        for v in self.variables[:5]:
+        for v in self.variables:
             repr_out += "\n    {} (dtype: {})".format(v.id, v.dtype)
-        if len(self.variables) > 5:
-            num_left = len(self.variables) - 5
-            repr_out += "\n    ...And {} more".format(num_left)
 
         shape = self.get_shape()
-        repr_out += u"\n  Shape:\n    ({}, {})".format(shape[0], shape[1])
+        repr_out += u"\n  Shape:\n    (Rows: {}, Columns: {})".format(
+            shape[0], shape[1])
         return repr_out
 
     @property

--- a/featuretools/entityset/base_entityset.py
+++ b/featuretools/entityset/base_entityset.py
@@ -129,27 +129,22 @@ class BaseEntitySet(FTBase):
         fmat = self.id
         repr_out = u"Entityset: {}\n".format(fmat)
         repr_out += u"  Entities:"
-        for e in self.entities[:5]:
+        for e in self.entities:
             if e.df.shape:
-                repr_out += u"\n    {} (shape = [{}, {}])".format(e.id, e.df.shape[0], e.df.shape[1])
+                repr_out += u"\n    {} [Rows: {}, Columns: {}]".format(
+                    e.id, e.df.shape[0], e.df.shape[1])
             else:
-                repr_out += u"\n    {} (shape = [None, None])".format(e.id)
-        if len(self.entities) > 5:
-            num_left = len(self.entities) - 5
-            repr_out += u"\n    ...And {} more".format(num_left)
+                repr_out += u"\n    {} [Rows: None, Columns: None]".format(
+                    e.id)
         repr_out += "\n  Relationships:"
 
         if len(self.relationships) == 0:
             repr_out += "\n    No relationships"
 
-        for r in self.relationships[:5]:
+        for r in self.relationships:
             repr_out += u"\n    %s.%s -> %s.%s" % \
                 (r._child_entity_id, r._child_variable_id,
                  r._parent_entity_id, r._parent_variable_id)
-
-        if len(self.relationships) > 5:
-            num_left = len(self.relationships) - 5
-            repr_out += u"\n    ...and {} more".format(num_left)
 
         return repr_out
 
@@ -181,7 +176,8 @@ class BaseEntitySet(FTBase):
                 relationship to be added.
         """
         if relationship in self.relationships:
-            logger.warning("Not adding duplicate relationship: %s", relationship)
+            logger.warning(
+                "Not adding duplicate relationship: %s", relationship)
             return self
 
         # _operations?
@@ -286,7 +282,8 @@ class BaseEntitySet(FTBase):
             return []
 
         for r in self.get_forward_relationships(start_entity_id):
-            new_path = self.find_forward_path(r.parent_entity.id, goal_entity_id)
+            new_path = self.find_forward_path(
+                r.parent_entity.id, goal_entity_id)
             if new_path is not None:
                 return [r] + new_path
 


### PR DESCRIPTION
Previously the output from an `EntitySet` was the first five entities. Now it shows all entities, all relationships and all columns in an entity. I've also changed the shape output to say `(Rows: {}, Columns: {})`.

Example images below.
![image](https://user-images.githubusercontent.com/27442755/38146459-0bfe3086-341c-11e8-94b6-fabcb8f78d74.png)

![image](https://user-images.githubusercontent.com/27442755/38146346-999aba46-341b-11e8-8108-90e2a4c452d2.png)
