### PR TITLE
remove convert_links_to_integers

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -741,7 +741,6 @@ class EntitySet(object):
 
     def normalize_entity(self, base_entity_id, new_entity_id, index,
                          additional_variables=None, copy_variables=None,
-                         convert_links_to_integers=False,
                          make_time_index=None,
                          make_secondary_time_index=None,
                          new_entity_time_index=None,
@@ -765,12 +764,6 @@ class EntitySet(object):
             copy_variables (list[str]): List of
                 variable ids to copy from old entity
                 and move to new entity.
-
-            convert_links_to_integers (bool) : If True,
-                convert the linking variable between the two
-                entities to an integer. Old variable will be kept only
-                in the new normalized entity, and the new variable will have
-                the old variable's name plus "_id".
 
             make_time_index (bool or str, optional): Create time index for new entity based
                 on time index in base_entity, optionally specifying which variable in base_entity
@@ -809,9 +802,6 @@ class EntitySet(object):
                 raise ValueError("Not copying {} as both index and variable".format(v))
                 break
         new_index = index
-
-        if convert_links_to_integers:
-            new_index = make_index_variable_name(new_entity_id)
 
         transfer_types = {}
         transfer_types[new_index] = type(base_entity[index])
@@ -876,20 +866,6 @@ class EntitySet(object):
             new_entity_df = new_entity_df2
 
         base_entity_index = index
-        if convert_links_to_integers:
-            old_entity_df = self[base_entity_id].df
-            link_variable_id = make_index_variable_name(new_entity_id)
-            new_entity_df[link_variable_id] = np.arange(0, new_entity_df.shape[0])
-            just_index = old_entity_df[[index]]
-            id_as_int = just_index.merge(new_entity_df,
-                                         left_on=index,
-                                         right_on=index,
-                                         how='left')[link_variable_id]
-
-            old_entity_df.loc[:, index] = id_as_int.values
-
-            base_entity.update_data(old_entity_df)
-            index = link_variable_id
 
         transfer_types[index] = vtypes.Categorical
         if make_secondary_time_index:

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -803,13 +803,12 @@ def test_make_time_index_keeps_original_sorting():
 def test_normalize_entity_new_time_index(entityset):
     entityset.normalize_entity('log', 'values', 'value',
                                make_time_index=True,
-                               new_entity_time_index="value_time",
-                               convert_links_to_integers=True)
+                               new_entity_time_index="value_time")
 
     assert entityset['log'].is_child_of('values')
     assert entityset['values'].time_index == 'value_time'
     assert 'value_time' in entityset['values'].df.columns
-    assert len(entityset['values'].df.columns) == 3
+    assert len(entityset['values'].df.columns) == 2
 
 
 def test_secondary_time_index(entityset):
@@ -818,8 +817,7 @@ def test_secondary_time_index(entityset):
                                make_secondary_time_index={
                                    'datetime': ['comments']},
                                new_entity_time_index="value_time",
-                               new_entity_secondary_time_index='second_ti',
-                               convert_links_to_integers=True)
+                               new_entity_secondary_time_index='second_ti')
 
     assert (isinstance(entityset['values'].df['second_ti'], pd.Series))
     assert (entityset['values']['second_ti']._dtype_repr == 'datetime')

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -19,23 +19,22 @@ def values_es(entityset):
     new_es = copy.deepcopy(entityset)
     new_es.normalize_entity('log', 'values', 'value',
                             make_time_index=True,
-                            new_entity_time_index="value_time",
-                            convert_links_to_integers=True)
+                            new_entity_time_index="value_time")
     return new_es
 
 
 @pytest.fixture
 def true_values_lti():
     true_values_lti = pd.Series([datetime(2011, 4, 10, 10, 41, 0),
-                                 datetime(2011, 4, 10, 10, 40, 1),
-                                 datetime(2011, 4, 9, 10, 30, 12),
-                                 datetime(2011, 4, 9, 10, 30, 18),
-                                 datetime(2011, 4, 9, 10, 30, 24),
                                  datetime(2011, 4, 9, 10, 31, 9),
                                  datetime(2011, 4, 9, 10, 31, 18),
                                  datetime(2011, 4, 9, 10, 31, 27),
+                                 datetime(2011, 4, 10, 10, 40, 1),
                                  datetime(2011, 4, 10, 10, 41, 3),
+                                 datetime(2011, 4, 9, 10, 30, 12),
                                  datetime(2011, 4, 10, 10, 41, 6),
+                                 datetime(2011, 4, 9, 10, 30, 18),
+                                 datetime(2011, 4, 9, 10, 30, 24),
                                  datetime(2011, 4, 10, 11, 10, 3)])
     return true_values_lti
 
@@ -109,18 +108,19 @@ class TestLastTimeIndex(object):
         values = values_es['values']
 
         # add extra value instance with no children
-        row_values = {'value': 6.0,
+        row_values = {'value': 21.0,
                       'value_time': pd.Timestamp("2011-04-10 11:10:02"),
                       'values_id': 11}
         # make sure index doesn't have same name as column to suppress pandas warning
         row = pd.DataFrame(row_values, index=pd.Index([11]))
         df = values.df.append(row, sort=True)
-        df = df.sort_values(['value_time', 'values_id'], kind='mergesort')
+        df = df[['value', 'value_time']].sort_values(by='value')
         df.index.name = 'values_id'
         values.update_data(df)
         values_es.add_last_time_indexes()
         # lti value should default to instance's time index
-        true_values_lti[11] = pd.Timestamp("2011-04-10 11:10:02")
+        true_values_lti[10] = pd.Timestamp("2011-04-10 11:10:02")
+        true_values_lti[11] = pd.Timestamp("2011-04-10 11:10:03")
 
         assert len(values.last_time_index) == 12
         sorted_lti = values.last_time_index.sort_index()


### PR DESCRIPTION
Removes the keyword argument `convert_links_to_integers` from normalize entity.

Some of the `last_time_index` tests were using a normalization with `convert_links_to_integers` and sorting values, leading to a resort of the "true" values in the test.

Original ordering was 
```
0.0, 5.0, 10.0, 15.0, 20.0, 1.0, 2.0, 3.0, 7.0, 14.0, NaN
```
if we convert these to range(11) and sort them according to the value in the list above, the new ordering of that range would become
```
0, 5, 6, 7, 1, 8, 2, 9, 3, 4, 10
```
which aligns exactly with the changes we had to make in `true_values_lti`. 

The other change, changing the `value` in `test_parent_some_missing`, is really a convenience measure to ensure that it ends up second to last on the sorted list. If we put it earlier, we'll have to move **all** the rows instead of just one. 