### PR TITLE
Check type of `ignore_entities` in dfs

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -120,6 +120,10 @@ class DeepFeatureSynthesis(object):
         if ignore_entities is None:
             self.ignore_entities = set()
         else:
+
+            if not isinstance(ignore_entities, list):
+                raise TypeError('ignore_entities must be a list')
+
             assert target_entity_id not in ignore_entities,\
                 "Can't ignore target_entity!"
             self.ignore_entities = set(ignore_entities)

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -114,6 +114,13 @@ def test_only_makes_supplied_agg_feat(es):
 
 
 def test_ignores_entities(es):
+    with pytest.raises(TypeError):
+        dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
+                                       entityset=es,
+                                       agg_primitives=[Last],
+                                       trans_primitives=[],
+                                       ignore_entities='log')
+
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                    entityset=es,
                                    agg_primitives=[Last],


### PR DESCRIPTION
Addresses #190 by checking the type of `ignore_entities` (using `isinstance`) when running `dfs`. Passing in any type other than a list will result in a `TypeError`. 