### PR TITLE
Make primitive lookup case insensitive 

### DIFF
--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -47,7 +47,7 @@ def get_aggregation_primitives():
                           featuretools.primitives.AggregationPrimitive):
                 if attribute.name:
                     aggregation_primitives.add(attribute)
-    return {prim.name: prim for prim in aggregation_primitives}
+    return {prim.name.lower(): prim for prim in aggregation_primitives}
 
 
 def get_transform_primitives():
@@ -59,7 +59,7 @@ def get_transform_primitives():
                           featuretools.primitives.TransformPrimitive):
                 if attribute.name:
                     transform_primitives.add(attribute)
-    return {prim.name: prim for prim in transform_primitives}
+    return {prim.name.lower(): prim for prim in transform_primitives}
 
 
 def list_primitives():

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -80,6 +80,7 @@ def test_makes_agg_features_from_mixed_str(es):
     assert (feature_with_name(features, 'LAST(log.value)'))
     assert (feature_with_name(features, 'COUNT(log)'))
 
+
 def test_case_insensitive(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                    entityset=es,

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -80,6 +80,16 @@ def test_makes_agg_features_from_mixed_str(es):
     assert (feature_with_name(features, 'LAST(log.value)'))
     assert (feature_with_name(features, 'COUNT(log)'))
 
+def test_case_insensitive(es):
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
+                                   entityset=es,
+                                   agg_primitives=['MiN'],
+                                   trans_primitives=['AbsOlute'])
+
+    features = dfs_obj.build_features()
+    assert (feature_with_name(features, 'MIN(log.value)'))
+    assert (feature_with_name(features, 'ABSOLUTE(MIN(log.value_many_nans))'))
+
 
 def test_makes_agg_features(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',


### PR DESCRIPTION
With this PR, we now handle the case where the name of the primitive isn't already all lower case