### PR TITLE
Add conda install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Circle CI](https://circleci.com/gh/Featuretools/featuretools.svg?maxAge=2592000&style=shield)](https://circleci.com/gh/Featuretools/featuretools)
 [![Coverage Status](https://codecov.io/gh/Featuretools/featuretools/branch/master/graph/badge.svg)](https://codecov.io/gh/Featuretools/featuretools)
 [![PyPI version](https://badge.fury.io/py/featuretools.svg?maxAge=2592000)](https://badge.fury.io/py/featuretools)
+[![Anaconda-Server Badge](https://anaconda.org/featuretools/featuretools/badges/version.svg)](https://anaconda.org/featuretools/featuretools)
 
 [Featuretools](https://www.featuretools.com) is a python library for automated feature engineering. See the [documentation](https://docs.featuretools.com) for more information.
 
@@ -19,7 +20,11 @@
 ## Installation
 Install with pip
 
-	pip install featuretools
+	python -m pip install featuretools
+	
+or from the Featuretools channel on [conda](https://anaconda.org/Featuretools/featuretools):
+
+	conda install -c featuretools featuretools
 
 ## Example
 Below is an example of using Deep Feature Synthesis (DFS) to perform automated feature engineering. In this example, we apply DFS to a multi-table dataset consisting of timestamped customer transactions.


### PR DESCRIPTION
Modify the README to match the documentation:
- adds a conda version badge (from badgelist [here](https://anaconda.org/Featuretools/featuretools/badges))
- changes `pip` to `python -m pip`
- adds conda install instructions