### PR TITLE
Optimize metadata calculation

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -544,6 +544,7 @@ class Entity(object):
             self.index_data()
         if recalculate_last_time_indexes and self.last_time_index is not None:
             self.entityset.add_last_time_indexes(updated_entities=[self.id])
+        self.entityset.reset_metadata()
 
     def add_interesting_values(self, max_values=5, verbose=False):
         """
@@ -600,6 +601,8 @@ class Entity(object):
                             # total_count -= counts[idx]
                         else:
                             break
+
+        self.entityset.reset_metadata()
 
     def add_variable(self, new_id, type=None, data=None):
         """Add variable to entity

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -181,15 +181,10 @@ class EntitySet(object):
         and if it is return the existing one. Thus, all features in the feature list
         would reference the same object, rather than copies. This saves a lot of memory
         '''
-        new_metadata = self.from_metadata(self.create_metadata_dict(),
-                                          data_root=None)
         if self._metadata is None:
-            self._metadata = new_metadata
-        else:
-            # Don't want to keep making new copies of metadata
-            # Only make a new one if something was changed
-            if self._metadata != new_metadata:
-                self._metadata = new_metadata
+            self._metadata = self.from_metadata(self.create_metadata_dict(),
+                                                data_root=None)
+
         return self._metadata
 
     @property
@@ -358,6 +353,7 @@ class EntitySet(object):
 
         self.relationships.append(relationship)
         self.index_data(relationship)
+        self._metadata = None
         return self
 
     def get_pandas_data_slice(self, filter_entity_ids, index_eid,
@@ -888,7 +884,7 @@ class EntitySet(object):
         new_entity = self.entity_dict[new_entity_id]
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
         self.add_relationship(Relationship(new_entity[index], base_entity[base_entity_index]))
-
+        self._metadata = None
         return self
 
     ###########################################################################
@@ -942,6 +938,7 @@ class EntitySet(object):
                                                recalculate_last_time_indexes=False)
 
         combined_es.add_last_time_indexes(updated_entities=has_last_time_index)
+        self._metadata = None
         return combined_es
 
     ###########################################################################
@@ -1049,6 +1046,7 @@ class EntitySet(object):
                     entity.last_time_index.name = 'last_time'
 
             explored.add(entity.id)
+        self._metadata = None
 
     ###########################################################################
     #  Other ###############################################
@@ -1067,6 +1065,7 @@ class EntitySet(object):
         """
         for entity in self.entities:
             entity.add_interesting_values(max_values=max_values, verbose=verbose)
+        self._metadata = None
 
     def related_instances(self, start_entity_id, final_entity_id,
                           instance_ids=None, time_last=None, add_link=False,
@@ -1258,6 +1257,7 @@ class EntitySet(object):
                         already_sorted=already_sorted,
                         created_index=created_index)
         self.entity_dict[entity.id] = entity
+        self._metadata = None
         return self
 
     def _add_multigenerational_link_vars(self, frames, start_entity_id,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -124,7 +124,7 @@ class EntitySet(object):
             child_variable = self[relationship[2]][relationship[3]]
             self.add_relationship(Relationship(parent_variable,
                                                child_variable))
-        self._metadata = None
+        self.reset_metadata()
 
     def __sizeof__(self):
         return sum([entity.__sizeof__() for entity in self.entities])
@@ -186,6 +186,9 @@ class EntitySet(object):
                                                 data_root=None)
 
         return self._metadata
+
+    def reset_metadata(self):
+        self._metadata = None
 
     @property
     def is_metadata(self):
@@ -353,7 +356,7 @@ class EntitySet(object):
 
         self.relationships.append(relationship)
         self.index_data(relationship)
-        self._metadata = None
+        self.reset_metadata()
         return self
 
     def get_pandas_data_slice(self, filter_entity_ids, index_eid,
@@ -884,7 +887,7 @@ class EntitySet(object):
         new_entity = self.entity_dict[new_entity_id]
         base_entity.convert_variable_type(base_entity_index, vtypes.Id, convert_data=False)
         self.add_relationship(Relationship(new_entity[index], base_entity[base_entity_index]))
-        self._metadata = None
+        self.reset_metadata()
         return self
 
     ###########################################################################
@@ -938,7 +941,7 @@ class EntitySet(object):
                                                recalculate_last_time_indexes=False)
 
         combined_es.add_last_time_indexes(updated_entities=has_last_time_index)
-        self._metadata = None
+        self.reset_metadata()
         return combined_es
 
     ###########################################################################
@@ -1046,7 +1049,7 @@ class EntitySet(object):
                     entity.last_time_index.name = 'last_time'
 
             explored.add(entity.id)
-        self._metadata = None
+        self.reset_metadata()
 
     ###########################################################################
     #  Other ###############################################
@@ -1065,7 +1068,7 @@ class EntitySet(object):
         """
         for entity in self.entities:
             entity.add_interesting_values(max_values=max_values, verbose=verbose)
-        self._metadata = None
+        self.reset_metadata()
 
     def related_instances(self, start_entity_id, final_entity_id,
                           instance_ids=None, time_last=None, add_link=False,
@@ -1257,7 +1260,7 @@ class EntitySet(object):
                         already_sorted=already_sorted,
                         created_index=created_index)
         self.entity_dict[entity.id] = entity
-        self._metadata = None
+        self.reset_metadata()
         return self
 
     def _add_multigenerational_link_vars(self, frames, start_entity_id,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -27,7 +27,8 @@ def test_operations_invalidate_metadata(entityset):
     new_es = ft.EntitySet(id="test")
     # test metadata gets created on access
     assert new_es._metadata is None
-    assert new_es.metadata is not None
+    assert new_es.metadata is not None # generated after access
+    assert new_es._metadata is not None
 
     new_es.entity_from_dataframe("customers",
                                  entityset["customers"].df,
@@ -37,24 +38,29 @@ def test_operations_invalidate_metadata(entityset):
                                  index=entityset["sessions"].index)
     assert new_es._metadata is None
     assert new_es.metadata is not None
+    assert new_es._metadata is not None
 
     r = ft.Relationship(new_es["customers"]["id"],
                         new_es["sessions"]["customer_id"])
     new_es = new_es.add_relationship(r)
     assert new_es._metadata is None
     assert new_es.metadata is not None
+    assert new_es._metadata is not None
 
     new_es = new_es.normalize_entity("customers", "cohort", "cohort")
     assert new_es._metadata is None
     assert new_es.metadata is not None
+    assert new_es._metadata is not None
 
     new_es.add_last_time_indexes()
     assert new_es._metadata is None
     assert new_es.metadata is not None
+    assert new_es._metadata is not None
 
     new_es.add_interesting_values()
     assert new_es._metadata is None
     assert new_es.metadata is not None
+    assert new_es._metadata is not None
 
 
 def test_cannot_readd_relationships_that_already_exists(entityset):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -63,6 +63,13 @@ def test_operations_invalidate_metadata(entityset):
     assert new_es._metadata is not None
 
 
+def test_reset_metadata(entityset):
+    assert entityset.metadata is not None
+    assert entityset._metadata is not None
+    entityset.reset_metadata()
+    assert entityset._metadata is None
+
+
 def test_cannot_readd_relationships_that_already_exists(entityset):
     before_len = len(entityset.relationships)
     entityset.add_relationship(entityset.relationships[0])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -23,6 +23,40 @@ def entityset():
     return make_ecommerce_entityset()
 
 
+def test_operations_invalidate_metadata(entityset):
+    new_es = ft.EntitySet(id="test")
+    # test metadata gets created on access
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+    new_es.entity_from_dataframe("customers",
+                                 entityset["customers"].df,
+                                 index=entityset["customers"].index)
+    new_es.entity_from_dataframe("sessions",
+                                 entityset["sessions"].df,
+                                 index=entityset["sessions"].index)
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+    r = ft.Relationship(new_es["customers"]["id"],
+                        new_es["sessions"]["customer_id"])
+    new_es = new_es.add_relationship(r)
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+    new_es = new_es.normalize_entity("customers", "cohort", "cohort")
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+    new_es.add_last_time_indexes()
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+    new_es.add_interesting_values()
+    assert new_es._metadata is None
+    assert new_es.metadata is not None
+
+
 def test_cannot_readd_relationships_that_already_exists(entityset):
     before_len = len(entityset.relationships)
     entityset.add_relationship(entityset.relationships[0])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -27,7 +27,7 @@ def test_operations_invalidate_metadata(entityset):
     new_es = ft.EntitySet(id="test")
     # test metadata gets created on access
     assert new_es._metadata is None
-    assert new_es.metadata is not None # generated after access
+    assert new_es.metadata is not None  # generated after access
     assert new_es._metadata is not None
 
     new_es.entity_from_dataframe("customers",


### PR DESCRIPTION
Currently, we recalculate the metadata for an entityset every time the property is accessed. This slows done many operations in Featuretools.

This pull request refactors things so we only calculate the metadata if it hasn't been created yet or if an operation invalidated it. 

Locally this change makes the tests run in 134 seconds vs 513 without this change. 