### PR TITLE
Make sure index variable comes first

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -120,6 +120,11 @@ class Entity(object):
         if self.index is not None and self.index not in inferred_variable_types:
             self.add_variable(self.index, vtypes.Index)
 
+        # make sure index is at the beginning
+        index_variable = [v for v in self.variables
+                          if v.id == self.index][0]
+        self.variables = [index_variable] + [v for v in self.variables
+                                             if v.id != self.index]
         self.update_data(df=self.df,
                          already_sorted=already_sorted,
                          recalculate_last_time_indexes=False,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -125,6 +125,7 @@ class Entity(object):
                           if v.id == self.index][0]
         self.variables = [index_variable] + [v for v in self.variables
                                              if v.id != self.index]
+
         self.update_data(df=self.df,
                          already_sorted=already_sorted,
                          recalculate_last_time_indexes=False,
@@ -568,6 +569,9 @@ class Entity(object):
 
     def update_data(self, df=None, data=None, already_sorted=False,
                     reindex=True, recalculate_last_time_indexes=True):
+        # Make sure column ordering matches variable ordering
+        df = df[[v.id for v in self.variables]]
+
         if data is not None:
             self.data = data
         elif df is not None:

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -569,13 +569,16 @@ class Entity(object):
 
     def update_data(self, df=None, data=None, already_sorted=False,
                     reindex=True, recalculate_last_time_indexes=True):
-        # Make sure column ordering matches variable ordering
-        df = df[[v.id for v in self.variables]]
 
         if data is not None:
             self.data = data
         elif df is not None:
             self.df = df
+
+        if data or df is not None:
+            # Make sure column ordering matches variable ordering
+            df = df[[v.id for v in self.variables]]
+
         self.set_index(self.index)
         self.set_time_index(self.time_index, already_sorted=already_sorted)
         self.set_secondary_time_index(self.secondary_time_index)

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -577,7 +577,7 @@ class Entity(object):
 
         if data or df is not None:
             # Make sure column ordering matches variable ordering
-            df = df[[v.id for v in self.variables]]
+            self.df = self.df[[v.id for v in self.variables]]
 
         self.set_index(self.index)
         self.set_time_index(self.time_index, already_sorted=already_sorted)

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -33,11 +33,17 @@ def test_reorders_index():
                              index='id')
     assert es['test'].variables[0].id == 'id'
     assert es['test'].variables[0].id == es['test'].index
+    assert [v.id for v in es['test'].variables] == list(es['test'].df.columns)
 
 
 def test_index_at_beginning(es):
     for e in es.entity_dict.values():
         assert e.index == e.variables[0].id
+
+
+def test_variable_ordering_matches_column_ordering(es):
+    for e in es.entity_dict.values():
+        assert [v.id for v in e.variables] == list(e.df.columns)
 
 
 def test_eq(es):

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -22,6 +22,11 @@ def test_is_index_column(es):
     assert es['cohorts'].index == 'cohort'
 
 
+def test_index_at_beginning(es):
+    for e in es.entity_dict.values():
+        assert e.index == e.variables[0].id
+
+
 def test_eq(es):
 
     es['log'].id = 'customers'

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import pandas as pd
 import pytest
 
 from ..testing_utils import make_ecommerce_entityset
 
+import featuretools as ft
 from featuretools import variable_types
 
 
@@ -20,6 +22,17 @@ def test_enforces_variable_id_is_str(es):
 
 def test_is_index_column(es):
     assert es['cohorts'].index == 'cohort'
+
+
+def test_reorders_index():
+    es = ft.EntitySet('test')
+    df = pd.DataFrame({'id': [1, 2, 3], 'other': [4, 5, 6]})
+    df.columns = ['other', 'id']
+    es.entity_from_dataframe('test',
+                             df,
+                             index='id')
+    assert es['test'].variables[0].id == 'id'
+    assert es['test'].variables[0].id == es['test'].index
 
 
 def test_index_at_beginning(es):


### PR DESCRIPTION
Reorders variable list in `Entity.__init__()` so that the index variable is at the front of the list.