### PR TITLE
Handle non-string column names

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -14,7 +14,7 @@ from .relationship import Relationship
 from .serialization import load_entity_data, write_entityset
 
 import featuretools.variable_types.variable as vtypes
-from featuretools.utils.gen_utils import make_tqdm_iterator
+from featuretools.utils.gen_utils import make_tqdm_iterator, is_string
 
 pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')
@@ -1211,7 +1211,7 @@ class EntitySet(object):
                                  r.child_entity.id == entity_id]
 
         for c in dataframe.columns:
-            if not isinstance(c, (''.__class__, u''.__class__)):
+            if not is_string(c):
                 raise ValueError("All column names must be strings. (Column has name {})".format(c))
 
             if dataframe[c].dtype.name.find('category') > -1:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1212,7 +1212,7 @@ class EntitySet(object):
 
         for c in dataframe.columns:
             if not is_string(c):
-                raise ValueError("All column names must be strings. (Column has name {})".format(c))
+                raise ValueError("All column names must be strings (Column {} is not a string)".format(c))
 
             if dataframe[c].dtype.name.find('category') > -1:
                 if c not in variable_types:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1211,8 +1211,9 @@ class EntitySet(object):
                                  r.child_entity.id == entity_id]
 
         for c in dataframe.columns:
-            if not isinstance(c, str):
+            if not isinstance(c, (''.__class__, u''.__class__)):
                 raise ValueError("All column names must be strings. (Column has name {})".format(c))
+
             if dataframe[c].dtype.name.find('category') > -1:
                 if c not in variable_types:
                     variable_types[c] = vtypes.Categorical

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1211,6 +1211,8 @@ class EntitySet(object):
                                  r.child_entity.id == entity_id]
 
         for c in dataframe.columns:
+            if not isinstance(c, str):
+                raise ValueError("All column names must be strings. (Column has name {})".format(c))
             if dataframe[c].dtype.name.find('category') > -1:
                 if c not in variable_types:
                     variable_types[c] = vtypes.Categorical

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -14,7 +14,7 @@ from .relationship import Relationship
 from .serialization import load_entity_data, write_entityset
 
 import featuretools.variable_types.variable as vtypes
-from featuretools.utils.gen_utils import make_tqdm_iterator, is_string
+from featuretools.utils.gen_utils import is_string, make_tqdm_iterator
 
 pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -366,6 +366,16 @@ def test_entity_init(entityset):
     assert entityset['test_entity'].df['time'].dtype == df['time'].dtype
     assert set(entityset['test_entity'].df['id']) == set(df['id'])
 
+def test_nonstr_column_names():
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 3: ['a', 'b', 'c']})
+    es = ft.EntitySet(id='Failure')
+
+    with pytest.raises(ValueError) as excinfo:
+        es.entity_from_dataframe(entity_id='str_cols',
+                             dataframe=df,
+                             index='index')
+    assert 'All column names must be strings. (Column has name 3)' in str(excinfo)
+
 
 def test_sort_time_id():
     transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -375,7 +375,7 @@ def test_nonstr_column_names():
         es.entity_from_dataframe(entity_id='str_cols',
                                  dataframe=df,
                                  index='index')
-    assert 'All column names must be strings. (Column has name 3)' in str(excinfo)
+    assert 'All column names must be strings (Column 3 is not a string)' in str(excinfo)
 
 
 def test_sort_time_id():

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -366,14 +366,15 @@ def test_entity_init(entityset):
     assert entityset['test_entity'].df['time'].dtype == df['time'].dtype
     assert set(entityset['test_entity'].df['id']) == set(df['id'])
 
+
 def test_nonstr_column_names():
     df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 3: ['a', 'b', 'c']})
     es = ft.EntitySet(id='Failure')
 
     with pytest.raises(ValueError) as excinfo:
         es.entity_from_dataframe(entity_id='str_cols',
-                             dataframe=df,
-                             index='index')
+                                 dataframe=df,
+                                 index='index')
     assert 'All column names must be strings. (Column has name 3)' in str(excinfo)
 
 


### PR DESCRIPTION
close #254 

This is an implementation of option 2 from #254 where we raise an error whenever we see a non `str` column name. There is also unit test with an integer column name to see that the error is raised.

Since this is one of a few possible solutions, it's marked as WIP until we determine which path we want to follow.