### PR TITLE
Parallel memory warnings

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -533,7 +533,8 @@ def parallel_calculate_chunks(chunks, features, approximate, training_window,
     try:
         client, cluster = create_client_and_cluster(n_jobs=n_jobs,
                                                     num_tasks=len(chunks),
-                                                    dask_kwargs=dask_kwargs)
+                                                    dask_kwargs=dask_kwargs,
+                                                    entityset_size=entityset.__sizeof__())
         # scatter the entityset
         # denote future with leading underscore
         start = time.time()

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import warnings
 from collections import defaultdict
@@ -11,6 +12,9 @@ from pandas.tseries.frequencies import to_offset
 
 from featuretools.primitives import AggregationPrimitive, DirectFeature
 from featuretools.utils.wrangle import _check_timedelta
+
+
+logger = logging.getLogger('featuretools.computational_backend')
 
 
 def bin_cutoff_times(cuttoff_time, bin_size):
@@ -197,11 +201,13 @@ def n_jobs_to_workers(n_jobs):
     return workers
 
 
-def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs):
+def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs, entityset_size):
     cluster = None
     if 'cluster' in dask_kwargs:
         cluster = dask_kwargs['cluster']
     else:
+        # diagnostics_port sets the default port to launch bokeh web interface
+        # if it is set to None web interface will not be launched
         diagnostics_port = None
         if 'diagnostics_port' in dask_kwargs:
             diagnostics_port = dask_kwargs['diagnostics_port']
@@ -209,10 +215,27 @@ def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs):
 
         workers = n_jobs_to_workers(n_jobs)
         workers = min(workers, num_tasks)
+
+        # Distributed default memory_limit for worker is 'auto'. It calculates worker
+        # memory limit as total virtual memory divided by the number
+        # of cores available to the workers (alwasy 1 for featuretools setup).
+        # This means reducing the number of workers does not increase the memory
+        # limit for other workers.  Featuretools default is to calculate memory limit
+        # as total virtual memory divided by number of workers. To use distributed
+        # default memory limit, set dask_kwargs['memory_limit']='auto'
+        if 'memory_limit' in dask_kwargs:
+            memory_limit = dask_kwargs['memory_limit']
+            del dask_kwargs['memory_limit']
+        else:
+            total_memory = psutil.virtual_memory().total
+            memory_limit = int(total_memory / float(workers))
+
         cluster = LocalCluster(n_workers=workers,
                                threads_per_worker=1,
                                diagnostics_port=diagnostics_port,
+                               memory_limit=memory_limit,
                                **dask_kwargs)
+
         # if cluster has bokeh port, notify user if unxepected port number
         if diagnostics_port is not None:
             if hasattr(cluster, 'scheduler') and cluster.scheduler:
@@ -222,4 +245,16 @@ def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs):
                     print(msg.format(info['services']['bokeh']))
 
     client = Client(cluster)
+
+    # TODO: check every worker?
+    memory_limit = cluster.workers
+    if memory_limit < entityset_size:
+        raise ValueError("Insufficient memory to use this many workers")
+    elif memory_limit < 2 * entityset_size:
+        logger.warn("Worker memory is between 1 to 2 times the memory"
+                    " size of the EntitySet. If errors occur that do"
+                    " not occur with n_jobs equals 1, this may be the "
+                    "cause.  See https://docs.featuretools.com/guides/parallel.html"
+                    " for more information.")
+
     return client, cluster

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -247,7 +247,7 @@ def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs, entityset_size):
     client = Client(cluster)
 
     # TODO: check every worker?
-    memory_limit = cluster.workers
+    memory_limit = list(client.scheduler_info()['workers'].values())[0]['memory']
     if memory_limit < entityset_size:
         raise ValueError("Insufficient memory to use this many workers")
     elif memory_limit < 2 * entityset_size:

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -912,8 +912,6 @@ def test_create_client_and_cluster(entityset, monkeypatch, capsys):
                               dask_kwargs={},
                               entityset_size=total_memory * .75)
 
-    # assert "Worker memory is between 1 to 2 times the memory" in captured
-
 
 def test_parallel_failure_raises_correct_error(entityset):
     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +


### PR DESCRIPTION
There are two main parts to this pull request
* **Change to how Featuretools sets worker memory limit by default:**  previously, reducing the number of distributed workers would not increase the maximum memory allotted to each worker.  With this change, Featuretools will set memory limits by splitting the total memory on the system equally between workers instead of equally between total cores on the system.
* **Raise errors or warnings about worker memory limits:** Featuretools will now raise an error if it is about to transmit the EntitySet to a worker and realizes the worker's memory limit is smaller than the size of the EntitySet.  Featuretools will also raise a warning if the worker's memory limit is less than twice the size of the EntitySet.
