### PR TITLE
Handle parquet serialization with last time index

### DIFF
--- a/featuretools/entityset/serialization.py
+++ b/featuretools/entityset/serialization.py
@@ -38,8 +38,7 @@ def read_entityset(path, load_data=True):
 
 
 def load_entity_data(metadata, root):
-    '''Load an entity's data from disk.
-    '''
+    '''Load an entity's data from disk.'''
     if metadata['data_files']['filetype'] == 'pickle':
         data = pd_read_pickle(os.path.join(root, metadata['data_files']['data_filename']))
         df = data['df']
@@ -167,10 +166,10 @@ def _write_parquet_entity_data(root, entity, metadata,
     df.to_parquet(df_filename, engine=engine, compression=compression)
 
     entity_size += os.stat(df_filename).st_size
-    if entity.last_time_index:
+    if entity.last_time_index is not None:
         rel_lti_filename = os.path.join(entity.id, 'lti.parq')
         lti_filename = os.path.join(root, rel_lti_filename)
-        entity.last_time_index.to_parquet(lti_filename,
+        entity.last_time_index.to_frame().to_parquet(lti_filename,
                                           engine=engine,
                                           compression=compression)
         entity_size += os.stat(lti_filename).st_size

--- a/featuretools/entityset/serialization.py
+++ b/featuretools/entityset/serialization.py
@@ -166,14 +166,7 @@ def _write_parquet_entity_data(root, entity, metadata,
     df.to_parquet(df_filename, engine=engine, compression=compression)
 
     entity_size += os.stat(df_filename).st_size
-    if entity.last_time_index is not None:
-        rel_lti_filename = os.path.join(entity.id, 'lti.parq')
-        lti_filename = os.path.join(root, rel_lti_filename)
-        entity.last_time_index.to_frame().to_parquet(lti_filename,
-                                          engine=engine,
-                                          compression=compression)
-        entity_size += os.stat(lti_filename).st_size
-        data_files[u'lti_filename'] = rel_lti_filename
+
     rel_index_path = os.path.join(entity.id, 'indexes')
     index_path = os.path.join(root, rel_index_path)
     os.makedirs(index_path)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -839,7 +839,6 @@ def test_to_parquet(entityset):
         shutil.rmtree(path)
     entityset.to_parquet(path)
     new_es = ft.read_parquet(path)
-    entityset.__eq__(new_es, deep=True)
     assert entityset.__eq__(new_es, deep=True)
     shutil.rmtree(path)
 
@@ -851,7 +850,6 @@ def test_to_parquet_with_lti():
         shutil.rmtree(path)
     entityset.to_parquet(path)
     new_es = ft.read_parquet(path)
-    entityset.__eq__(new_es, deep=True)
     assert entityset.__eq__(new_es, deep=True)
     shutil.rmtree(path)
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -843,6 +843,18 @@ def test_to_parquet(entityset):
     assert entityset.__eq__(new_es, deep=True)
     shutil.rmtree(path)
 
+def test_to_parquet_with_lti():
+    entityset = ft.demo.load_mock_customer(return_entityset=True, random_seed=0)
+    dirname = os.path.dirname(integration_data.__file__)
+    path = os.path.join(dirname, 'test_entityset.p')
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    entityset.to_parquet(path)
+    new_es = ft.read_parquet(path)
+    entityset.__eq__(new_es, deep=True)
+    assert entityset.__eq__(new_es, deep=True)
+    shutil.rmtree(path)
+
 
 def test_sizeof(entityset):
     total_size = 0

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -842,6 +842,7 @@ def test_to_parquet(entityset):
     assert entityset.__eq__(new_es, deep=True)
     shutil.rmtree(path)
 
+
 def test_to_parquet_with_lti():
     entityset = ft.demo.load_mock_customer(return_entityset=True, random_seed=0)
     dirname = os.path.dirname(integration_data.__file__)


### PR DESCRIPTION
Handles cases where we are serializing an entityset with a last time index. Also added test

Fixes #202 