### PR TITLE
Avoid stacking "expanding" primitives

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -690,6 +690,9 @@ def check_stacking(primitive, input_types):
             if type(f) in primitive.stack_on_exclude:
                 return False
 
+    if primitive.expanding:
+        return False
+
     for f in input_types:
         if f.base_of_exclude is not None:
             if primitive in f.base_of_exclude:

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -690,8 +690,9 @@ def check_stacking(primitive, input_types):
             if type(f) in primitive.stack_on_exclude:
                 return False
 
-    if primitive.expanding:
-        return False
+    for f in input_types:
+        if f.expanding:
+            return False
 
     for f in input_types:
         if f.base_of_exclude is not None:

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -218,6 +218,7 @@ def test_stack_on_self(es, test_primitive, parent_entity):
 
 
 def test_stack_expanding(es, test_primitive, parent_entity):
+    test_primitive.input_types = [Discrete]
     expanding_primitive = NMostCommon(es['sessions']['device_type'], parent_entity)
     assert not (check_stacking(test_primitive, [expanding_primitive]))
 

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -15,6 +15,7 @@ from featuretools.primitives import (
     Feature,
     Mean,
     Median,
+    NMostCommon,
     NumTrue,
     Sum,
     TimeSinceLast,
@@ -29,6 +30,7 @@ from featuretools.synthesis.deep_feature_synthesis import (
 from featuretools.variable_types import (
     Datetime,
     DatetimeTimeIndex,
+    Discrete,
     Index,
     Numeric,
     Variable
@@ -213,6 +215,11 @@ def test_stack_on_self(es, test_primitive, parent_entity):
     test_primitive.stack_on = None
     test_primitive.stack_on_self = False
     assert not (check_stacking(test_primitive, [child]))
+
+
+def test_stack_expanding(es, test_primitive, parent_entity):
+    expanding_primitive = NMostCommon(es['sessions']['device_type'], parent_entity)
+    assert not (check_stacking(test_primitive, [expanding_primitive]))
 
 
 # P TODO: this functionality is currently missing


### PR DESCRIPTION
This PR prevents DFS from trying to stack on primitives which output "expanding" features. It is resolves the error from #85.