### PR TITLE
Update flight

### DIFF
--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -1,7 +1,6 @@
 import os
 import re
 import boto3
-import botocore
 from botocore.handlers import disable_signing
 from builtins import str
 
@@ -16,8 +15,8 @@ def load_flight(use_cache=True,
                 demo=True,
                 only_return_data=False,
                 nrows=None,
-                month_filter=[1, 2],
-                categorical_filter={'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}):
+                month_filter=None,
+                categorical_filter=None):
     """ Download, clean, and filter flight data from 2017.
         Input:
             month_filter (list[int]): Only use data from these months. Default is [1, 2].
@@ -31,6 +30,11 @@ def load_flight(use_cache=True,
 
 
     """
+    if month_filter is None:
+        month_filter = [1, 2]
+    if categorical_filter is None:
+        categorical_filter = {'origin_city': ['Boston, MA'],
+                              'dest_city': ['Boston, MA']}
     demo_save_path, key = make_flight_pathname(demo=demo)
 
     if not use_cache or not os.path.isfile(demo_save_path):
@@ -176,9 +180,9 @@ def _reconstruct_times(clean_data):
 
 
 def filter_data(clean_data,
-                month_filter=[1, 2],
-                categorical_filter={'origin_city': ['Boston, MA']}):
-    if month_filter != []:
+                month_filter=None,
+                categorical_filter=None):
+    if month_filter is not None:
         tmp = False
         for month in month_filter:
             tmp = tmp | (clean_data['scheduled_dep_time'].apply(lambda x: x.month) == month)

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -13,7 +13,7 @@ def load_flight(use_cache=True,
                 demo=True,
                 only_return_data=False,
                 month_filter=[1, 2],
-                filterer={'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}):
+                categorical_filter={'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}):
     """ Download, clean, and filter flight data from 2017.
         Input:
             month_filter (list[int]): Only use data from these months. Default is [1, 2].
@@ -122,9 +122,6 @@ def clean_data(data):
     clean_data = clean_data.dropna(
         axis='rows', subset=['CRSDepTime', 'CRSArrTime'])
 
-    # Rename columns to underscore
-    # Code via SO https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
-
     clean_data = clean_data.rename(
         columns={col: convert(col) for col in clean_data})
     clean_data = clean_data.rename(columns={'crs_arr_time': 'scheduled_arr_time',
@@ -160,5 +157,7 @@ def filter_data(clean_data,
 
 
 def convert(name):
+    # Rename columns to underscore
+    # Code via SO https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -184,9 +184,7 @@ def filter_data(clean_data,
                 month_filter=None,
                 categorical_filter=None):
     if month_filter is not None:
-        tmp = False
-        for month in month_filter:
-            tmp = tmp | (clean_data['scheduled_dep_time'].apply(lambda x: x.month) == month)
+        tmp = clean_data['scheduled_dep_time'].dt.month.isin(month_filter)
         clean_data = clean_data[tmp]
 
     if categorical_filter is not None:
@@ -209,11 +207,11 @@ def make_flight_pathname(demo=True):
     if demo:
         filename = 'flight_dataset_sample.csv.zip'
         key = 'bots_flight_data_2017/data_2017_jan_feb.csv.zip'
-        rows = 860457.0
+        rows = 860457
     else:
         filename = 'flight_dataset_full.csv.zip'
         key = 'bots_flight_data_2017/data_all_2017.csv.zip'
-        rows = 5162742.0
+        rows = 5162742
     filepath = os.path.join(ft_config['csv_save_location'], filename)
 
     return filepath, key, rows

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -1,15 +1,16 @@
+import math
 import os
 import re
-import boto3
-from tqdm import tqdm
-from botocore.handlers import disable_signing
 from builtins import str
 
+import boto3
 import pandas as pd
-import math
-from featuretools.config import config as ft_config
+from botocore.handlers import disable_signing
+from tqdm import tqdm
+
 import featuretools as ft
 import featuretools.variable_types as vtypes
+from featuretools.config import config as ft_config
 
 
 def load_flight(month_filter=None,

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -26,14 +26,7 @@ def load_flight(use_cache=True,
 
 
     """
-    if demo:
-        filename = 'flight_dataset_sample.csv'
-        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_2017_jan_feb.csv.zip'
-    else:
-        filename = 'flight_dataset_full.csv'
-        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_all_2017.csv.zip'
-
-    demo_save_path = os.path.join(ft_config['csv_save_location'], filename)
+    demo_save_path, csv_s3 = make_flight_pathname(demo=demo)
 
     if not use_cache or not os.path.isfile(demo_save_path):
         print('Downloading data from s3...')
@@ -194,3 +187,14 @@ def convert(name):
     # Code via SO https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+def make_flight_pathname(demo=True):
+    if demo:
+        filename = 'flight_dataset_sample.csv'
+        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_2017_jan_feb.csv.zip'
+    else:
+        filename = 'flight_dataset_full.csv'
+        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_all_2017.csv.zip'
+
+    return os.path.join(ft_config['csv_save_location'], filename), csv_s3

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -12,25 +12,25 @@ import featuretools as ft
 import featuretools.variable_types as vtypes
 
 
-def load_flight(use_cache=True,
+def load_flight(month_filter=None,
+                categorical_filter=None,
+                nrows=None,
+                use_cache=True,
                 demo=True,
                 return_single_table=False,
-                nrows=None,
-                month_filter=None,
-                categorical_filter=None,
                 verbose=False):
     """ Download, clean, and filter flight data from 2017.
         Input:
-            month_filter (list[int]): Only use data from these months. Default is [1, 2].
-            filterer (dict[str->str]): Use only specified categorical values.
-                Default is {'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}
+            month_filter (list[int]): Only use data from these months (example is [1, 2]).
+                To skip, set to None.
+            categorical_filter (dict[str->str]): Use only specified categorical values.
+                Example is {'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}
                 which returns all flights in OR out of Boston. To skip, set to None.
-            nrows (int): Passed to nrows in pd.read_csv.
+            nrows (int): Passed to nrows in pd.read_csv. Used before filtering.
             use_cache (bool): Use previously downloaded csv if possible.
-            demo (bool): Use only two months of data. If false, use whole year.
+            demo (bool): Use only two months of data. If False, use the whole year.
             return_single_table (bool): Exit the function early and return a dataframe.
-
-
+            verbose (bool): Show a progress bar while loading the data.
     """
     demo_save_path, key, csv_length = make_flight_pathname(demo=demo)
 

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -1,68 +1,164 @@
 import os
+import re
 from builtins import str
 
 import pandas as pd
 
-import featuretools as ft
 from featuretools.config import config as ft_config
+import featuretools as ft
+import featuretools.variable_types as vtypes
 
 
-def load_flight(entity_id='flight_dataset', nrows=None, force=False):
-    '''
-    Returns the flight dataset. Publishes the dataset if it has not been
-    published before. This function requires Dask, which is not a requirement
-    of Featuretools.
+def load_flight(use_cache=True,
+                demo=True,
+                only_return_data=False,
+                month_filter=[1, 2],
+                filterer={'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}):
+    """ Download, clean, and filter flight data from 2017.
+        Input:
+            month_filter (list[int]): Only use data from these months. Default is [1, 2].
+            filterer (dict[str->str]): Use only specified categorical values.
+                Default is {'dest_city': ['Boston, MA'], 'origin_city': ['Boston, MA']}
+                which returns all flights in OR out of Boston. To skip, set to None.
+            use_cache (bool): Use previously downloaded csv if possible.
+            demo (bool): Use only two months of data. If false, use whole year.
+            only_return_data (bool): Exit the function early and return a dataframe.
 
-    Args:
-        entity_id (str):  Id of retail dataset on scheduler.
-    '''
-    try:
-        import dask.dataframe as dd
-    except:
-        raise ImportError('Dask is a requirement of load_flight. Please make sure you have the latest version installed.')
 
-    demo_save_path = make_flight_pathname(nrows)
+    """
+    if demo:
+        filename = 'flight_dataset_sample.csv'
+        demo_save_path = os.path.join(ft_config['csv_save_location'], filename)
+        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_2017_jan_feb.csv.zip'
+    else:
+        filename = 'flight_dataset_full.csv'
+        demo_save_path = os.path.join(ft_config['csv_save_location'], filename)
+        csv_s3 = 'https://s3.amazonaws.com/featuretools-static/bots_flight_data_2017/data_all_2017.csv.zip'
 
-    es = ft.EntitySet(entity_id)
-    csv_s3 = "s3://featuretools-static/raw_flight_data/raw_csv_data/data_*.csv"
-
-    if not os.path.isfile(demo_save_path) or force:
-        df = dd.read_csv(csv_s3,
-                         parse_dates=["FL_DATE"],
-                         blocksize=None,
-                         low_memory=False,
-                         storage_options={'anon': True})
-        if nrows:
-            df = df.head(n=nrows, npartitions=-1, compute=False)
-        df = df.compute()
+    if not use_cache or not os.path.isfile(demo_save_path):
+        print('Downloading data from s3...')
+        df = pd.read_csv(csv_s3)
         df.to_csv(demo_save_path, index=False)
 
-    df = pd.read_csv(demo_save_path,
-                     nrows=nrows,
-                     parse_dates=["FL_DATE"])
+    pd.options.display.max_columns = 200
+    iter_csv = pd.read_csv(demo_save_path,
+                           iterator=True,
+                           chunksize=1000)
+    print('Cleaning and Filtering data...')
+    data = pd.concat([filter_data(clean_data(chunk),
+                                  month_filter=month_filter,
+                                  categorical_filter=filterer) for chunk in iter_csv])
+    if only_return_data:
+        return data
 
-    df.drop("Unnamed: 27", axis=1, inplace=True)
-    df = df.reset_index(drop=True)
-    df['trip_id'] = df.index.values
+    es = make_es(data)
 
-    es.entity_from_dataframe("trips",
-                             index='trip_id',
-                             dataframe=df,
-                             time_index='FL_DATE')
-
-    es.combine_variables("trips", "flight_id", [
-                         "UNIQUE_CARRIER", "TAIL_NUM", "FL_NUM"])
-
-    es.normalize_entity(base_entity_id="trips",
-                        new_entity_id="flights",
-                        index="flight_id",
-                        additional_variables=["UNIQUE_CARRIER", "TAIL_NUM", "FL_NUM", "ORIGIN_AIRPORT_ID",
-                                              "ORIGIN_CITY_MARKET_ID", "DEST_AIRPORT_ID", "DEST_CITY_MARKET_ID"],
-                        make_time_index=True)
-    es.add_last_time_indexes()
     return es
 
 
-def make_flight_pathname(nrows):
-    file_name = 'raw_flight_data_' + str(nrows) + '.csv'
-    return os.path.join(ft_config['csv_save_location'], file_name)
+def make_es(data):
+    print('Making EntitySet...')
+    es = ft.EntitySet('Flight Data')
+
+    variable_types = {'flight_num': vtypes.Categorical,
+                      'distance_group': vtypes.Ordinal,
+                      'cancelled': vtypes.Boolean,
+                      'diverted': vtypes.Boolean}
+    labely_columns = ['ArrDelay', 'DepDelay', 'CarrierDelay', 'WeatherDelay',
+                      'NASDelay', 'SecurityDelay', 'LateAircraftDelay', 'Cancelled', 'Diverted',
+                      'TaxiIn', 'TaxiOut', 'AirTime']
+
+    es.entity_from_dataframe('trip_logs',
+                             data,
+                             index='trip_log_id',
+                             make_index=True,
+                             time_index='time_index',
+                             secondary_time_index={'arr_time': labely_columns},
+                             variable_types=variable_types)
+
+    es.normalize_entity('trip_logs', 'flights', 'flight_id',
+                        additional_variables=['origin', 'origin_city', 'origin_state',
+                                              'dest', 'dest_city', 'dest_state',
+                                              'distance_group', 'carrier', 'flight_num'])
+    es.normalize_entity('flights', 'airlines', 'carrier',
+                        make_time_index=False)
+
+    es.normalize_entity('flights', 'airports', 'dest',
+                        additional_variables=['dest_city', 'dest_state'],
+                        make_time_index=False)
+    return es
+
+
+def clean_data(data):
+    # Split columns by when we can know them
+    main_info = ['FlightDate', 'Carrier', 'FlightNum', 'Origin',
+                 'OriginCityName', 'OriginState', 'Dest', 'DestCityName',
+                 'DestState', 'Distance', 'DistanceGroup', 'CRSDepTime', 'CRSElapsedTime']
+
+    labely_columns = ['ArrDelay', 'DepDelay', 'CarrierDelay', 'WeatherDelay',
+                      'NASDelay', 'SecurityDelay', 'LateAircraftDelay', 'Cancelled', 'Diverted',
+                      'TaxiIn', 'TaxiOut', 'AirTime']
+
+    # Fix times
+    clean_data = data[main_info + labely_columns]
+
+    clean_data['CRSDepTime'] = data['CRSDepTime'].apply(lambda x: str(x)) + data['FlightDate'].astype(str)
+
+    clean_data.loc[:, 'CRSDepTime'] = pd.to_datetime(
+        clean_data['CRSDepTime'], format='%H%M%Y-%m-%d', errors='coerce')
+
+    clean_data.loc[:, 'DepTime'] = clean_data['CRSDepTime'] + \
+        pd.to_timedelta(clean_data['DepDelay'], unit='m')
+    clean_data.loc[:, 'ArrTime'] = clean_data['DepTime'] + pd.to_timedelta(
+        clean_data['TaxiOut'] + clean_data['AirTime'] + clean_data['TaxiIn'], unit='m')
+    clean_data.loc[:, 'CRSArrTime'] = clean_data['CRSDepTime'] + \
+        pd.to_timedelta(clean_data['CRSElapsedTime'], unit='m')
+    clean_data.loc[:, 'time_index'] = clean_data['DepTime'] - \
+        pd.Timedelta('120d')
+    # Fix labels: a null entry for a delay means no delay
+    for col in labely_columns:
+        clean_data.loc[:, col] = clean_data[col].fillna(0)
+
+    clean_data = clean_data.dropna(
+        axis='rows', subset=['CRSDepTime', 'CRSArrTime'])
+
+    # Rename columns to underscore
+    # Code via SO https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+
+    clean_data = clean_data.rename(
+        columns={col: convert(col) for col in clean_data})
+    clean_data = clean_data.rename(columns={'crs_arr_time': 'scheduled_arr_time',
+                                            'crs_dep_time': 'scheduled_dep_time',
+                                            'crs_elapsed_time': 'scheduled_elapsed_time',
+                                            'nas_delay': 'national_airspace_delay',
+                                            'origin_city_name': 'origin_city',
+                                            'dest_city_name': 'dest_city'})
+    clean_data.loc[:, 'flight_id'] = clean_data['carrier'] + '-' + \
+        clean_data['flight_num'].apply(lambda x: str(x)) + ':' + clean_data['origin'] + '->' + clean_data['dest']
+
+    return clean_data
+
+
+def filter_data(clean_data,
+                month_filter=[1, 2],
+                categorical_filter={'origin_city': ['Boston, MA']}):
+    if month_filter != []:
+        tmp = clean_data['origin']
+        tmp = False
+        for month in month_filter:
+            tmp = tmp | (clean_data['scheduled_dep_time'].apply(lambda x: x.month) == month)
+        clean_data = clean_data[tmp]
+
+    if categorical_filter is not None:
+        tmp = clean_data['origin']
+        tmp = False
+        for key, values in categorical_filter.items():
+            tmp = tmp | clean_data[key].isin(values)
+        clean_data = clean_data[tmp]
+
+    return clean_data
+
+
+def convert(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -1,7 +1,8 @@
 import os
 
-from featuretools.demo import load_mock_customer, load_retail
+from featuretools.demo import load_mock_customer, load_retail, load_flight
 from featuretools.demo.retail import make_retail_pathname
+from featuretools.demo.flight import make_flight_pathname
 from featuretools.synthesis import dfs
 
 
@@ -32,3 +33,12 @@ def test_mock_customer():
     fm, fl = dfs(entityset=es, target_entity="customers", max_depth=3)
     for feature in fl:
         assert feature.get_name() in fm.columns
+
+
+def test_load_flight():
+    demo_path, _ = make_flight_pathname(demo=True)
+    load_flight(month_filter=[1],
+                categorical_filter={'dest': ['Syracuse, NY']},
+                only_return_data=False)
+    assert os.path.isfile(demo_path)
+    os.remove(demo_path)

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -1,8 +1,8 @@
 import os
 
-from featuretools.demo import load_mock_customer, load_retail, load_flight
-from featuretools.demo.retail import make_retail_pathname
+from featuretools.demo import load_flight, load_mock_customer, load_retail
 from featuretools.demo.flight import make_flight_pathname
+from featuretools.demo.retail import make_retail_pathname
 from featuretools.synthesis import dfs
 
 
@@ -36,10 +36,10 @@ def test_mock_customer():
 
 
 def test_load_flight():
-    demo_path, _ = make_flight_pathname(demo=True)
+    demo_path, _, _ = make_flight_pathname(demo=True)
     es = load_flight(month_filter=[1],
                      categorical_filter={'origin_city': ['Charlotte, NC']},
-                     only_return_data=False, nrows=1000)
+                     return_single_table=False, nrows=1000)
 
     assert os.path.isfile(demo_path)
     entity_names = ['airports', 'flights', 'trip_logs', 'airlines']

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -37,8 +37,12 @@ def test_mock_customer():
 
 def test_load_flight():
     demo_path, _ = make_flight_pathname(demo=True)
-    load_flight(month_filter=[1],
-                categorical_filter={'dest': ['Syracuse, NY']},
-                only_return_data=False)
+    es = load_flight(month_filter=[1],
+                     categorical_filter={'origin_city': ['Charlotte, NC']},
+                     only_return_data=False, nrows=1000)
+
     assert os.path.isfile(demo_path)
-    os.remove(demo_path)
+    entity_names = ['airports', 'flights', 'trip_logs', 'airlines']
+    realvals = [(11, 3), (13, 9), (103, 22), (1, 1)]
+    for i, name in enumerate(entity_names):
+        assert es[name].shape == realvals[i]


### PR DESCRIPTION
Rework the `load_flight` data to use newly uploaded csvs from 2017. New functionality:
1. Can take in a `month_filter` to restrict which months are used (e.g. [3, 5] to use March and May)
2. Can take in a `categorical_filter` to restrict which categorical values are loaded. As an example  `{'dest_city': ['Boston, MA'], 'origin_city': ['Washington, DC']}` will take all flights into Boston and all flights out of Washington DC). 
3. An optional `verbose` argument which gives a progress bar while loading the data.