### PR TITLE
Reset index of cutoff times in calculate feature matrix

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -120,6 +120,8 @@ class DeepFeatureSynthesis(object):
         if ignore_entities is None:
             self.ignore_entities = set()
         else:
+            if not isinstance(ignore_entities, list):
+                raise TypeError('ignore_entities must be a list')
             assert target_entity_id not in ignore_entities,\
                 "Can't ignore target_entity!"
             self.ignore_entities = set(ignore_entities)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -852,16 +852,22 @@ def test_create_client_and_cluster(entityset, monkeypatch):
                                                 num_tasks=3,
                                                 dask_kwargs={'cluster': 'tcp://127.0.0.1:54321'})
     assert cluster == 'tcp://127.0.0.1:54321'
+
+    try:
+        cpus = len(psutil.Process().cpu_affinity())
+    except AttributeError:
+        cpus = psutil.cpu_count()
+
     # jobs < tasks case
     client, cluster = create_client_and_cluster(n_jobs=2,
                                                 num_tasks=3,
                                                 dask_kwargs={})
-    assert cluster == (2, 1, None)
+    assert cluster == (min(cpus, 2), 1, None)
     # jobs > tasks case
     client, cluster = create_client_and_cluster(n_jobs=10,
                                                 num_tasks=3,
                                                 dask_kwargs={'diagnostics_port': 8789})
-    assert cluster == (3, 1, 8789)
+    assert cluster == (min(cpus, 3), 1, 8789)
 
 
 def test_parallel_failure_raises_correct_error(entityset):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -166,6 +166,23 @@ def test_cfm_no_cutoff_time_index(entityset):
     assert feature_matrix_2[agg_feat.get_name()].tolist() == [5, 1]
 
 
+def test_cfm_duplicated_index_in_cutoff_time(entityset):
+    times = [pd.datetime(2011, 4, 1), pd.datetime(2011, 5, 1),
+             pd.datetime(2011, 4, 1), pd.datetime(2011, 5, 1)]
+
+    instances = [1, 1, 2, 2]
+    property_feature = IdentityFeature(entityset['log']['value']) > 10
+    cutoff_time = pd.DataFrame({'id': instances, 'time': times},
+                               index=[1, 1, 1, 1])
+
+    feature_matrix = calculate_feature_matrix([property_feature],
+                                              entityset,
+                                              cutoff_time=cutoff_time,
+                                              chunk_size=1)
+
+    assert (feature_matrix.shape[0] == cutoff_time.shape[0])
+
+
 def test_saveprogress(entityset):
     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
                  [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -114,6 +114,13 @@ def test_only_makes_supplied_agg_feat(es):
 
 
 def test_ignores_entities(es):
+    with pytest.raises(TypeError):
+        DeepFeatureSynthesis(target_entity_id='sessions',
+                             entityset=es,
+                             agg_primitives=[Last],
+                             trans_primitives=[],
+                             ignore_entities='log')
+
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                    entityset=es,
                                    agg_primitives=[Last],


### PR DESCRIPTION
Addresses issue where duplicated indices in `cutoff_time` dataframe results in duplicated rows in the feature matrix with `calculate_feature_matrix`. Solution is to reset the index in `cutoff_time` to remove the duplicates. 