### PR TITLE
Bump minimum pandas version from 0.20.3 to 0.23.0

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -249,11 +249,7 @@ class PandasBackend(ComputationalBackend):
         if missing_ids:
             default_df = self.generate_default_df(instance_ids=missing_ids,
                                                   extra_columns=df.columns)
-            # pandas added sort parameter in 0.23.0
-            try:
-                df = df.append(default_df, sort=True)
-            except:
-                df = df.append(default_df)
+            df = df.append(default_df, sort=True)
 
         df.index.name = self.entityset[self.target_eid].index
         return df[[feat.get_name() for feat in self.features]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.13.3
 scipy>=1.0.0
-pandas>=0.20.3
+pandas>=0.23.0
 s3fs>=0.1.2
 tqdm>=4.19.2
 toolz>=0.8.2


### PR DESCRIPTION
We require the `observed` keyword argument in pandas groupby, which is new in 0.23.0.