### PR TITLE
Use filenames from S3 for Demos

### DIFF
--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -233,12 +233,12 @@ def convert(name):
 
 def make_flight_pathname(demo=True):
     if demo:
-        filename = 'flight_dataset_sample.csv.zip'
-        key = 'bots_flight_data_2017/data_2017_jan_feb.csv.zip'
+        filename = 'data_2017_jan_feb.csv.zip'
+        key = 'bots_flight_data_2017/' + filename
         rows = 860457
     else:
-        filename = 'flight_dataset_full.csv.zip'
-        key = 'bots_flight_data_2017/data_all_2017.csv.zip'
+        filename = 'data_all_2017.csv.zip'
+        key = 'bots_flight_data_2017/' + filename
         rows = 5162742
     filepath = os.path.join(ft_config['csv_save_location'], filename)
 

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -233,13 +233,17 @@ def convert(name):
 
 def make_flight_pathname(demo=True):
     if demo:
-        filename = 'data_2017_jan_feb.csv.zip'
+        filename = SMALL_FLIGHT_CSV
         key = 'bots_flight_data_2017/' + filename
         rows = 860457
     else:
-        filename = 'data_all_2017.csv.zip'
+        filename = BIG_FLIGHT_CSV
         key = 'bots_flight_data_2017/' + filename
         rows = 5162742
     filepath = os.path.join(ft_config['csv_save_location'], filename)
 
     return filepath, key, rows
+
+
+BIG_FLIGHT_CSV = 'data_2017_jan_feb.csv.zip'
+SMALL_FLIGHT_CSV = 'data_all_2017.csv.zip'

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -57,9 +57,8 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
 
     '''
     es = ft.EntitySet(id)
-    csv_name = "online-retail-logs-2018-08-03"
-    csv_s3 = "https://s3.amazonaws.com/featuretools-static/" + csv_name + ".csv"
-    demo_save_path = make_retail_pathname(nrows, csv_name)
+    csv_s3 = "https://s3.amazonaws.com/featuretools-static/" + RETAIL_CSV + ".csv"
+    demo_save_path = make_retail_pathname(nrows, RETAIL_CSV)
 
     if not use_cache or not os.path.isfile(demo_save_path):
 
@@ -102,3 +101,6 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
 def make_retail_pathname(nrows, csv_name):
     file_name = csv_name + '_' + str(nrows) + '.csv'
     return os.path.join(ft_config['csv_save_location'], file_name)
+
+
+RETAIL_CSV = "online-retail-logs-2018-08-03"

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -56,10 +56,10 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
                 order_products (shape = [1000, 7])
 
     '''
-    demo_save_path = make_retail_pathname(nrows)
-
     es = ft.EntitySet(id)
-    csv_s3 = "https://s3.amazonaws.com/featuretools-static/online-retail-logs-2018-08-03.csv"
+    csv_name = "online-retail-logs-2018-08-03"
+    csv_s3 = "https://s3.amazonaws.com/featuretools-static/" + csv_name + ".csv"
+    demo_save_path = make_retail_pathname(nrows, csv_name)
 
     if not use_cache or not os.path.isfile(demo_save_path):
 
@@ -99,6 +99,6 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
     return es
 
 
-def make_retail_pathname(nrows):
-    file_name = 'online_retail_logs_' + str(nrows) + '.csv'
+def make_retail_pathname(nrows, csv_name):
+    file_name = csv_name + '_' + str(nrows) + '.csv'
     return os.path.join(ft_config['csv_save_location'], file_name)

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -2,18 +2,17 @@ import os
 
 from featuretools.demo import load_flight, load_mock_customer, load_retail
 from featuretools.demo.flight import make_flight_pathname
-from featuretools.demo.retail import make_retail_pathname
+from featuretools.demo.retail import make_retail_pathname, RETAIL_CSV
 from featuretools.synthesis import dfs
 
 
 def test_load_retail_save():
     nrows = 10
-    current_csv_name = "online-retail-logs-2018-08-03"
 
     load_retail(nrows=nrows, return_single_table=True)
-    assert os.path.isfile(make_retail_pathname(nrows, current_csv_name))
-    assert os.path.getsize(make_retail_pathname(nrows, current_csv_name)) < 45580670
-    os.remove(make_retail_pathname(nrows, current_csv_name))
+    assert os.path.isfile(make_retail_pathname(nrows, RETAIL_CSV))
+    assert os.path.getsize(make_retail_pathname(nrows, RETAIL_CSV)) < 45580670
+    os.remove(make_retail_pathname(nrows, RETAIL_CSV))
 
 
 def test_load_retail_diff():
@@ -24,6 +23,9 @@ def test_load_retail_diff():
     nrows_second = 11
     es_second = load_retail(nrows=nrows_second)
     assert es_second['order_products'].df.shape[0] == nrows_second
+
+    os.remove(make_retail_pathname(nrows, RETAIL_CSV))
+    os.remove(make_retail_pathname(nrows_second, RETAIL_CSV))
 
 
 def test_mock_customer():

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -2,7 +2,7 @@ import os
 
 from featuretools.demo import load_flight, load_mock_customer, load_retail
 from featuretools.demo.flight import make_flight_pathname
-from featuretools.demo.retail import make_retail_pathname, RETAIL_CSV
+from featuretools.demo.retail import RETAIL_CSV, make_retail_pathname
 from featuretools.synthesis import dfs
 
 

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -8,24 +8,22 @@ from featuretools.synthesis import dfs
 
 def test_load_retail_save():
     nrows = 10
+    current_csv_name = "online-retail-logs-2018-08-03"
+
     load_retail(nrows=nrows, return_single_table=True)
-    assert os.path.isfile(make_retail_pathname(nrows))
-    assert os.path.getsize(make_retail_pathname(nrows)) < 45580670
-    os.remove(make_retail_pathname(nrows))
+    assert os.path.isfile(make_retail_pathname(nrows, current_csv_name))
+    assert os.path.getsize(make_retail_pathname(nrows, current_csv_name)) < 45580670
+    os.remove(make_retail_pathname(nrows, current_csv_name))
 
 
 def test_load_retail_diff():
     nrows = 10
     es_first = load_retail(nrows=nrows)
-    assert os.path.isfile(make_retail_pathname(nrows))
     assert es_first['order_products'].df.shape[0] == nrows
 
     nrows_second = 11
     es_second = load_retail(nrows=nrows_second)
-    assert os.path.isfile(make_retail_pathname(nrows_second))
     assert es_second['order_products'].df.shape[0] == nrows_second
-    os.remove(make_retail_pathname(nrows))
-    os.remove(make_retail_pathname(nrows_second))
 
 
 def test_mock_customer():


### PR DESCRIPTION
This PR would update our CSV naming convention to use the name of the CSV on S3. I've marked it as WIP because we should consider adding a step to explicitly hunt down old file names from their `csv_save_location` and delete old CSVs. The current branch only downloads a new file with the new name.

Deleting old files might be a reasonable thing to do given the size of the full flight dataset.