### PR TITLE
Update deep_feature_synthesis.py

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -32,7 +32,7 @@ class DeepFeatureSynthesis(object):
             agg_primitives (list[str or :class:`.primitives.AggregationPrimitive`], optional):
                 list of Aggregation Feature types to apply.
 
-                Default: ["sum", "std", "max", "skew", "min", "mean", "count", "percent_true", "n_unique", "mode"]
+                Default: ["sum", "std", "max", "skew", "min", "mean", "count", "percent_true", "num_unique", "mode"]
 
             trans_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
                 list of Transform primitives to use.


### PR DESCRIPTION
- change docstring which shows wrong string it should be `num_unique`, not `n_unique`, see [here](https://github.com/Featuretools/featuretools/blob/master/featuretools/primitives/aggregation_primitives.py#L106)