### PR TITLE
Improved handling of integer time index

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -313,6 +313,7 @@ Variable types
     Id
     TimeIndex
     DatetimeTimeIndex
+    NumericTimeIndex
     Datetime
     Numeric
     Categorical

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -26,7 +26,8 @@ from featuretools.utils.wrangle import _check_timedelta
 
 logger = logging.getLogger('featuretools.computational_backend')
 
-_numeric_types = (int, np.int32, np.int64)
+_numeric_types = (int, np.int16, np.int32, np.int64,
+                  float, np.float16, np.float32, np.float64)
 
 
 def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
@@ -145,6 +146,9 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
             not_instance_id = [c for c in cutoff_time.columns if c != "instance_id"]
             cutoff_time.rename(columns={not_instance_id[0]: "time"}, inplace=True)
         pass_columns = [column_name for column_name in cutoff_time.columns[2:]]
+
+    if not isinstance(cutoff_time['time'].iloc[0],  (datetime,) + _numeric_types):
+        raise ValueError("cutoff_time time values must be datetime or numeric")
 
     backend = PandasBackend(entityset, features)
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -147,7 +147,7 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
             cutoff_time.rename(columns={not_instance_id[0]: "time"}, inplace=True)
         pass_columns = [column_name for column_name in cutoff_time.columns[2:]]
 
-    if not isinstance(cutoff_time['time'].iloc[0],  (datetime,) + _numeric_types):
+    if not isinstance(cutoff_time['time'].iloc[0], (datetime,) + _numeric_types):
         raise ValueError("cutoff_time time values must be datetime or numeric")
 
     backend = PandasBackend(entityset, features)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -305,7 +305,7 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
             else:
                 # all rows have same cutoff time. set time and add passed columns
                 num_rows = _feature_matrix.shape[0]
-                time_index = pd.DatetimeIndex([time_last] * num_rows, name='time')
+                time_index = pd.Index([time_last] * num_rows, name='time')
                 _feature_matrix.set_index(time_index, append=True, inplace=True)
                 if len(pass_columns) > 0:
                     pass_through = group[['instance_id', cutoff_df_time_var] + pass_columns]

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -250,6 +250,12 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
                     no_unapproximated_aggs, cutoff_df_time_var, target_time,
                     pass_columns):
     feature_matrix = []
+    if no_unapproximated_aggs and approximate is not None:
+        if isinstance(chunk[target_time].iloc[0], _numeric_types):
+            chunk_time = np.inf
+        else:
+            chunk_time = datetime.now()
+
     for _, group in chunk.groupby(cutoff_df_time_var):
         # if approximating, calculate the approximate features
         if approximate is not None:
@@ -277,10 +283,7 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
 
         # if all aggregations have been approximated, can calculate all together
         if no_unapproximated_aggs and approximate is not None:
-            if isinstance(group[target_time].iloc[0], _numeric_types):
-                grouped = [[np.inf, group]]
-            else:
-                grouped = [[datetime.now(), group]]
+            grouped = [[chunk_time, group]]
         else:
             # if approximated features, set cutoff_time to unbinned time
             if precalculated_features is not None:

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -109,12 +109,10 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
 
     if not isinstance(cutoff_time, pd.DataFrame):
         if cutoff_time is None:
-            cutoff_time = datetime.now()
-            # if integer time index, use max value as cutoff time instead
-            if target_entity.time_index:
-                target_time_index = target_entity.df[target_entity.time_index]
-                if _check_time_type(target_time_index.iloc[0]) == "numeric":
-                    cutoff_time = np.inf
+            if entityset.time_type == "numeric":
+                cutoff_time = np.inf
+            else:
+                cutoff_time = datetime.now()
 
         if instance_ids is None:
             index_var = target_entity.index
@@ -248,7 +246,7 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
                     pass_columns):
     feature_matrix = []
     if no_unapproximated_aggs and approximate is not None:
-        if _check_time_type(chunk[target_time].iloc[0]) == "numeric":
+        if entityset.time_type == "numeric":
             chunk_time = np.inf
         else:
             chunk_time = datetime.now()

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -117,7 +117,7 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
             if target_entity.time_index:
                 target_time_index = target_entity.df[target_entity.time_index]
                 if isinstance(target_time_index.iloc[0], _numeric_types):
-                    cutoff_time = target_time_index.max()
+                    cutoff_time = np.inf
 
         if instance_ids is None:
             index_var = target_entity.index
@@ -278,7 +278,7 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
         # if all aggregations have been approximated, can calculate all together
         if no_unapproximated_aggs and approximate is not None:
             if isinstance(group[target_time].iloc[0], _numeric_types):
-                grouped = [[group[target_time].max(), group]]
+                grouped = [[np.inf, group]]
             else:
                 grouped = [[datetime.now(), group]]
         else:

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -23,6 +23,7 @@ from featuretools.primitives import (
 )
 from featuretools.utils.gen_utils import make_tqdm_iterator
 from featuretools.utils.wrangle import _check_time_type, _check_timedelta
+from featuretools.variable_types import NumericTimeIndex
 
 logger = logging.getLogger('featuretools.computational_backend')
 
@@ -109,7 +110,7 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
 
     if not isinstance(cutoff_time, pd.DataFrame):
         if cutoff_time is None:
-            if entityset.time_type == "numeric":
+            if entityset.time_type == NumericTimeIndex:
                 cutoff_time = np.inf
             else:
                 cutoff_time = datetime.now()
@@ -142,7 +143,7 @@ def calculate_feature_matrix(features, cutoff_time=None, instance_ids=None,
             cutoff_time.rename(columns={not_instance_id[0]: "time"}, inplace=True)
         pass_columns = [column_name for column_name in cutoff_time.columns[2:]]
 
-    if _check_time_type(cutoff_time['time'].iloc[0]) == "unknown":
+    if _check_time_type(cutoff_time['time'].iloc[0]) is None:
         raise ValueError("cutoff_time time values must be datetime or numeric")
 
     backend = PandasBackend(entityset, features)
@@ -246,7 +247,7 @@ def calculate_chunk(features, chunk, approximate, entityset, training_window,
                     pass_columns):
     feature_matrix = []
     if no_unapproximated_aggs and approximate is not None:
-        if entityset.time_type == "numeric":
+        if entityset.time_type == NumericTimeIndex:
             chunk_time = np.inf
         else:
             chunk_time = datetime.now()

--- a/featuretools/entityset/base_entityset.py
+++ b/featuretools/entityset/base_entityset.py
@@ -52,6 +52,7 @@ class BaseEntitySet(FTBase):
         self.entity_stores = {}
         self.relationships = []
         self._verbose = verbose
+        self.time_type = None
 
     def __eq__(self, other, deep=False):
         if not deep:

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -13,7 +13,7 @@ from .base_entity import BaseEntity
 from .timedelta import Timedelta
 
 from featuretools import variable_types as vtypes
-from featuretools.utils.wrangle import _check_timedelta
+from featuretools.utils.wrangle import _check_time_type, _check_timedelta
 
 logger = logging.getLogger('featuretools.entityset')
 
@@ -516,6 +516,19 @@ class Entity(BaseEntity):
 
     def set_time_index(self, variable_id, already_sorted=False):
         if variable_id is not None:
+            # check time type
+            time_type = _check_time_type(self.df[variable_id].iloc[0])
+            if time_type == "unknown":
+                raise TypeError("%s time index not recognized as numeric or"
+                                " datetime" % (self.id))
+
+            if self.entityset.time_type is None:
+                self.entityset.time_type = time_type
+            elif self.entityset.time_type != time_type:
+                raise TypeError("%s time index is %s type which differs from"
+                                " other entityset time indexes" %
+                                (self.id, time_type))
+
             # use stable sort
             if not already_sorted:
                 # sort by time variable, then by index

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -518,7 +518,7 @@ class Entity(BaseEntity):
         if variable_id is not None:
             # check time type
             time_type = _check_time_type(self.df[variable_id].iloc[0])
-            if time_type == "unknown":
+            if time_type is None:
                 raise TypeError("%s time index not recognized as numeric or"
                                 " datetime" % (self.id))
 
@@ -568,7 +568,7 @@ class Entity(BaseEntity):
         if secondary_time_index is not None:
             for time_index in secondary_time_index:
                 time_type = _check_time_type(self.df[time_index].iloc[0])
-                if time_type == "unknown":
+                if time_type is None:
                     raise TypeError("%s time index not recognized as numeric or"
                                     " datetime" % (self.id))
                 if self.entityset.time_type != time_type:

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -564,6 +564,23 @@ class Entity(BaseEntity):
 
         super(Entity, self).set_index(variable_id)
 
+    def set_secondary_time_index(self, secondary_time_index):
+        if secondary_time_index is not None:
+            for time_index in secondary_time_index:
+                time_type = _check_time_type(self.df[time_index].iloc[0])
+                if time_type == "unknown":
+                    raise TypeError("%s time index not recognized as numeric or"
+                                    " datetime" % (self.id))
+
+                if self.entityset.time_type is None:
+                    self.entityset.time_type = time_type
+                elif self.entityset.time_type != time_type:
+                    raise TypeError("%s time index is %s type which differs from"
+                                    " other entityset time indexes" %
+                                    (self.id, time_type))
+
+        super(Entity, self).set_secondary_time_index(secondary_time_index)
+
     def set_last_time_index(self, last_time_index):
         self.last_time_index = last_time_index
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -591,25 +591,19 @@ class Entity(BaseEntity):
         """
         if self.time_index:
             if time_last is not None and not df.empty:
-                # TODO: make sure this try/except is a good idea
-                try:
-                    df.iloc[0][self.time_index] <= time_last
-                except TypeError:
-                    pass
-                else:
-                    df = df[df[self.time_index] <= time_last]
-                    if training_window is not None:
-                        mask = df[self.time_index] >= time_last - training_window
-                        if self.last_time_index is not None:
-                            lti_slice = self.last_time_index.reindex(df.index)
-                            lti_mask = lti_slice >= time_last - training_window
-                            mask = mask | lti_mask
-                        else:
-                            logger.warning(
-                                "Using training_window but last_time_index is "
-                                "not set on entity %s" % (self.id)
-                            )
-                        df = df[mask]
+                df = df[df[self.time_index] <= time_last]
+                if training_window is not None:
+                    mask = df[self.time_index] >= time_last - training_window
+                    if self.last_time_index is not None:
+                        lti_slice = self.last_time_index.reindex(df.index)
+                        lti_mask = lti_slice >= time_last - training_window
+                        mask = mask | lti_mask
+                    else:
+                        logger.warning(
+                            "Using training_window but last_time_index is "
+                            "not set on entity %s" % (self.id)
+                        )
+                    df = df[mask]
 
         for secondary_time_index in self.secondary_time_index:
                 # should we use ignore time last here?

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -571,10 +571,7 @@ class Entity(BaseEntity):
                 if time_type == "unknown":
                     raise TypeError("%s time index not recognized as numeric or"
                                     " datetime" % (self.id))
-
-                if self.entityset.time_type is None:
-                    self.entityset.time_type = time_type
-                elif self.entityset.time_type != time_type:
+                if self.entityset.time_type != time_type:
                     raise TypeError("%s time index is %s type which differs from"
                                     " other entityset time indexes" %
                                     (self.id, time_type))

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -662,6 +662,12 @@ class EntitySet(BaseEntitySet):
         #         transfer_types[v_id] = variable_types[v_id]
 
         transfer_types[index] = vtypes.Categorical
+        if make_secondary_time_index:
+            old_ti_name = list(make_secondary_time_index.keys())[0]
+            ti_cols = list(make_secondary_time_index.values())[0]
+            ti_cols = [c if c != old_ti_name else secondary_time_index for c in ti_cols]
+            make_secondary_time_index = {secondary_time_index: ti_cols}
+
         self._import_from_dataframe(new_entity_id, new_entity_df,
                                     index,
                                     time_index=new_entity_time_index,
@@ -675,15 +681,7 @@ class EntitySet(BaseEntitySet):
         self.delete_entity_variables(base_entity_id, additional_variables)
 
         new_entity = self.entity_stores[new_entity_id]
-        if make_secondary_time_index:
-            old_ti_name = list(make_secondary_time_index.keys())[0]
-            ti_cols = list(make_secondary_time_index.values())[0]
-            ti_cols = [c if c != old_ti_name else secondary_time_index for c in ti_cols]
-            new_dict = {secondary_time_index: ti_cols}
-            new_entity.secondary_time_index = new_dict
-
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
-
         self.add_relationship(Relationship(new_entity[index], base_entity[base_entity_index]))
 
         return self

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -761,7 +761,7 @@ def test_verbose_cutoff_time_chunks(entityset):
 
 
 def test_integer_time_index(int_es):
-    times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 10, 11, 12, 13, 14, 15]
+    times = list(range(8, 18)) + list(range(19, 26))
     labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
     cutoff_df = pd.DataFrame({'time': times, 'instance_id': range(17)})
     property_feature = IdentityFeature(int_es['log']['value']) > 10
@@ -788,7 +788,7 @@ def test_integer_time_index_datetime_cutoffs(int_es):
 
 
 def test_integer_time_index_passes_extra_columns(int_es):
-    times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 10, 11, 12, 15, 14, 13]
+    times = list(range(8, 18)) + list(range(19, 23)) + [25, 24, 23]
     labels = [False] * 3 + [True] * 2 + [False] * 9 + [False] * 2 + [True]
     instances = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16, 15, 14]
     cutoff_df = pd.DataFrame({'time': times,
@@ -805,7 +805,7 @@ def test_integer_time_index_passes_extra_columns(int_es):
 
 
 def test_integer_time_index_mixed_cutoff(int_es):
-    times_dt = [0, 1, 2, 3, 4, 5, datetime(2011, 1, 1), 7, 8, 9, 9, 10, 11, 12, 15, 14, 13]
+    times_dt = list(range(8, 17)) + [datetime(2011, 1, 1), 19, 20, 21, 22, 25, 24, 23]
     labels = [False] * 3 + [True] * 2 + [False] * 9 + [False] * 2 + [True]
     instances = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16, 15, 14]
     cutoff_df = pd.DataFrame({'time': times_dt,
@@ -818,19 +818,21 @@ def test_integer_time_index_mixed_cutoff(int_es):
         calculate_feature_matrix([property_feature],
                                  cutoff_time=cutoff_df)
 
-    times_str = [0, 1, 2, 3, 4, 5, "foobar", 7, 8, 9, 9, 10, 11, 12, 15, 14, 13]
+    times_str = list(range(8, 17)) + ["foobar", 19, 20, 21, 22, 25, 24, 23]
     cutoff_df['time'] = times_str
     with pytest.raises(TypeError):
         calculate_feature_matrix([property_feature],
                                  cutoff_time=cutoff_df)
 
-    times_date_str = [0, 1, 2, 3, 4, 5, '2018-04-02 18:50:45.453216', 7, 8, 9, 9, 10, 11, 12, 15, 14, 13]
+    times_date_str = list(range(8, 17)) + ['2018-04-02', 19, 20, 21, 22, 25, 24, 23]
     cutoff_df['time'] = times_date_str
     with pytest.raises(TypeError):
         calculate_feature_matrix([property_feature],
                                  cutoff_time=cutoff_df)
 
+    [19, 20, 21, 22]
     times_int_str = [0, 1, 2, 3, 4, 5, '6', 7, 8, 9, 9, 10, 11, 12, 15, 14, 13]
+    times_int_str = list(range(8, 17)) + ['17', 19, 20, 21, 22, 25, 24, 23]
     cutoff_df['time'] = times_int_str
     with pytest.raises(TypeError):
         calculate_feature_matrix([property_feature],
@@ -840,7 +842,7 @@ def test_integer_time_index_mixed_cutoff(int_es):
 def test_datetime_index_mixed_cutoff(entityset):
     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
                  [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
-                 [5] +
+                 [17] +
                  [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
                  [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
                  [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
@@ -867,7 +869,7 @@ def test_datetime_index_mixed_cutoff(entityset):
         calculate_feature_matrix([property_feature],
                                  cutoff_time=cutoff_df)
 
-    times[9] = '6'
+    times[9] = '17'
     cutoff_df['time'] = times
     with pytest.raises(ValueError):
         calculate_feature_matrix([property_feature],

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -67,6 +67,10 @@ def test_calc_feature_matrix(entityset):
     with pytest.raises(AssertionError):
         feature_matrix = calculate_feature_matrix([1, 2, 3], instance_ids=range(17),
                                                   cutoff_time=times)
+    with pytest.raises(TypeError):
+        calculate_feature_matrix([property_feature],
+                                 instance_ids=range(17),
+                                 cutoff_time=17)
 
 
 def test_cfm_approximate_correct_ordering():
@@ -770,6 +774,17 @@ def test_integer_time_index(int_es):
     sorted_df = cutoff_df.sort_values(['time', 'instance_id'], kind='mergesort')
     assert (time_level_vals == sorted_df['time'].values).all()
     assert (feature_matrix == labels).values.all()
+
+
+def test_integer_time_index_datetime_cutoffs(int_es):
+    times = [datetime.now()] * 17
+    cutoff_df = pd.DataFrame({'time': times, 'instance_id': range(17)})
+    property_feature = IdentityFeature(int_es['log']['value']) > 10
+
+    with pytest.raises(TypeError):
+        calculate_feature_matrix([property_feature],
+                                 cutoff_time=cutoff_df,
+                                 cutoff_time_in_index=True)
 
 
 def test_integer_time_index_passes_extra_columns(int_es):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -787,3 +787,12 @@ def test_integer_time_index_passes_extra_columns(int_es):
                                   cutoff_time_in_index=True)
 
     assert (fm[property_feature.get_name()] == fm['labels']).all()
+
+
+def test_string_time_values_in_cutoff_time(entityset):
+    times = ['2011-04-09 10:31:27', '2011-04-09 10:30:18']
+    cutoff_time = pd.DataFrame({'time': times, 'instance_id': [0, 0]})
+    agg_feature = Sum(entityset['log']['value'], entityset['customers'])
+
+    with pytest.raises(ValueError):
+        calculate_feature_matrix([agg_feature], cutoff_time=cutoff_time)

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -491,6 +491,10 @@ class TestVariableHandling(object):
                                     "signup_date": [datetime(2002, 5, 1),
                                                     datetime(2006, 3, 20),
                                                     datetime(2011, 11, 11)]})
+        accounts_df_string = pd.DataFrame({"id": [3, 4, 5],
+                                           "signup_date": ["May 1 2002",
+                                                           "March 20 2006",
+                                                           "November 11 2011"]})
         # create empty entityset
         entityset = EntitySet("fraud")
         # assert it's not set
@@ -513,6 +517,12 @@ class TestVariableHandling(object):
         with pytest.raises(TypeError):
             entityset.entity_from_dataframe("accounts",
                                             accounts_df,
+                                            index="id",
+                                            time_index="signup_date")
+        # add non time type as time index
+        with pytest.raises(TypeError):
+            entityset.entity_from_dataframe("accounts",
+                                            accounts_df_string,
                                             index="id",
                                             time_index="signup_date")
 

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -480,7 +480,7 @@ class TestVariableHandling(object):
         relationships = [("cards", "id", "transactions", "card_id")]
         entityset = EntitySet("fraud", entities, relationships)
         # assert time_type is set
-        assert entityset.time_type == "numeric"
+        assert entityset.time_type == variable_types.NumericTimeIndex
 
     def test_sets_time_when_adding_entity(self):
         transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
@@ -505,14 +505,14 @@ class TestVariableHandling(object):
                                         index="id",
                                         time_index="transaction_time")
         # assert time_type is set
-        assert entityset.time_type == "numeric"
+        assert entityset.time_type == variable_types.NumericTimeIndex
         # add another entity
         entityset.normalize_entity("transactions",
                                    "cards",
                                    "card_id",
                                    make_time_index=True)
         # assert time_type unchanged
-        assert entityset.time_type == "numeric"
+        assert entityset.time_type == variable_types.NumericTimeIndex
         # add wrong time type entity
         with pytest.raises(TypeError):
             entityset.entity_from_dataframe("accounts",
@@ -528,12 +528,12 @@ class TestVariableHandling(object):
 
     def test_checks_time_type_setting_secondary_time_index(self, entityset):
         # entityset is timestamp time type
-        assert entityset.time_type == "datetime"
+        assert entityset.time_type == variable_types.DatetimeTimeIndex
         # add secondary index that is timestamp type
         new_2nd_ti = {'upgrade_date': ['upgrade_date', 'favorite_quote'],
                       'cancel_date': ['cancel_date', 'cancel_reason']}
         entityset["customers"].set_secondary_time_index(new_2nd_ti)
-        assert entityset.time_type == "datetime"
+        assert entityset.time_type == variable_types.DatetimeTimeIndex
         # add secondary index that is numeric type
         new_2nd_ti = {'age': ['age', 'loves_ice_cream']}
         with pytest.raises(TypeError):
@@ -565,11 +565,11 @@ class TestVariableHandling(object):
         }
         relationships = [("cards", "id", "transactions", "card_id")]
         card_es = EntitySet("fraud", entities, relationships)
-        assert card_es.time_type == "numeric"
+        assert card_es.time_type == variable_types.NumericTimeIndex
         # add secondary index that is numeric time type
         new_2nd_ti = {'fraud_decision_time': ['fraud_decision_time', 'fraud']}
         card_es['transactions'].set_secondary_time_index(new_2nd_ti)
-        assert card_es.time_type == "numeric"
+        assert card_es.time_type == variable_types.NumericTimeIndex
         # add secondary index that is timestamp type
         new_2nd_ti = {'transaction_date': ['transaction_date', 'fraud']}
         with pytest.raises(TypeError):

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -530,7 +530,8 @@ class TestVariableHandling(object):
         # entityset is timestamp time type
         assert entityset.time_type == "datetime"
         # add secondary index that is timestamp type
-        new_2nd_ti = {'upgrade_date': ['upgrade_date', 'favorite_quote']}
+        new_2nd_ti = {'upgrade_date': ['upgrade_date', 'favorite_quote'],
+                      'cancel_date': ['cancel_date', 'cancel_reason']}
         entityset["customers"].set_secondary_time_index(new_2nd_ti)
         assert entityset.time_type == "datetime"
         # add secondary index that is numeric type

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -492,9 +492,9 @@ class TestVariableHandling(object):
                                                     datetime(2006, 3, 20),
                                                     datetime(2011, 11, 11)]})
         accounts_df_string = pd.DataFrame({"id": [3, 4, 5],
-                                           "signup_date": ["May 1 2002",
-                                                           "March 20 2006",
-                                                           "November 11 2011"]})
+                                           "signup_date": ["element",
+                                                           "exporting",
+                                                           "editable"]})
         # create empty entityset
         entityset = EntitySet("fraud")
         # assert it's not set

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -466,6 +466,56 @@ class TestVariableHandling(object):
                 for x, y in zip(df[column], df_3[column]):
                     assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))
 
+    def test_set_time_type_on_init(self):
+        # create cards entity
+        cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
+        transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                                        "card_id": [1, 2, 1, 3, 4, 5],
+                                        "transaction_time": [10, 12, 13, 20, 21, 20],
+                                        "fraud": [True, False, False, False, True, True]})
+        entities = {
+            "cards": (cards_df, "id"),
+            "transactions": (transactions_df, "id", "transaction_time")
+        }
+        relationships = [("cards", "id", "transactions", "card_id")]
+        entityset = EntitySet("fraud", entities, relationships)
+        # assert time_type is set
+        assert entityset.time_type == "numeric"
+
+    def test_sets_time_when_adding_entity(self):
+        transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                                        "card_id": [1, 2, 1, 3, 4, 5],
+                                        "transaction_time": [10, 12, 13, 20, 21, 20],
+                                        "fraud": [True, False, False, False, True, True]})
+        accounts_df = pd.DataFrame({"id": [3, 4, 5],
+                                    "signup_date": [datetime(2002, 5, 1),
+                                                    datetime(2006, 3, 20),
+                                                    datetime(2011, 11, 11)]})
+        # create empty entityset
+        entityset = EntitySet("fraud")
+        # assert it's not set
+        assert getattr(entityset, "time_type", None) is None
+        # add entity
+        entityset.entity_from_dataframe("transactions",
+                                        transactions_df,
+                                        index="id",
+                                        time_index="transaction_time")
+        # assert time_type is set
+        assert entityset.time_type == "numeric"
+        # add another entity
+        entityset.normalize_entity("transactions",
+                                   "cards",
+                                   "card_id",
+                                   make_time_index=True)
+        # assert time_type unchanged
+        assert entityset.time_type == "numeric"
+        # add wrong time type entity
+        with pytest.raises(TypeError):
+            entityset.entity_from_dataframe("accounts",
+                                            accounts_df,
+                                            index="id",
+                                            time_index="signup_date")
+
 
 class TestRelatedInstances(object):
     def test_related_instances_backward(self, entityset):

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -555,7 +555,7 @@ class TestVariableHandling(object):
             "transaction_time": [10, 12, 13, 20, 21, 20],
             "fraud_decision_time": [11, 14, 15, 21, 22, 21],
             "transaction_city": ["City A"] * 6,
-            "transaction_date": [datetime(1989, 2, i) for i in range(6)],
+            "transaction_date": [datetime(1989, 2, i) for i in range(1, 7)],
             "fraud": [True, False, False, False, True, True]
         })
         entities = {
@@ -567,21 +567,21 @@ class TestVariableHandling(object):
         assert card_es.time_type == "numeric"
         # add secondary index that is numeric time type
         new_2nd_ti = {'fraud_decision_time': ['fraud_decision_time', 'fraud']}
-        card_es.set_secondary_time_index(new_2nd_ti)
+        card_es['transactions'].set_secondary_time_index(new_2nd_ti)
         assert card_es.time_type == "numeric"
         # add secondary index that is timestamp type
         new_2nd_ti = {'transaction_date': ['transaction_date', 'fraud']}
         with pytest.raises(TypeError):
-            card_es.set_secondary_time_index(new_2nd_ti)
+            card_es['transactions'].set_secondary_time_index(new_2nd_ti)
         # add secondary index that is non-time type
         new_2nd_ti = {'transaction_city': ['transaction_city', 'fraud']}
         with pytest.raises(TypeError):
-            card_es.set_secondary_time_index(new_2nd_ti)
+            card_es['transactions'].set_secondary_time_index(new_2nd_ti)
         # add mixed secondary time indexes
         new_2nd_ti = {'transaction_city': ['transaction_city', 'fraud'],
                       'fraud_decision_time': ['fraud_decision_time', 'fraud']}
         with pytest.raises(TypeError):
-            card_es.set_secondary_time_index(new_2nd_ti)
+            card_es['transactions'].set_secondary_time_index(new_2nd_ti)
 
 
 class TestRelatedInstances(object):

--- a/featuretools/tests/integration_data/customers_int.csv
+++ b/featuretools/tests/integration_data/customers_int.csv
@@ -1,4 +1,4 @@
 age,cancel_date,cancel_reason,cohort,cohort_name,date_of_birth,engagement_level,favorite_quote,id,loves_ice_cream,region_id,signup_date,upgrade_date
-33,2011-06-08,reason_1,0,Early Adopters,1993-03-08,1,The proletariat have nothing to lose but their chains,0,True,United States,2011-04-08,2011-04-10
-25,2011-10-09,reason_2,1,Late Adopters,1926-08-02,3,Capitalism deprives us all of self-determination,1,False,United States,2011-04-09,2011-04-11
-56,2012-01-06,reason_1,0,Early Adopters,1993-04-20,2,All members of the working classes must seize the means of production.,2,True,United States,2011-04-06,2011-04-07
+33,27,reason_1,0,Early Adopters,2,1,The proletariat have nothing to lose but their chains,0,True,United States,6,18
+25,28,reason_2,1,Late Adopters,1,3,Capitalism deprives us all of self-determination,1,False,United States,7,26
+56,29,reason_1,0,Early Adopters,3,2,All members of the working classes must seize the means of production.,2,True,United States,4,5

--- a/featuretools/tests/integration_data/log_int.csv
+++ b/featuretools/tests/integration_data/log_int.csv
@@ -40,9 +40,9 @@ Coca-Cola Zero: ""Has more of a sharply sweet aftertaste I associate with diet s
 Overall comments: ""That was a lot more difficult than I though it would be."" ""Both equally palatable."" A few people said Diet Coke tasted much better ... unbeknownst to them, they were actually referring to Coca-Cola Zero.
 
 IN SUMMARY: It is a real toss up. There is not one artificially-sweetened Coca-Cola beverage that outshines the other. So how do people choose between one or the other? It is either a matter of personal taste, or maybe the marketing campaigns will influence their choice.
-",0,0,"(0, 0)","(0, 0)",0,coke zero,True,0,0.0,0.0,
-I loved it,1,1,"(5, 2)","(2, -5)",0,coke zero,True,0,5.0,2.0,
-I loved it,2,2,"(10, 4)","(4, -10)",1,coke zero,True,0,10.0,4.0,
+",8,0,"(0, 0)","(0, 0)",0,coke zero,True,0,0.0,0.0,
+I loved it,9,1,"(5, 2)","(2, -5)",0,coke zero,True,0,5.0,2.0,
+I loved it,10,2,"(10, 4)","(4, -10)",1,coke zero,True,0,10.0,4.0,
 "
 The full-size pickup truck and the V-8 engine were supposed to be inseparable, like the internet and cat videos. You can’t have one without the other—or so we thought.
 
@@ -63,7 +63,7 @@ For the most part, though, the equipment in this particular Lariat lives up to t
 Middle-Child Syndrome
 
 In the F-150, Ford has a trifecta of engines (the fourth, a naturally aspirated 3.5-liter V-6, is best left to the fleet operators). The 2.7-liter twin-turbo V-6 delivers remarkable performance at an affordable price. The 3.5-liter twin-turbo V-6 is the workhorse, with power, torque, and hauling capability to spare. Compared with those two logical options, the middle-child 5.0-liter V-8 is the right-brain choice. Its strongest selling points may be its silky power delivery and the familiar V-8 rumble. That’s a flimsy argument when it comes to rationalizing a $50,000-plus purchase, though, so perhaps it’s no surprise that today’s boosted six-cylinders are now the engines of choice in the F-150.
-",3,3,"(15, 6)","(6, -15)",1,car,True,0,15.0,6.0,
+",11,3,"(15, 6)","(6, -15)",1,car,True,0,15.0,6.0,
 "
 THE GOOD
 The Tesla Model S 90D's electric drivetrain is substantially more efficient than any internal combustion engine, and gives the car smooth and quick acceleration. All-wheel drive comes courtesy of a smart dual motor system. The new Autopilot feature eases the stress of stop-and-go traffic and long road trips.
@@ -129,7 +129,7 @@ The 2016 Tesla Model S 90D adds features to keep it competitive against the inte
 Lengthy charging times mean longer trips are either out of the question or require more planning than with an internal combustion car. And while the infotainment system responds quickly to touch inputs and offers useful screens, it hasn't changed much in four years. Most notably, Tesla hasn't added any music apps beyond the ones it launched with. Along with new, useful apps, it would be nice to have some themes or other aesthetic changes to the infotainment interface.
 
 The Model S 90D's base price of $88,000 puts it out of reach of the average buyer, and the model I drove was optioned up to around $95,000. Against its Audi, BMW and Mercedes-Benz competition, however, it makes a compelling argument, especially for its uncomplicated nature.
-",4,4,"(20, 8)","(8, -20)",1,car,True,0,20.0,8.0,
+",12,4,"(20, 8)","(8, -20)",1,car,True,0,20.0,8.0,
 "
 Toothpaste can do more harm than good
 
@@ -221,12 +221,12 @@ But now I’m tired of talking about toothpaste.
 Next topic?
 
 I’m bringing pyorrhea back.
-    ",5,5,"(0, 0)","(0, 0)",1,toothpaste,True,1,0.0,0.0,0.0
+    ",13,5,"(0, 0)","(0, 0)",1,toothpaste,True,1,0.0,0.0,0.0
 "
 I’ve been a user of Colgate Total Whitening Toothpaste for many years because I’ve always tried to maintain a healthy smile (I’m a receptionist so I need a white smile). But because I drink coffee at least twice a day (sometimes more!) and a lot of herbal teas, I’ve found that using just this toothpaste alone doesn’t really get my teeth white...
 
 The best way to get white teeth is to really try some professional products specifically for tooth whitening. I’ve tried a few products, like Crest White Strips and found that the strips are really not as good as the trays. Although the Crest White Strips are easy to use, they really DO NOT cover your teeth perfectly like some other professional dental whitening kits. This Product did cover my teeth well however because of their custom heat trays, and whitening my teeth A LOT. I would say if you really want white teeth, use the Colgate Toothpaste and least 2 times a day, along side a professional Gel product like Shine Whitening.
-    ",6,6,"(1, 1)","(1, -1)",1,toothpaste,True,1,1.0,1.0,1.0
+    ",14,6,"(1, 1)","(1, -1)",1,toothpaste,True,1,1.0,1.0,1.0
 "
 The first feature is the price, and it is right.
 
@@ -239,10 +239,10 @@ Whitening is important. This one is supposed ot whiten. After spending money to 
 Avoiding all kinds of oral pathology is a major consideration. This toothpaste claims that it can help fight cavities, gingivitis, plaque, tartar, and bad breath.
 
 I hope this product stays on the market a long time and does not change.
-    ",7,7,"(2, 2)","(2, -2)",0,toothpaste,True,1,2.0,2.0,2.0
+    ",15,7,"(2, 2)","(2, -2)",0,toothpaste,True,1,2.0,2.0,2.0
 "
 These bags looked exactly like I'd hoped, however, the handles broke off of almost every single bag as soon as items were placed in them! I used these as gift bags for out-of-town guests at my wedding, so imagine my embarassment as the handles broke off as I was handing them out. I would not recommend purchaing these bags unless you plan to fill them with nothing but paper! Anything heavier will cause the handles to snap right off.
-",8,8,"(3, 3)","(3, -3)",0,brown bag,True,1,3.0,3.0,3.0
+",16,8,"(3, 3)","(3, -3)",0,brown bag,True,1,3.0,3.0,3.0
 "
 I purchased these in August 2014 from Big Blue Supplies. I have no problem with the seller, these arrived new condition, fine shape.
 
@@ -257,7 +257,7 @@ Even the dollar store bags I normally purchase do not have that stamped on the b
 I do not think I would purchase again for all the reasons stated above.
 
 Another thing for those still wanting to purchase, the ones I received were: 12 3/4 inches high not including handle, 10 1/4 inches wide and a 5 1/4 inch depth.
-",9,9,"(0, 0)","(0, 0)",0,brown bag,True,2,0.0,0.0,0.0
+",17,9,"(0, 0)","(0, 0)",0,brown bag,True,2,0.0,0.0,0.0
 "
 The place: BMO Harris Bradley Center
 The event: Bucks VS Spurs
@@ -285,14 +285,14 @@ Not a word was said, but a diaper was thrown over the stall. I catch it, line my
 
 My son asks me, ""Daddy, why are we leaving early?""
 ""Well son, I need to change my diaper""
-",9,10,"(0, 0)","(0, 0)",0,Haribo sugar-free gummy bears,True,3,0.0,0.0,
-I loved it,10,11,"(5, 2)","(2, -5)",0,coke zero,False,3,5.0,2.0,
-I loved it,11,12,"(0, 0)","(0, 0)",0,coke zero,False,4,0.0,0.0,0.0
-I loved it,12,13,"(7, 3)","(3, -7)",2,coke zero,False,4,7.0,3.0,3.0
-I loved it,13,14,"(14, 6)","(6, -14)",2,coke zero,False,4,14.0,6.0,6.0
+",19,10,"(0, 0)","(0, 0)",0,Haribo sugar-free gummy bears,True,3,0.0,0.0,
+I loved it,20,11,"(5, 2)","(2, -5)",0,coke zero,False,3,5.0,2.0,
+I loved it,21,12,"(0, 0)","(0, 0)",0,coke zero,False,4,0.0,0.0,0.0
+I loved it,22,13,"(7, 3)","(3, -7)",2,coke zero,False,4,7.0,3.0,3.0
+I loved it,23,14,"(14, 6)","(6, -14)",2,coke zero,False,4,14.0,6.0,6.0
 "
 This timer does what it is supposed to do. Setup is elementary. Replacing the old one (after 12 years) was relatively easy. It has performed flawlessly since. I'm delighted I could find an esoteric product like this at Amazon. Their service, and the customer reviews, are just excellent.
-",14,15,"(nan, nan)","(nan, nan)",1,taco clock,True,5,,,
+",24,15,"(nan, nan)","(nan, nan)",1,taco clock,True,5,,,
 "
 Funny, cute clock. A little spendy for how light the clock is, but its hard to find a taco clock.
-",15,16,"(nan, nan)","(nan, nan)",1,taco clock,False,5,,,
+",25,16,"(nan, nan)","(nan, nan)",1,taco clock,False,5,,,

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -35,6 +35,23 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
                                       'toothpaste', 'brown bag', 'coke zero',
                                       'taco clock'],
                                'rating': [3.5, 4.0, 4.5, 1.5, 5.0, 5.0]})
+    customer_times = {
+        'signup_date': [datetime(2011, 4, 8), datetime(2011, 4, 9),
+                        datetime(2011, 4, 6)],
+        # some point after signup date
+        'upgrade_date': [datetime(2011, 4, 10), datetime(2011, 4, 11),
+                         datetime(2011, 4, 7)],
+        'cancel_date': [datetime(2011, 6, 8), datetime(2011, 10, 9),
+                        datetime(2012, 1, 6)],
+        'date_of_birth': [datetime(1993, 3, 8), datetime(1926, 8, 2),
+                          datetime(1993, 4, 20)]
+    }
+    if with_integer_time_index:
+        customer_times['signup_date'] = range(3)
+        customer_times['upgrade_date'] = range(3)
+        customer_times['cancel_date'] = range(3)
+        customer_times['date_of_birth'] = range(3)
+
     customer_df = pd.DataFrame({
         'id': [0, 1, 2],
         'age': [33, 25, 56],
@@ -46,16 +63,12 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
                            'Capitalism deprives us all of self-determination',
                            'All members of the working classes must seize the '
                            'means of production.'],
-        'signup_date': [datetime(2011, 4, 8), datetime(2011, 4, 9),
-                        datetime(2011, 4, 6)],
+        'signup_date': customer_times['signup_date'],
         # some point after signup date
-        'upgrade_date': [datetime(2011, 4, 10), datetime(2011, 4, 11),
-                         datetime(2011, 4, 7)],
-        'cancel_date': [datetime(2011, 6, 8), datetime(2011, 10, 9),
-                        datetime(2012, 1, 6)],
+        'upgrade_date': customer_times['upgrade_date'],
+        'cancel_date': customer_times['cancel_date'],
         'cancel_reason': ["reason_1", "reason_2", "reason_1"],
-        'date_of_birth': [datetime(1993, 3, 8), datetime(1926, 8, 2),
-                          datetime(1993, 4, 20)],
+        'date_of_birth': customer_times['date_of_birth'],
         'engagement_level': [1, 3, 2]
     })
 
@@ -249,6 +262,7 @@ def make_variable_types(with_integer_time_index=False):
     }
     if with_integer_time_index:
         log_variable_types['datetime'] = variable_types.Numeric
+        customer_variable_types['signup_date'] = variable_types.Numeric
 
     return {
         'customers': customer_variable_types,

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -47,10 +47,10 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
                           datetime(1993, 4, 20)]
     }
     if with_integer_time_index:
-        customer_times['signup_date'] = range(3)
-        customer_times['upgrade_date'] = range(3)
-        customer_times['cancel_date'] = range(3)
-        customer_times['date_of_birth'] = range(3)
+        customer_times['signup_date'] = [6, 7, 4]
+        customer_times['upgrade_date'] = [18, 26, 5]
+        customer_times['cancel_date'] = [27, 28, 29]
+        customer_times['date_of_birth'] = [2, 1, 3]
 
     customer_df = pd.DataFrame({
         'id': [0, 1, 2],
@@ -85,7 +85,7 @@ def make_ecommerce_files(with_integer_time_index=False, base_path=None, file_loc
                  [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
                  [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
     if with_integer_time_index:
-        times = list(range(9)) + [9] + list(range(9, 16))
+        times = list(range(8, 18)) + list(range(19, 26))
 
     values = list([i * 5 for i in range(5)] +
                   [i * 1 for i in range(4)] +
@@ -263,6 +263,9 @@ def make_variable_types(with_integer_time_index=False):
     if with_integer_time_index:
         log_variable_types['datetime'] = variable_types.Numeric
         customer_variable_types['signup_date'] = variable_types.Numeric
+        customer_variable_types['upgrade_date'] = variable_types.Numeric
+        customer_variable_types['cancel_date'] = variable_types.Numeric
+        customer_variable_types['date_of_birth'] = variable_types.Numeric
 
     return {
         'customers': customer_variable_types,

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -213,3 +213,17 @@ def _check_time_against_time(time1, time2):
         return isinstance(time2, (pd.Timedelta))
     else:
         return False
+
+
+def _check_time_type(time):
+    '''
+    Checks if `time` is an instance of common int, float, or datetime types.
+    Returns "numeric", "datetime", or "unknown" based on results
+    '''
+    time_type = "unknown"
+    if isinstance(time, (int, np.int16, np.int32, np.int64, float, np.float16,
+                         np.float32, np.float64)):
+        time_type = "numeric"
+    elif isinstance(time, (datetime, np.datetime64)):
+        time_type = "datetime"
+    return time_type

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -220,10 +220,10 @@ def _check_time_type(time):
     Checks if `time` is an instance of common int, float, or datetime types.
     Returns "numeric", "datetime", or "unknown" based on results
     '''
-    time_type = "unknown"
+    time_type = None
     if isinstance(time, (int, np.int16, np.int32, np.int64, float, np.float16,
                          np.float32, np.float64)):
-        time_type = "numeric"
+        time_type = variable_types.NumericTimeIndex
     elif isinstance(time, (datetime, np.datetime64)):
-        time_type = "datetime"
+        time_type = variable_types.DatetimeTimeIndex
     return time_type

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -291,6 +291,11 @@ class TimeIndex(Variable):
     _dtype_repr = "time_index"
 
 
+class NumericTimeIndex(TimeIndex, Numeric):
+    """Represents time index of entity that is a datetime"""
+    _dtype_repr = "numeric_time_index"
+
+
 class DatetimeTimeIndex(TimeIndex, Datetime):
     """Represents time index of entity that is a datetime"""
     _dtype_repr = "datetime_time_index"

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -292,7 +292,7 @@ class TimeIndex(Variable):
 
 
 class NumericTimeIndex(TimeIndex, Numeric):
-    """Represents time index of entity that is a datetime"""
+    """Represents time index of entity that is numeric"""
     _dtype_repr = "numeric_time_index"
 
 


### PR DESCRIPTION
Addresses #99 and #125.

* Time values in `cutoff_time` that are not numeric or datetime will raise an error
* If target entity has an integer time index, feature matrix will also have integer time index
* Extra columns in `cutoff_time` will now pass through correctly when using integer time index
* Incompatible time index and cutoff time types will raise an error