### PR TITLE
Fix worker memory limit to entityset size comparison

### DIFF
--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -247,7 +247,7 @@ def create_client_and_cluster(n_jobs, num_tasks, dask_kwargs, entityset_size):
 
     warned_of_memory = False
     for worker in list(client.scheduler_info()['workers'].values()):
-        worker_limit = worker['memory']
+        worker_limit = worker['memory_limit']
         if worker_limit < entityset_size:
             raise ValueError("Insufficient memory to use this many workers")
         elif worker_limit < 2 * entityset_size and not warned_of_memory:

--- a/featuretools/tests/testing_utils/cluster.py
+++ b/featuretools/tests/testing_utils/cluster.py
@@ -14,4 +14,4 @@ class MockClient():
         self.cluster = cluster
 
     def scheduler_info(self):
-        return {'workers': {'worker 1': {'memory': virtual_memory().total}}}
+        return {'workers': {'worker 1': {'memory_limit': virtual_memory().total}}}


### PR DESCRIPTION
There was a bug in #208 causing featuretools to treat the current memory use of a dask worker as the workers' total usable memory when deciding if the worker had enough memory to store an EntitySet.