### PR TITLE
v0.1.21

### DIFF
--- a/docs/source/automated_feature_engineering/primitives.rst
+++ b/docs/source/automated_feature_engineering/primitives.rst
@@ -62,12 +62,8 @@ In the example above, we use two types of primitives.
 
 **Transform primitives:** These primitives take one or more variables from an entity as an input and output a new variable for that entity. They are applied to a single entity. E.g: ``"hour"``, ``"time_since_previous"``, ``"absolute"``.
 
-
-
-
-.. Built in Primitives
-.. *******************
 For a DataFrame that lists and describes each built-in primitive in Featuretools, call ``ft.list_primitives()``.
+
 
 .. ipython:: python
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,20 @@
 
 Changelog
 ---------
+**v0.1.21** May 30, 2018
+    * Support Pandas 0.23.0 (:pr:`153`, :pr:`154`, :pr:`155`, :pr:`159`)
+    * No EntitySet required in loading/saving features (:pr:`141`)
+    * Use s3 demo csv with better column names (:pr:`139`)
+    * more reasonable start parameter (:pr:`149`)
+    * add issue template (:pr:`133`)
+    * Improve tests (:pr:`136`, :pr:`137`, :pr:`144`, :pr:`147`)
+    * Remove unused functions (:pr:`140`, :pr:`143`, :pr:`146`)
+    * Update documentation after recent changes / removals (:pr:`157`)
+    * Rename demo retail csv file (:pr:`148`)
+    * Add names for binary (:pr:`142`)
+    * EntitySet repr to use get_name rather than id (:pr:`134`)
+    * Ensure config dir is writable (:pr:`135`)
+
 **v0.1.20** Apr 13, 2018
     * Primitives as strings in DFS parameters (:pr:`129`)
     * Integer time index bugfixes (:pr:`128`)

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -12,4 +12,4 @@ from .utils.pickle_utils import *
 from .utils.time_utils import *
 import featuretools.demo
 
-__version__ = '0.1.20'
+__version__ = '0.1.21'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class build_ext(_build_ext):
 
 setup(
     name='featuretools',
-    version='0.1.20',
+    version='0.1.21',
     packages=find_packages(),
     package_data={'featuretools': ['config.yaml']},
     description='a framework for automated feature engineering',


### PR DESCRIPTION
**v0.1.21** May 30, 2018
    * Support Pandas 0.23.0 (#153, #154, #155, #159)
    * No EntitySet required in loading/saving features (#141)
    * Use s3 demo csv with better column names (#139)
    * more reasonable start parameter (#149)
    * add issue template (#133)
    * Improve tests (#136, #137, #144, #147)
    * Remove unused functions (#140, #143, #146)
    * Update documentation after recent changes / removals (#157)
    * Rename demo retail csv file (#148)
    * Add names for binary (#142)
    * EntitySet repr to use get_name rather than id (#134)
    * Ensure config dir is writable (#135)