### PR TITLE
Improve memory usage through support for pandas categorical types

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -169,6 +169,12 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     backend = PandasBackend(entityset, features)
 
+    # make sure dtype of instance_id in cutoff time
+    # is same as column it references
+    target_entity = features[0].entity
+    dtype = entityset[target_entity.id].df[target_entity.index].dtype
+    cutoff_time["instance_id"] = cutoff_time["instance_id"].astype(dtype)
+
     # Get dictionary of features to approximate
     if approximate is not None:
         to_approximate, all_approx_feature_set = gather_approximate_features(features, backend)

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -413,7 +413,7 @@ class PandasBackend(ComputationalBackend):
                 def last_n(df):
                     return df.iloc[-n:]
 
-                base_frame = base_frame.groupby(groupby_var).apply(last_n)
+                base_frame = base_frame.groupby(groupby_var, observed=True, sort=False).apply(last_n)
 
         if not base_frame.empty:
             if groupby_var not in base_frame:
@@ -484,7 +484,7 @@ class PandasBackend(ComputationalBackend):
             # to silence pandas warning about ambiguity we explicitly pass
             # the column (in actuality grouping by both index and group would
             # work)
-            to_merge = base_frame.groupby(base_frame[groupby_var]).apply(wrap)
+            to_merge = base_frame.groupby(base_frame[groupby_var], observed=True, sort=False).apply(wrap)
 
             to_merge.reset_index(1, drop=True, inplace=True)
             frame = pd.merge(left=frame, right=to_merge,
@@ -500,8 +500,7 @@ class PandasBackend(ComputationalBackend):
             # to silence pandas warning about ambiguity we explicitly pass
             # the column (in actuality grouping by both index and group would
             # work)
-
-            to_merge = base_frame.groupby(base_frame[groupby_var]).agg(to_agg)
+            to_merge = base_frame.groupby(base_frame[groupby_var], observed=True, sort=False).agg(to_agg)
             # we apply multiple functions to each column, creating
             # a multiindex as the column
             # rename the columns to a concatenation of the two indexes
@@ -511,8 +510,7 @@ class PandasBackend(ComputationalBackend):
             to_merge = to_merge.rename(columns=agg_rename)
             variables = list(agg_rename.values())
             to_merge = to_merge[variables]
-            frame = pd.merge(left=frame, right=to_merge,
-                             left_on=frame[index_var], right_index=True, how='left')
+            frame = pd.merge(left=frame, right=to_merge, left_index=True, right_index=True, how='left')
 
         # Handle default values
         # 1. handle non scalar default values

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -824,7 +824,7 @@ class EntitySet(object):
             transfer_types[v] = type(base_entity[v])
 
         # create and add new entity
-        new_entity_df = self[base_entity_id].df
+        new_entity_df = self[base_entity_id].df.copy()
 
         if make_time_index is None and base_entity.time_index is not None:
             make_time_index = True
@@ -1268,31 +1268,14 @@ class EntitySet(object):
         current_relationships = [r for r in self.relationships
                                  if r.parent_entity.id == entity_id or
                                  r.child_entity.id == entity_id]
-        # "category" dtype generates a lot of errors because pandas treats it
-        # differently in merges. In particular, if there are no matching
-        # instances on a dataframe to join, the new joined dataframe turns out
-        # to be empty if the column we're joining on is a category
-        # When its any other dtype, we get the same number of rows as the
-        # original dataframe but filled in with nans
 
-        df = dataframe
-        for c in df.columns:
-            if df[c].dtype.name.find('category') > -1:
-                try:
-                    df[c] = df[c].astype(int)
-                except ValueError:
-                    df[c] = df[c].astype(object)
+        for c in dataframe.columns:
+            if dataframe[c].dtype.name.find('category') > -1:
                 if c not in variable_types:
                     variable_types[c] = vtypes.Categorical
-        if df.index.dtype.name.find('category') > -1:
-            try:
-                df[c] = df[c].astype(int)
-            except ValueError:
-                df[c] = df[c].astype(object)
-            df.index = df.index.astype(object)
 
         entity = Entity(entity_id,
-                        df,
+                        dataframe,
                         self,
                         variable_types=variable_types,
                         index=index,

--- a/featuretools/primitives/cum_transform_feature.py
+++ b/featuretools/primitives/cum_transform_feature.py
@@ -188,7 +188,7 @@ def pd_rolling_outer(rolling_func, f):
                         }
             if rolling_func in ["count", "sum", "max", "min"]:
                 cumfunc = cumfuncs[rolling_func]
-                grouped = df.groupby(groupby, sort=False)[bf_name]
+                grouped = df.groupby(groupby, sort=False, observed=True)[bf_name]
                 applied = getattr(grouped, cumfunc)()
                 # TODO: to produce same functionality as the rolling cases already
                 # implemented, we add 1
@@ -254,7 +254,7 @@ def pd_rolling_outer(rolling_func, f):
         new_index_name = str(uuid.uuid1())
         new_index = pd.RangeIndex(len(df), name=new_index_name)
         df.set_index(new_index, append=True, inplace=True)
-        grouped = df.groupby(groupby).apply(apply_rolling)
+        grouped = df.groupby(groupby, observed=True).apply(apply_rolling)
         original_index = pd.Series(np.nan, index=df.index)
         if isinstance(grouped, pd.DataFrame):
             if grouped.shape[0] == 0 or grouped.empty:

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -285,9 +285,20 @@ def test_training_window_recent_time_index(entityset):
         'date_of_birth': [datetime(1938, 2, 1)],
         'engagement_level': [2],
     }
-    df = pd.DataFrame(row)
-    df.index = range(3, 4)
-    df = entityset['customers'].df.append(df, sort=False)
+    to_add_df = pd.DataFrame(row)
+    to_add_df.index = range(3, 4)
+
+    # have to convert category to int in order to concat
+    old_df = entityset['customers'].df
+    old_df.index = old_df.index.astype("int")
+    old_df["id"] = old_df["id"].astype(int)
+
+    df = pd.concat([old_df, to_add_df])
+
+    # convert back after
+    df.index = df.index.astype("category")
+    df["id"] = df["id"].astype("category")
+
     entityset['customers'].update_data(df=df,
                                        recalculate_last_time_indexes=False)
     entityset.add_last_time_indexes()
@@ -462,7 +473,7 @@ def test_empty_path_approximate_full(entityset):
 
 def test_empty_path_approximate_partial(entityset):
     es = copy.deepcopy(entityset)
-    es['sessions'].df['customer_id'] = [0, 0, np.nan, 1, 1, 2]
+    es['sessions'].df['customer_id'] = pd.Categorical([0, 0, np.nan, 1, 1, 2])
     agg_feat = Count(es['log']['id'], es['sessions'])
     agg_feat2 = Sum(agg_feat, es['customers'])
     dfeat = DirectFeature(agg_feat2, es['sessions'])

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -329,6 +329,8 @@ def make_ecommerce_entityset(with_integer_time_index=False, base_path=None, save
             secondary = time_index['secondary']
 
         df = pd.read_csv(filenames[entity], encoding='utf-8')
+        if entity == "customers":
+            df["id"] = pd.Categorical(df['id'])
         if entity == 'sessions':
             # This should be changed back when converted to an EntitySet
             df['customer_id'] = pd.Categorical(df['customer_id'])


### PR DESCRIPTION
Currently, we convert columns that are pandas categorical types to an object type. This is bad for memory usage.

This pull request changes removes that conversion so that the categorical dtype is preserved while running featuretools. 

Test cases pass, but more integration and performance testing is needed. 