### PR TITLE
No longer cache demo csvs, remove config file

### DIFF
--- a/featuretools/config.py
+++ b/featuretools/config.py
@@ -1,134 +1,26 @@
-from __future__ import print_function
-
 import logging
 import os
 import sys
-import tempfile
-from warnings import warn
-
-import yaml
 
 
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+def initialize_logging():
+    loggers = {}
 
+    # Check for environmental variables
+    logger_env_vars = {
+        'FEATURETOOLS_LOG_LEVEL': 'featuretools',
+        'FEATURETOOLS_ES_LOG_LEVEL': 'featuretools.entityset',
+        'FEATURETOOLS_BACKEND_LOG_LEVEL': 'featuretools.computation_backend'
+    }
+    for logger_env, logger in logger_env_vars.items():
+        log_level = os.environ.get(logger_env, None)
+        if log_level is not None:
+            loggers[logger] = log_level
 
-dirname = os.path.dirname(__file__)
-default_path = os.path.join(dirname, 'config.yaml')
-
-
-def _writable_dir(path):
-    """Whether `path` is a directory, to which the user has write access.
-    Taken from IPython source:
-    https://github.com/ipython/ipython/blob/master/IPython/paths.py (`_writable_dir()`)
-    """
-    return os.path.isdir(path) and os.access(path, os.W_OK)
-
-
-def get_featuretools_dir():
-    '''Get the Featuretools directory for this platform and user.
-
-    Uses os.path.expanduser('~') and checks for writability .
-    Then adds .featuretools to the end of the path.
-
-    Modified from IPython source:
-
-    https://github.com/ipython/ipython/blob/master/IPython/paths.py (`get_home_dir()`)
-    And
-    https://github.com/ipython/ipython/blob/master/IPython/utils/path.py (`get_ipython_dir()`)
-    '''
-    env = os.environ
-    ftdir_def = '.featuretools'
-
-    ftdir = env.get('FEATURETOOLS_DIR', None)
-    if ftdir is None:
-        home_dir = os.path.expanduser('~')
-        # Next line will make things work even when /home/ is a symlink to
-        # /usr/home as it is on FreeBSD, for example
-        home_dir = os.path.realpath(home_dir)
-        if not _writable_dir(home_dir) and os.name == 'nt':
-            # expanduser failed, use the registry to get the 'My Documents' folder.
-            try:
-                import winreg as wreg  # Py 3
-            except ImportError:
-                import _winreg as wreg  # Py 2
-            key = wreg.OpenKey(
-                wreg.HKEY_CURRENT_USER,
-                "Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
-            )
-            home_dir = wreg.QueryValueEx(key, 'Personal')[0]
-            key.Close()
-
-        ftdir = os.path.join(home_dir, ftdir_def)
-    ftdir = os.path.normpath(os.path.expanduser(ftdir))
-
-    if os.path.exists(ftdir) and not _writable_dir(ftdir):
-        # ftdir exists, but is not writable
-        warn("Featuretools dir '{0}' is not a writable location,"
-             " using a temp directory.".format(ftdir))
-        ftdir = tempfile.mkdtemp()
-    elif not os.path.exists(ftdir):
-        parent = os.path.dirname(ftdir)
-        if not _writable_dir(parent):
-            # ftdir does not exist and parent isn't writable
-            warn("Featuretools dir parent '{0}' is not a writable location,"
-                 " using a temp directory.".format(parent))
-            ftdir = tempfile.mkdtemp()
-    return ftdir
-
-
-ftdir = get_featuretools_dir()
-ft_config_path = os.path.join(ftdir, 'config.yaml')
-csv_save_location = os.path.join(ftdir, 'csv_files')
-
-
-def ensure_config_file(destination=ft_config_path):
-    if not os.path.exists(destination):
-        import shutil
-        if not os.path.exists(os.path.dirname(destination)):
-            try:
-                os.mkdir(os.path.dirname(destination))
-            except OSError:
-                pass
-        try:
-            shutil.copy(default_path, destination)
-        except OSError:
-            eprint("Unable to copy config file. Check file permissions")
-
-
-def load_config_file(path=ft_config_path):
-    if not os.path.exists(path):
-        path = default_path
-    try:
-        with open(path) as f:
-            text = f.read()
-            config_dict = yaml.load(text)
-            return config_dict
-    except OSError:
-        eprint("Unable to load config file. Check file permissions")
-        return {'logging': {'featuretools': 'info',
-                            'featuretools.entityset': 'info',
-                            'featuretools.computation_backend': 'info'}}
-
-
-def ensure_data_folders():
-    for dest in [csv_save_location]:
-        if not os.path.exists(dest):
-            try:
-                os.makedirs(dest)
-            except OSError:
-                eprint("Unable to make folder {}. Check file permissions".format(dest))
-
-
-ensure_config_file()
-ensure_data_folders()
-config = load_config_file()
-config['csv_save_location'] = csv_save_location
-
-
-def initialize_logging(config):
-    loggers = config.get('logging', {})
+    # Set log level to info if not otherwise specified.
     loggers.setdefault('featuretools', 'info')
+    loggers.setdefault('featuretools.computation_backend', 'info')
+    loggers.setdefault('featuretools.entityset', 'info')
 
     fmt = '%(asctime)-15s %(name)s - %(levelname)s    %(message)s'
     out_handler = logging.StreamHandler(sys.stdout)
@@ -150,5 +42,4 @@ def initialize_logging(config):
             logger.addHandler(out_handler)
         logger.propagate = False
 
-
-initialize_logging(config)
+initialize_logging()

--- a/featuretools/config.py
+++ b/featuretools/config.py
@@ -42,4 +42,5 @@ def initialize_logging():
             logger.addHandler(out_handler)
         logger.propagate = False
 
+
 initialize_logging()

--- a/featuretools/config.yaml
+++ b/featuretools/config.yaml
@@ -1,6 +1,0 @@
-logging:
-  featuretools: info
-  featuretools.entityset: info
-  featuretools.computational_backend: info
-
-csv_save_location:

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -1,14 +1,10 @@
-import os
-from builtins import str
-
 import pandas as pd
 
 import featuretools as ft
 import featuretools.variable_types as vtypes
-from featuretools.config import config as ft_config
 
 
-def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, use_cache=True):
+def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):
     '''
     Returns the retail entityset example which is a modified version of
     the data found `here <https://archive.ics.uci.edu/ml/datasets/online+retail>`_.
@@ -18,8 +14,6 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
         nrows (int):  Number of rows to load of the underlying CSV.
             If None, load all.
         return_single_table (bool): If True, return a CSV rather than an EntitySet. Default is False.
-        use_cache (bool): If True, use a stored version of the CSV. Otherwise redownload.
-            Default is True.
 
     Examples:
 
@@ -58,16 +52,8 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
     '''
     es = ft.EntitySet(id)
     csv_s3 = "https://s3.amazonaws.com/featuretools-static/" + RETAIL_CSV + ".csv"
-    demo_save_path = make_retail_pathname(nrows, RETAIL_CSV)
 
-    if not use_cache or not os.path.isfile(demo_save_path):
-
-        df = pd.read_csv(csv_s3,
-                         nrows=nrows,
-                         parse_dates=["order_date"])
-        df.to_csv(demo_save_path, index_label='order_product_id')
-
-    df = pd.read_csv(demo_save_path,
+    df = pd.read_csv(csv_s3,
                      nrows=nrows,
                      parse_dates=["order_date"])
 
@@ -96,11 +82,5 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False, us
     es.add_last_time_indexes()
 
     return es
-
-
-def make_retail_pathname(nrows, csv_name):
-    file_name = csv_name + '_' + str(nrows) + '.csv'
-    return os.path.join(ft_config['csv_save_location'], file_name)
-
 
 RETAIL_CSV = "online-retail-logs-2018-08-28"

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -83,4 +83,5 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):
 
     return es
 
+
 RETAIL_CSV = "online-retail-logs-2018-08-28"

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -1,18 +1,5 @@
-import os
-
 from featuretools.demo import load_flight, load_mock_customer, load_retail
-from featuretools.demo.flight import make_flight_pathname
-from featuretools.demo.retail import RETAIL_CSV, make_retail_pathname
 from featuretools.synthesis import dfs
-
-
-def test_load_retail_save():
-    nrows = 10
-
-    load_retail(nrows=nrows, return_single_table=True)
-    assert os.path.isfile(make_retail_pathname(nrows, RETAIL_CSV))
-    assert os.path.getsize(make_retail_pathname(nrows, RETAIL_CSV)) < 45580670
-    os.remove(make_retail_pathname(nrows, RETAIL_CSV))
 
 
 def test_load_retail_diff():
@@ -24,9 +11,6 @@ def test_load_retail_diff():
     es_second = load_retail(nrows=nrows_second)
     assert es_second['order_products'].df.shape[0] == nrows_second
 
-    os.remove(make_retail_pathname(nrows, RETAIL_CSV))
-    os.remove(make_retail_pathname(nrows_second, RETAIL_CSV))
-
 
 def test_mock_customer():
     es = load_mock_customer(return_entityset=True)
@@ -36,12 +20,10 @@ def test_mock_customer():
 
 
 def test_load_flight():
-    demo_path, _, _ = make_flight_pathname(demo=True)
     es = load_flight(month_filter=[1],
                      categorical_filter={'origin_city': ['Charlotte, NC']},
                      return_single_table=False, nrows=1000)
 
-    assert os.path.isfile(demo_path)
     entity_names = ['airports', 'flights', 'trip_logs', 'airlines']
     realvals = [(11, 3), (13, 9), (103, 22), (1, 1)]
     for i, name in enumerate(entity_names):

--- a/featuretools/tests/utils_tests/test_config.py
+++ b/featuretools/tests/utils_tests/test_config.py
@@ -1,42 +1,47 @@
 import os
-# import stat
-# import subprocess
-import tempfile
+import logging
 
-from featuretools.config import get_featuretools_dir
+from featuretools.config import initialize_logging
 
-# import warnings
-
-
-# TODO: how to test windows path from Unix?
+logging_env_vars = {'FEATURETOOLS_LOG_LEVEL': "debug",
+                    'FEATURETOOLS_ES_LOG_LEVEL': "critical",
+                    'FEATURETOOLS_BACKEND_LOG_LEVEL': "error"}
 
 
-def test_featuretools_dir_from_os_env():
-    env = os.environ
-    desired_ftdir = tempfile.mkdtemp()
-    env['FEATURETOOLS_DIR'] = desired_ftdir
-    ftdir = get_featuretools_dir()
-    del env['FEATURETOOLS_DIR']
-    assert desired_ftdir == ftdir
+def test_logging_defaults():
+    old_env_vars = {}
+    for env_var in logging_env_vars:
+        old_env_vars[env_var] = os.environ.get(env_var, None)
+        if old_env_vars[env_var] is not None:
+            del os.environ[env_var]
+
+    initialize_logging()
+    main_logger = logging.getLogger('featuretools')
+    assert main_logger.getEffectiveLevel() == logging.INFO
+    es_logger = logging.getLogger('featuretools.entityset')
+    assert es_logger.getEffectiveLevel() == logging.INFO
+    backend_logger = logging.getLogger('featuretools.computation_backend')
+    assert backend_logger.getEffectiveLevel() == logging.INFO
+
+    for env_var, value in old_env_vars.items():
+        if value is not None:
+            os.environ[env_var] = value
 
 
-def test_featuretools_dir_normal():
-    env = os.environ
-    if 'FEATURETOOLS_DIR' in env:
-        del env['FEATURETOOLS_DIR']
-    assert get_featuretools_dir() == os.path.expanduser('~/.featuretools')
+def test_logging_set_via_env():
+    old_env_vars = {}
+    for env_var, value in logging_env_vars.items():
+        old_env_vars[env_var] = os.environ.get(env_var, None)
+        os.environ[env_var] = value
 
+    initialize_logging()
+    main_logger = logging.getLogger('featuretools')
+    assert main_logger.getEffectiveLevel() == logging.DEBUG
+    es_logger = logging.getLogger('featuretools.entityset')
+    assert es_logger.getEffectiveLevel() == logging.CRITICAL
+    backend_logger = logging.getLogger('featuretools.computation_backend')
+    assert backend_logger.getEffectiveLevel() == logging.ERROR
 
-# TODO: this doesn't work on CircleCI because it runs tox as the root user
-# def test_featuretools_dir_from_os_env_not_writable():
-#     env = os.environ
-#     desired_ftdir = tempfile.mkdtemp()
-#     env['FEATURETOOLS_DIR'] = desired_ftdir
-#     subprocess.call(["chattr", str(stat.SF_IMMUTABLE), desired_ftdir])
-#     os.chmod(desired_ftdir, stat.S_IREAD)
-#     assert not os.access(desired_ftdir, os.W_OK)
-#     with warnings.catch_warnings():
-#         warnings.simplefilter("ignore")
-#         ftdir = get_featuretools_dir()
-#     assert desired_ftdir != ftdir and os.access(ftdir, os.W_OK)
-#     del env['FEATURETOOLS_DIR']
+    for env_var, value in old_env_vars.items():
+        if value is not None:
+            os.environ[env_var] = value

--- a/featuretools/tests/utils_tests/test_config.py
+++ b/featuretools/tests/utils_tests/test_config.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from featuretools.config import initialize_logging
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     name='featuretools',
     version='0.3.0',
     packages=find_packages(),
-    package_data={'featuretools': ['config.yaml']},
     description='a framework for automated feature engineering',
     url='http://featuretools.com',
     license='BSD 3-clause',


### PR DESCRIPTION
The retail and flight datasets will no longer save a copy of the data to a local csv to use the next time the function is called.  Users can use `EntitySet.to_pickle` or `EntitySet.to_parquet` to save the entitysets locally.

The featuretools config file only stored the default save location for these csvs and the default logging levels for featuretools loggers.  To keep things simple, featuretools will no longer look use a config file. Logging levels can be set via the environmental variables `FEATURETOOLS_LOG_LEVEL`, `FEATURETOOLS_ES_LOG_LEVEL`, and  `FEATURETOOLS_BACKEND_LOG_LEVEL`.