### PR TITLE
Modify retail demo (v2)

### DIFF
--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -8,14 +8,23 @@ import featuretools.variable_types as vtypes
 from featuretools.config import config as ft_config
 
 
-def load_retail(id='demo_retail_data', nrows=None, use_cache=True):
+def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, use_cache=True):
     '''
-    Returns the retail entityset example.
+    Returns the retail entityset example which is a modified version of
+    the data found `here <https://archive.ics.uci.edu/ml/datasets/online+retail>`_.
+    In version 2 of our CSV, we have
+
+    1. updated the column names,
+    2. dropped null and duplicate rows and,
+    3. added descriptive columns like a boolean "cancelled" and a numeric "total" which is ``quantity`` times ``unit_price``.
 
     Args:
         id (str):  Id to assign to EntitySet.
-        nrows (int):  Number of rows to load of item_purchases
-            entity. If None, load all.
+        nrows (int):  Number of rows to load of the underlying CSV.
+            If None, load all.
+        return_single_table (bool): If True, return a CSV rather than an EntitySet. Default is False.
+        use_cache (bool): If True, use a stored version of the CSV. Otherwise redownload.
+            Default is True.
 
     Examples:
 
@@ -30,32 +39,32 @@ def load_retail(id='demo_retail_data', nrows=None, use_cache=True):
             Out[3]:
             Entityset: demo_retail_data
               Entities:
-                orders (shape = [25900, 3])
-                products (shape = [4070, 3])
-                customers (shape = [4373, 3])
-                order_products (shape = [541909, 6])
+                orders (shape = [22190, 3])
+                products (shape = [3684, 3])
+                customers (shape = [4372, 2])
+                order_products (shape = [401704, 7])
 
         Load in subset of data
 
         .. ipython::
             :verbatim:
 
-            In [2]: es = ft.demo.load_retail(nrows=1000)
+            In [4]: es = ft.demo.load_retail(nrows=1000)
 
-            In [3]: es
-            Out[3]:
+            In [5]: es
+            Out[5]:
             Entityset: demo_retail_data
               Entities:
-                orders (shape = [66, 3])
-                products (shape = [590, 3])
-                customers (shape = [49, 3])
-                order_products (shape = [1000, 6])
+                orders (shape = [67, 5])
+                products (shape = [606, 3])
+                customers (shape = [50, 2])
+                order_products (shape = [1000, 7])
 
     '''
     demo_save_path = make_retail_pathname(nrows)
 
     es = ft.EntitySet(id)
-    csv_s3 = "https://s3.amazonaws.com/featurelabs-static/online-retail-logs.csv"
+    csv_s3 = "https://s3.amazonaws.com/featuretools-static/online-retail-logs-v2.csv"
 
     if not use_cache or not os.path.isfile(demo_save_path):
 
@@ -68,9 +77,13 @@ def load_retail(id='demo_retail_data', nrows=None, use_cache=True):
                      nrows=nrows,
                      parse_dates=["order_date"])
 
+    if return_single_table:
+        return df
+
     es.entity_from_dataframe("order_products",
                              dataframe=df,
                              index="order_product_id",
+                             time_index="order_date",
                              variable_types={'description': vtypes.Text})
 
     es.normalize_entity(new_entity_id="products",
@@ -81,14 +94,11 @@ def load_retail(id='demo_retail_data', nrows=None, use_cache=True):
     es.normalize_entity(new_entity_id="orders",
                         base_entity_id="order_products",
                         index="order_id",
-                        additional_variables=[
-                            "customer_id", "country", "order_date"],
-                        make_time_index="order_date")
+                        additional_variables=["customer_id", "country", "cancelled"])
 
     es.normalize_entity(new_entity_id="customers",
                         base_entity_id="orders",
-                        index="customer_id",
-                        additional_variables=["country"])
+                        index="customer_id")
     es.add_last_time_indexes()
 
     return es


### PR DESCRIPTION
We change the underlying CSV of the retail demo to include the following:
1. Drop duplicate and null rows
2. Update `price` to `unit_price` and add a `total` column
3. Mark cancelled orders with a boolean column
4. Change the `unit_price` and `total` values to be in dollars

In addition to those changes to the CSV, there were some changes to the `demo.load_retail` function:
1. Add a `return_single_table` optional argument to match the other demos
2. Add a dataset source to the docstring as well as a changelog
3. Move the time index to `order_products` (which is what it represented) and make new time indices for all of the entities.
4. Remove `country` from the customers entity and move it to the `orders` entity.
