### PR TITLE
Improve Consistency of Transform Primitives

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -749,4 +749,7 @@ def match(input_types, features, replace=False, commutative=False):
                 new_match = tuple(new_match)
             matching_inputs.add(new_match)
 
+    if commutative:
+        return set([tuple(sorted(s, key = lambda x: x.get_name())) for s in matching_inputs])
+
     return set([tuple(s) for s in matching_inputs])

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -750,6 +750,6 @@ def match(input_types, features, replace=False, commutative=False):
             matching_inputs.add(new_match)
 
     if commutative:
-        return set([tuple(sorted(s, key = lambda x: x.get_name())) for s in matching_inputs])
+        return set([tuple(sorted(s, key=lambda x: x.get_name().lower())) for s in matching_inputs])
 
     return set([tuple(s) for s in matching_inputs])

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -681,3 +681,34 @@ def test_commutative(es):
 
     assert num_add_feats == 3
     assert num_add_as_base_feat == 9
+
+
+def test_transform_consistency():
+    # Create dataframe
+    df = pd.DataFrame({'a': [14, 12, 10], 'b': [False, False, True],
+                       'b1': [True, True, False], 'b12': [4, 5, 6],
+                       'P': [10, 15, 12]})
+    es = ft.EntitySet(id='test')
+    # Add dataframe to entityset
+    es.entity_from_dataframe(entity_id='first', dataframe=df,
+                             index='index',
+                             make_index=True)
+
+    # Generate features
+    feature_defs = ft.dfs(entityset=es, target_entity='first',
+                          trans_primitives=['and', 'add', 'or'],
+                          features_only=True)
+
+    # Check for correct ordering of features
+    assert (feature_with_name(feature_defs, 'a'))
+    assert (feature_with_name(feature_defs, 'b'))
+    assert (feature_with_name(feature_defs, 'b1'))
+    assert (feature_with_name(feature_defs, 'b12'))
+    assert (feature_with_name(feature_defs, 'P'))
+    assert (feature_with_name(feature_defs, 'AND(b, b1)'))
+    assert (feature_with_name(feature_defs, 'a + P'))
+    assert (feature_with_name(feature_defs, 'b12 + P'))
+    assert (feature_with_name(feature_defs, 'a + b12'))
+    assert (feature_with_name(feature_defs, 'OR(b, b1)'))
+    assert (feature_with_name(feature_defs, 'OR(AND(b, b1), b)'))
+    assert (feature_with_name(feature_defs, 'OR(AND(b, b1), b1)'))


### PR DESCRIPTION
Due to the use of a `frozenset` which is an [unordered Python object](https://docs.python.org/3/library/stdtypes.html?highlight=frozenset#set-types-set-frozenset), the order of commutative transform primitives that used multiple columns, such as `AND`, could change when running Deep Feature Synthesis in different Python sessions. This behavior did not affect the feature values because the primitives are commutative. It did change the feature definitions which made comparing different sets of feature definitions a challenge.

The behavior is addressed by sorting the features used in commutative transform primitives alphabetically by name. For example, if the transform primitive `AND` is used with the features (columns) `FLAG_A` and `FLAG_B` the resulting feature will be `AND(FLAG_A, FLAG_B)`. 