### PR TITLE
Update documentation after recent changes / removals

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -190,7 +190,6 @@ Feature methods
 .. autosummary::
     :toctree: generated/
 
-    PrimitiveBase.head
     PrimitiveBase.rename
     PrimitiveBase.get_depth
 
@@ -295,7 +294,6 @@ Entity methods
 .. autosummary::
     :toctree: generated/
 
-    Entity.head
     Entity.show_instance
     Entity.is_child_of
     Entity.is_parent_of

--- a/docs/source/feature_engineering_language/feature-types.rst
+++ b/docs/source/feature_engineering_language/feature-types.rst
@@ -97,7 +97,8 @@ Aggregation features are used to create features for a :term:`parent entity` by 
 
     from featuretools.primitives import Count
     total_events = Count(es["transactions"]["id"], es["customers"])
-    total_events.head()
+    fm = ft.calculate_feature_matrix([total_events], es)
+    fm.head()
 
 .. note::
 
@@ -110,7 +111,8 @@ Often times, we only want to aggregate using a certain amount of previous data. 
     total_events_last_30_days = Count(es["transactions"]["id"],
                                       parent_entity=es["customers"],
                                       use_previous="30 days")
-    total_events_last_30_days.head()
+    fm = ft.calculate_feature_matrix([total_events_last_30_days], es)
+    fm.head()
 
 Unlike with cumulative transform features, the ``use_previous`` parameter here is evaluated relative to instances of the parent entity, not the child entity. The above feature translates roughly to the following: "For each customer, count the events which occurred in the 30 days preceding the customer's timestamp."
 
@@ -125,7 +127,8 @@ When defining aggregation or cumulative transform features, we can provide a ``w
     afternoon_events = Count(es["transactions"]["id"],
                          parent_entity=es["customers"],
                          where=is_afternoon).rename("afternoon_events")
-    afternoon_events.head()
+    fm = ft.calculate_feature_matrix([afternoon_events], es)
+    fm.head()
 
 The where argument can be any previously-defined boolean feature. Only instances for which the where feature is True are included in the final calculation.
 
@@ -143,7 +146,8 @@ Say we want to calculate the number of events per customer in the past 30 days. 
     total_events = CumCount(base_feature=es["transactions"]["id"],
                             group_feature=es["transactions"]["session_id"],
                             use_previous="1 hour")
-    total_events.head()
+    fm = ft.calculate_feature_matrix([total_events], es)
+    fm.head()
 
 
 Because they use previous data, cumulative transform features can only be defined on entities that have a time index. Find the list of available cumulative transform features :ref:`here <api_ref.cumulative_features>`.
@@ -162,7 +166,8 @@ For instance, we can aggregate direct features on a child entity from a differen
     from featuretools.primitives import Mode
     brand = Feature(es["products"]["brand"], es["transactions"])
     favorite_brand = Mode(brand, parent_entity=es["customers"])
-    favorite_brand.head()
+    fm = ft.calculate_feature_matrix([favorite_brand], es)
+    fm.head()
 
 
 .. Sliding Window Aggregation Features

--- a/docs/source/guides/deployment.rst
+++ b/docs/source/guides/deployment.rst
@@ -58,7 +58,7 @@ After we load the features back in, we can calculate the feature matrix.
 
 .. ipython:: python
 
-    feature_matrix = ft.calculate_feature_matrix(saved_features)
+    feature_matrix = ft.calculate_feature_matrix(saved_features, es_test)
     feature_matrix
 
 As you can see above, we have the exact same features as before, but calculated on using our test data.

--- a/docs/source/loading_data/using_entitysets.rst
+++ b/docs/source/loading_data/using_entitysets.rst
@@ -131,8 +131,8 @@ If we look at the dataframes, can see what the ``normalize_entity`` did to the a
 
 .. ipython:: python
 
-    es["sessions"].head(5)
-    es["transactions"].head(5)
+    es["sessions"].df.head(5)
+    es["transactions"].df.head(5)
 
 
 To finish preparing this dataset, create a "customers" entity using the same method call.

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -40,7 +40,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
 
                 features = [f1, f2, f3]
                 ids = [0, 1, 2, 3, 4, 5]
-                feature_matrix = ft.calculate_feature_matrix(features,
+                feature_matrix = ft.calculate_feature_matrix(features, es,
                                                              instance_ids=ids)
 
                 fm_encoded, f_encoded = ft.encode_features(feature_matrix,


### PR DESCRIPTION
Some examples in the docs still depended on `Entity.head` and `Primitive.head` and needed to be updated.  Likewise, the change requiring either `entityset` or `entities` and `relationships` to be passed to calculate_feature_matrix meant some documentation required updating.