### PR TITLE
Clean up merging of aggregation primitives

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -438,8 +438,6 @@ class PandasBackend(ComputationalBackend):
             # the column (in actuality grouping by both index and group would
             # work)
             to_merge = base_frame.groupby(base_frame[groupby_var], observed=True, sort=False).apply(wrap)
-
-            to_merge.reset_index(1, drop=True, inplace=True)
             frame = pd.merge(left=frame, right=to_merge,
                              left_index=True,
                              right_index=True, how='left')
@@ -513,11 +511,11 @@ def agg_wrapper(feats, time_last):
             args = [df[v] for v in variable_ids]
 
             if f.uses_calc_time:
-                d[f.get_name()] = [func(*args, time=time_last)]
+                d[f.get_name()] = func(*args, time=time_last)
             else:
-                d[f.get_name()] = [func(*args)]
+                d[f.get_name()] = func(*args)
 
-        return pd.DataFrame(d)
+        return pd.Series(d)
     return wrap
 
 

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal
 
 from ..testing_utils import make_ecommerce_entityset
 
@@ -477,7 +476,7 @@ def test_trend(entityset, backend):
 
     true_results = [-0.812730, 4.870378, np.nan]
 
-    assert_almost_equal(df[trend.get_name()].values.tolist(), true_results, decimal=5)
+    np.testing.assert_almost_equal(df[trend.get_name()].values.tolist(), true_results, decimal=5)
 
 
 def test_direct_squared(entityset, backend):

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -2,7 +2,9 @@
 
 from datetime import datetime
 
+import numpy as np
 import pytest
+from numpy.testing import assert_almost_equal
 
 from ..testing_utils import make_ecommerce_entityset
 
@@ -23,7 +25,8 @@ from featuretools.primitives import (
     Mode,
     NMostCommon,
     NotEquals,
-    Sum
+    Sum,
+    Trend
 )
 
 
@@ -462,6 +465,19 @@ def test_topn(entityset, backend):
     assert (topn.get_name() in df.columns)
     for i, values in enumerate(df[topn.get_name()].values):
         assert set(true_results[i]) == set(values)
+
+
+def test_trend(entityset, backend):
+    trend = Trend([entityset['log']['value'], entityset['log']['datetime']],
+                  entityset['customers'])
+    pandas_backend = backend([trend])
+
+    df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2],
+                                               time_last=None)
+
+    true_results = [-0.812730, 4.870378, np.nan]
+
+    assert_almost_equal(df[trend.get_name()].values.tolist(), true_results, decimal=5)
 
 
 def test_direct_squared(entityset, backend):


### PR DESCRIPTION
This pull request makes a minor refactor to how we calculate and then merge some aggregation primitives. By returning a series instead of a dataframe, so we can avoid a reset index. 

I also noticed we don't test the trend primitive, which uses this code path, so I added another test for good measure. 

fixes #252 

Overall this PR simplifies code without changing any functionality. 