### PR TITLE
EntitySet repr to use get_name rather than id

### DIFF
--- a/featuretools/entityset/base_entityset.py
+++ b/featuretools/entityset/base_entityset.py
@@ -127,7 +127,7 @@ class BaseEntitySet(FTBase):
         return entityset.get_dataframe(entity_id)
 
     def __repr__(self):
-        fmat = self.id
+        fmat = self.get_name()
         repr_out = u"Entityset: {}\n".format(fmat)
         repr_out += u"  Entities:"
         for e in self.entities:


### PR DESCRIPTION
When showing an entityset name, use the `get_name` method rather than `es.id`. 