### PR TITLE
Removing slow indexing 

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -1,5 +1,4 @@
 import cProfile
-import io
 import logging
 import os
 import pstats
@@ -235,15 +234,12 @@ class PandasBackend(ComputationalBackend):
         # debugging
         if profile:
             pr.disable()
-            s = io.StringIO()
-            ps = pstats.Stats(pr, stream=s).sort_stats("cumulative", "tottime")
-            ps.print_stats()
             prof_folder_path = os.path.join(ROOT_DIR, 'prof')
             if not os.path.exists(prof_folder_path):
                 os.mkdir(prof_folder_path)
             with open(os.path.join(prof_folder_path, 'inst-%s.log' %
                                    list(instance_ids)[0]), 'w') as f:
-                f.write(s.getvalue())
+                pstats.Stats(pr, stream=f).strip_dirs().sort_stats("cumulative", "tottime").print_stats()
 
         df = eframes_by_filter[self.target_eid][self.target_eid]
 
@@ -369,15 +365,11 @@ class PandasBackend(ComputationalBackend):
 
     def _calculate_agg_features(self, features, entity_frames):
         test_feature = features[0]
-        use_previous = test_feature.use_previous
-        base_features = test_feature.base_features
-        where = test_feature.where
         entity = test_feature.entity
-        child_entity = base_features[0].entity
+        child_entity = test_feature.base_features[0].entity
 
         assert entity.id in entity_frames and child_entity.id in entity_frames
 
-        index_var = entity.index
         frame = entity_frames[entity.id]
         base_frame = entity_frames[child_entity.id]
         # Sometimes approximate features get computed in a previous filter frame
@@ -389,6 +381,7 @@ class PandasBackend(ComputationalBackend):
             return frame
 
         # handle where clause for all functions below
+        where = test_feature.where
         if where is not None:
             base_frame = base_frame[base_frame[where.get_name()]]
 
@@ -399,6 +392,7 @@ class PandasBackend(ComputationalBackend):
 
         # if the use_previous property exists on this feature, include only the
         # instances from the child entity included in that Timedelta
+        use_previous = test_feature.use_previous
         if use_previous and not base_frame.empty:
             # Filter by use_previous values
             time_last = self.time_last
@@ -414,38 +408,6 @@ class PandasBackend(ComputationalBackend):
                     return df.iloc[-n:]
 
                 base_frame = base_frame.groupby(groupby_var, observed=True, sort=False).apply(last_n)
-
-        if not base_frame.empty:
-            if groupby_var not in base_frame:
-                # This occured sometimes. I think it might have to do with category
-                # but not sure. TODO: look into when this occurs
-                no_instances = True
-            # if the foreign key column in the child (base_frame) that links to
-            # frame is an integer and the id column in the parent is an object or
-            # category dtype, the .isin() call errors.
-            elif (frame[index_var].dtype != base_frame[groupby_var].dtype or
-                    frame[index_var].dtype.name.find('category') > -1):
-                try:
-                    frame_as_obj = frame[index_var].astype(object)
-                    base_frame_as_obj = base_frame[groupby_var].astype(object)
-                except ValueError:
-                    msg = u"Could not join {}.{} (dtype={}) with {}.{} (dtype={})"
-                    raise ValueError(msg.format(entity.id, index_var,
-                                                frame[index_var].dtype,
-                                                child_entity.id, groupby_var,
-                                                base_frame[groupby_var].dtype))
-                else:
-                    no_instances = check_no_related_instances(
-                        frame_as_obj.values, base_frame_as_obj.values)
-            else:
-                no_instances = check_no_related_instances(
-                    frame[index_var].values, base_frame[groupby_var].values)
-
-        if base_frame.empty or no_instances:
-            for f in features:
-                set_default_column(entity_frames[entity.id], f)
-
-            return frame
 
         def wrap_func_with_name(func, name):
             def inner(x):
@@ -565,18 +527,6 @@ def agg_wrapper(feats, time_last):
 
         return pd.DataFrame(d)
     return wrap
-
-
-def check_no_related_instances(array1, array2):
-    some_instances = False
-    set_frame = set(array1)
-    set_base_frame = set(array2)
-    for s in set_frame:
-        for b in set_base_frame:
-            if s == b:
-                some_instances = True
-                break
-    return not some_instances
 
 
 def set_default_column(frame, f):

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function
 
 import copy
 import logging
-import time
 from builtins import range
 from datetime import datetime
 
@@ -39,7 +38,6 @@ class Entity(object):
     variables = None
     time_index = None
     index = None
-    indexed_by = None
 
     def __init__(self, id, df, entityset, variable_types=None,
                  index=None, time_index=None, secondary_time_index=None,
@@ -72,7 +70,6 @@ class Entity(object):
         assert len(df.columns) == len(set(df.columns)), "Duplicate column names"
         self.data = {"df": df,
                      "last_time_index": last_time_index,
-                     "indexed_by": {}
                      }
         self.encoding = encoding
         self._verbose = verbose
@@ -80,7 +77,6 @@ class Entity(object):
         self.convert_all_variable_data(variable_types)
         self.id = id
         self.entityset = entityset
-        self.indexed_by = {}
         variable_types = variable_types or {}
         self.index = index
         self.time_index = time_index
@@ -126,8 +122,7 @@ class Entity(object):
                                              if v.id != self.index]
         self.update_data(df=self.df,
                          already_sorted=already_sorted,
-                         recalculate_last_time_indexes=False,
-                         reindex=False)
+                         recalculate_last_time_indexes=False)
 
     def __repr__(self):
         repr_out = u"Entity: {}\n".format(self.id)
@@ -162,23 +157,6 @@ class Entity(object):
             if v not in other.variables:
                 return False
         if deep:
-            if self.indexed_by is None and other.indexed_by is not None:
-                return False
-            elif self.indexed_by is not None and other.indexed_by is None:
-                return False
-            else:
-                for v, index_map in self.indexed_by.items():
-                    if v not in other.indexed_by:
-                        return False
-                    for i, related in index_map.items():
-                        if i not in other.indexed_by[v]:
-                            return False
-                        # indexed_by maps instances of two entities together by lists
-                        # We want to check that all the elements of the lists of instances
-                        # for each relationship are the same in both entities being
-                        # checked for equality, but don't care about the order.
-                        if not set(related) == set(other.indexed_by[v][i]):
-                            return False
             if self.last_time_index is None and other.last_time_index is not None:
                 return False
             elif self.last_time_index is not None and other.last_time_index is None:
@@ -214,14 +192,6 @@ class Entity(object):
     @last_time_index.setter
     def last_time_index(self, lti):
         self.data["last_time_index"] = lti
-
-    @property
-    def indexed_by(self):
-        return self.data["indexed_by"]
-
-    @indexed_by.setter
-    def indexed_by(self, idx):
-        self.data["indexed_by"] = idx
 
     @property
     def parents(self):
@@ -379,6 +349,7 @@ class Entity(object):
         Returns:
             pd.DataFrame : instances that match constraints
         """
+        # import pdb; pdb.set_trace()
         instance_vals = self._vals_to_series(instance_vals, variable_id)
 
         training_window = _check_timedelta(training_window)
@@ -394,21 +365,17 @@ class Entity(object):
             df = self.df.reindex(instance_vals)
             df.dropna(subset=[self.index], inplace=True)
 
-        elif variable_id in self.indexed_by:
-            # some variables are indexed ahead of time
-            index = self.indexed_by[variable_id]
-
-            # generate pd.Series of all values from the index. Indexing
-            # is much faster on this type.
-            to_append = [pd.Series(index[v]) for v in instance_vals
-                         if v in index]
-            my_id_vals = pd.Series([]).append(to_append)
-            df = self.df.loc[my_id_vals]
-
         else:
-            # filter by "row.variable_id IN instance_vals"
-            mask = self.df[variable_id].isin(instance_vals)
-            df = self.df[mask]
+            def temp():
+                # filter by "row.variable_id IN instance_vals"
+                # import pdb; pdb.set_trace()
+                # mask = self.df[variable_id].isin(instance_vals)
+                # df = self.df[mask]
+
+                df = self.df.merge(instance_vals.to_frame(), how="inner", copy=False)
+                return df
+
+            df = temp()
 
         sortby = variable_id if (return_sorted and not shuffle) else None
         return self._filter_and_sort(df=df,
@@ -420,46 +387,6 @@ class Entity(object):
                                      end=end,
                                      shuffle=shuffle,
                                      random_seed=random_seed)
-
-    def index_data(self):
-        for p in self.parents:
-            self.index_by_parent(self.entityset[p])
-
-    def index_by_parent(self, parent_entity):
-        """
-        Cache the instances of this entity grouped by the parent entity.
-        """
-        r = parent_entity.entityset.get_relationship(self.id,
-                                                     parent_entity.id)
-        relation_var_id = r.child_variable.id
-        if relation_var_id not in self.indexed_by:
-            self.indexed_by[relation_var_id] = {}
-        else:
-            if self._verbose:
-                print('Re-indexing %s by %s' % (self.id, parent_entity.id))
-
-        self._index_by_variable(relation_var_id)
-
-    def _index_by_variable(self, variable_id):
-        """
-        Cache the instances of this entity grouped by a variable.
-        This allows filtering to happen much more quickly later.
-        """
-        ts = time.time()
-        gb = self.df.groupby(self.df[variable_id])
-        index = self.indexed_by[variable_id]
-
-        if self._verbose:
-            print("Indexing '%s' in %d groups by variable '%s'" %
-                  (self.id, len(gb.groups), variable_id))
-
-        # index by each parent instance separately
-        for i in gb.groups:
-            index[i] = np.array(gb.groups[i])
-
-        if self._verbose:
-            print("...%d child instances took %.2f seconds" %
-                  (len(self.df.index), time.time() - ts))
 
     def infer_variable_types(self, ignore=None, link_vars=None):
         """Extracts the variables from a dataframe
@@ -537,7 +464,7 @@ class Entity(object):
         return inferred_types
 
     def update_data(self, df, already_sorted=False,
-                    reindex=True, recalculate_last_time_indexes=True):
+                    recalculate_last_time_indexes=True):
         '''Update entity's internal dataframe, optionaly making sure data is sorted,
         reference indexes to other entities are consistent, and last_time_indexes
         are consistent.
@@ -554,8 +481,6 @@ class Entity(object):
         self.set_index(self.index)
         self.set_time_index(self.time_index, already_sorted=already_sorted)
         self.set_secondary_time_index(self.secondary_time_index)
-        if reindex:
-            self.index_data()
         if recalculate_last_time_indexes and self.last_time_index is not None:
             self.entityset.add_last_time_indexes(updated_entities=[self.id])
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -365,7 +365,7 @@ class Entity(object):
             df.dropna(subset=[self.index], inplace=True)
 
         else:
-            df = self.df.merge(instance_vals.to_frame(), how="inner", copy=False)
+            df = self.df[self.df[variable_id].isin(instance_vals)]
 
         sortby = variable_id if (return_sorted and not shuffle) else None
         return self._filter_and_sort(df=df,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -349,7 +349,6 @@ class Entity(object):
         Returns:
             pd.DataFrame : instances that match constraints
         """
-        # import pdb; pdb.set_trace()
         instance_vals = self._vals_to_series(instance_vals, variable_id)
 
         training_window = _check_timedelta(training_window)
@@ -366,16 +365,7 @@ class Entity(object):
             df.dropna(subset=[self.index], inplace=True)
 
         else:
-            def temp():
-                # filter by "row.variable_id IN instance_vals"
-                # import pdb; pdb.set_trace()
-                # mask = self.df[variable_id].isin(instance_vals)
-                # df = self.df[mask]
-
-                df = self.df.merge(instance_vals.to_frame(), how="inner", copy=False)
-                return df
-
-            df = temp()
+            df = self.df.merge(instance_vals.to_frame(), how="inner", copy=False)
 
         sortby = variable_id if (return_sorted and not shuffle) else None
         return self._filter_and_sort(df=df,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -357,7 +357,6 @@ class EntitySet(object):
                                         child_v, child_e.id, child_dtype))
 
         self.relationships.append(relationship)
-        self.index_data(relationship)
         return self
 
     def get_pandas_data_slice(self, filter_entity_ids, index_eid,
@@ -962,7 +961,6 @@ class EntitySet(object):
                     other[entity.id].last_time_index is not None):
                 has_last_time_index.append(entity.id)
             combined_es[entity.id].update_data(df=combined_df,
-                                               reindex=True,
                                                recalculate_last_time_indexes=False)
 
         combined_es.add_last_time_indexes(updated_entities=has_last_time_index)
@@ -971,16 +969,6 @@ class EntitySet(object):
     ###########################################################################
     #  Indexing methods  ###############################################
     ###########################################################################
-
-    def index_data(self, r):
-        """
-        If necessary, generate an index on the data which links instances of
-        parent entities to collections of child instances which link to them.
-        """
-        parent_entity = self.entity_dict[r.parent_variable.entity.id]
-        child_entity = self.entity_dict[r.child_variable.entity.id]
-        child_entity.index_by_parent(parent_entity=parent_entity)
-
     def add_last_time_indexes(self, updated_entities=None):
         """
         Calculates the last time index values for each entity (the last time

--- a/featuretools/entityset/serialization.py
+++ b/featuretools/entityset/serialization.py
@@ -167,24 +167,6 @@ def _write_parquet_entity_data(root, entity, metadata,
 
     entity_size += os.stat(df_filename).st_size
 
-    rel_index_path = os.path.join(entity.id, 'indexes')
-    index_path = os.path.join(root, rel_index_path)
-    os.makedirs(index_path)
-    data_files['indexes'] = {}
-    for var_id, mapping_dict in entity.indexed_by.items():
-        rel_var_path = os.path.join(rel_index_path, var_id)
-        var_path = os.path.join(root, rel_var_path)
-        os.makedirs(var_path)
-        data_files['indexes'][var_id] = []
-        for instance, index in mapping_dict.items():
-            rel_var_index_filename = os.path.join(rel_var_path, '{}.parq'.format(instance))
-            var_index_filename = os.path.join(root, rel_var_index_filename)
-            pd.Series(index).to_frame(str(instance)).to_parquet(var_index_filename,
-                                                                engine=engine,
-                                                                compression=compression)
-            entity_size += os.stat(var_index_filename).st_size
-            data_files['indexes'][var_id].append({'instance': instance,
-                                                  'filename': rel_var_index_filename})
     data_files[u'to_join'] = to_join
     data_files[u'filetype'] = 'parquet'
     data_files[u'engine'] = engine

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -472,3 +472,15 @@ def test_direct_squared(entityset, backend):
                                                time_last=None)
     for i, row in df.iterrows():
         assert (row[0] * row[0]) == row[1]
+
+
+def test_agg_empty_child(entityset, backend):
+    customer_count_feat = Count(entityset['log']['id'],
+                                parent_entity=entityset['customers'])
+    pandas_backend = backend([customer_count_feat])
+
+    # time last before the customer had any events, so child frame is empty
+    df = pandas_backend.calculate_all_features(instance_ids=[0],
+                                               time_last=datetime(2011, 4, 8))
+
+    assert df["COUNT(log)"].iloc[0] == 0

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -62,9 +62,6 @@ def test_eq(es):
         'cancel_date': ['cancel_reason', 'cancel_date']}
     assert not es['customers'].__eq__(es['log'], deep=True)
 
-    es['log'].indexed_by = None
-    assert not es['log'].__eq__(es['customers'], deep=True)
-
 
 def test_parents(es):
     assert set(es['log'].parents) == set(['sessions', 'products'])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -866,6 +866,5 @@ def test_sizeof(entityset):
     for entity in entityset.entities:
         total_size += entity.df.__sizeof__()
         total_size += entity.last_time_index.__sizeof__()
-        total_size += entity.indexed_by.__sizeof__()
 
     assert entityset.__sizeof__() == total_size


### PR DESCRIPTION
Based on benchmarking with larger real world datasets, we've observed that calls to `Entity.query_by_value` are frequently a bottleneck in feature calculation. This is due to a python loop that we used to look up values in an index. 

Rather than optimize the python loop, I am simply removing the pre-indexing of data and using a cython optimized pandas merge within `Entity.query_by_value`.
 