### PR TITLE
Add `is_string` utils function

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -7,11 +7,11 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pandas.api.types as pdtypes
-from past.builtins import basestring
 
 from .timedelta import Timedelta
 
 from featuretools import variable_types as vtypes
+from featuretools.utils import is_string
 from featuretools.utils.wrangle import (
     _check_time_type,
     _check_timedelta,
@@ -66,7 +66,7 @@ class Entity(object):
                 used for inferring variable types.
 
         """
-        assert isinstance(id, basestring), "Entity id must be a string"
+        assert is_string(id), "Entity id must be a string"
         assert len(df.columns) == len(set(df.columns)), "Duplicate column names"
         self.data = {"df": df,
                      "last_time_index": last_time_index,

--- a/featuretools/entityset/timedelta.py
+++ b/featuretools/entityset/timedelta.py
@@ -6,9 +6,9 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 from dateutil.relativedelta import relativedelta
-from past.builtins import basestring
 
 from featuretools.exceptions import NotEnoughData
+from featuretools.utils import is_string
 
 
 class Timedelta(object):
@@ -74,7 +74,7 @@ class Timedelta(object):
                 exactly timedelta distance away from the original time/observation
         """
         # TODO: check if value is int or float
-        if isinstance(value, basestring):
+        if is_string(value):
             from featuretools.utils.wrangle import _check_timedelta
             td = _check_timedelta(value)
             value, unit = td.value, td.unit

--- a/featuretools/primitives/cum_transform_feature.py
+++ b/featuretools/primitives/cum_transform_feature.py
@@ -3,13 +3,13 @@ from builtins import str
 
 import numpy as np
 import pandas as pd
-from past.builtins import basestring
 
 from .aggregation_primitives import Count, Max, Mean, Min, Sum
 from .primitive_base import IdentityFeature, PrimitiveBase
 from .transform_primitive import TransformPrimitive
 from .utils import apply_dual_op_from_feat
 
+from featuretools.utils import is_string
 from featuretools.utils.wrangle import _check_timedelta
 from featuretools.variable_types import Id, Index, Numeric, TimeIndex
 from featuretools.variable_types.variable import Discrete
@@ -45,7 +45,7 @@ class CumFeature(TransformPrimitive):
         base_feature = self._check_feature(base_feature)
 
         td_entity_id = None
-        if isinstance(use_previous, basestring):
+        if is_string(use_previous):
             td_entity_id = base_feature.entity.id
         self.use_previous = _check_timedelta(
             use_previous, entity_id=td_entity_id)

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,11 +1,11 @@
 from inspect import getargspec, isclass
 
 import pandas as pd
-from past.builtins import basestring
 
 from .primitive_base import PrimitiveBase
 
 import featuretools.primitives
+from featuretools.utils import is_string
 
 
 def apply_dual_op_from_feat(f, array_1, array_2=None):
@@ -87,10 +87,10 @@ def ensure_compatible_dtype(left, right):
         elif right.dtype != object and left.dtype == object:
             right = right.astype(object)
     elif isinstance(left, pd.Series):
-        if left.dtype != object and isinstance(right, basestring):
+        if left.dtype != object and is_string(right):
             left = left.astype(object)
     elif isinstance(right, pd.Series):
-        if right.dtype != object and isinstance(left, basestring):
+        if right.dtype != object and is_string(left):
             right = right.astype(object)
     return left, right
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -2,8 +2,6 @@ import logging
 from builtins import filter, object, str
 from collections import defaultdict
 
-from past.builtins import basestring
-
 import featuretools.primitives.api as ftypes
 from featuretools import variable_types
 from featuretools.primitives.api import (
@@ -16,6 +14,7 @@ from featuretools.primitives.api import (
     IdentityFeature,
     TimeSince
 )
+from featuretools.utils import is_string
 from featuretools.variable_types import Boolean, Categorical, Numeric, Ordinal
 
 logger = logging.getLogger('featuretools')
@@ -140,7 +139,7 @@ class DeepFeatureSynthesis(object):
         self.agg_primitives = []
         agg_prim_dict = ftypes.get_aggregation_primitives()
         for a in agg_primitives:
-            if isinstance(a, basestring):
+            if is_string(a):
                 if a.lower() not in agg_prim_dict:
                     raise ValueError("Unknown aggregation primitive {}. ".format(a),
                                      "Call ft.primitives.list_primitives() to get",
@@ -156,7 +155,7 @@ class DeepFeatureSynthesis(object):
         self.trans_primitives = []
         trans_prim_dict = ftypes.get_transform_primitives()
         for t in trans_primitives:
-            if isinstance(t, basestring):
+            if is_string(t):
                 if t.lower() not in trans_prim_dict:
                     raise ValueError("Unknown transform primitive {}. ".format(t),
                                      "Call ft.primitives.list_primitives() to get",
@@ -169,7 +168,7 @@ class DeepFeatureSynthesis(object):
             where_primitives = [ftypes.Count]
         self.where_primitives = []
         for p in where_primitives:
-            if isinstance(p, basestring):
+            if is_string(p):
                 prim_obj = agg_prim_dict.get(p.lower(), None)
                 if prim_obj is None:
                     raise ValueError("Unknown where primitive {}. ".format(p),

--- a/featuretools/utils/api.py
+++ b/featuretools/utils/api.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-from .gen_utils import make_tqdm_iterator
+from .gen_utils import is_string, make_tqdm_iterator
 from .pickle_utils import load_features, save_features
 from .time_utils import make_temporal_cutoffs

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -77,3 +77,14 @@ def make_tqdm_iterator(**kwargs):
     else:
         iterator = tqdm(**options)
     return iterator
+
+
+def is_string(test_value):
+    """Checks for string in Python2 and Python3
+       Via Stack Overflow: https://stackoverflow.com/a/22679982/9458191
+    """
+    try:
+        basestring
+    except NameError:
+        basestring = str
+    return isinstance(test_value, basestring)

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -84,7 +84,7 @@ def is_string(test_value):
        Via Stack Overflow: https://stackoverflow.com/a/22679982/9458191
     """
     try:
-        from builtins import basestring
-    except ImportError:
-        basestring = str
-    return isinstance(test_value, basestring)
+        python_string = basestring
+    except NameError:
+        python_string = str
+    return isinstance(test_value, python_string)

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -1,5 +1,6 @@
 import sys
 from builtins import object
+
 from pympler.asizeof import asizeof as getsize  # noqa
 from tqdm import tqdm
 

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -1,6 +1,5 @@
 import sys
 from builtins import object
-
 from pympler.asizeof import asizeof as getsize  # noqa
 from tqdm import tqdm
 
@@ -84,7 +83,7 @@ def is_string(test_value):
        Via Stack Overflow: https://stackoverflow.com/a/22679982/9458191
     """
     try:
-        basestring
-    except NameError:
+        from builtins import basestring
+    except ImportError:
         basestring = str
     return isinstance(test_value, basestring)

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
-from past.builtins import basestring
 
 from featuretools import variable_types
 from featuretools.entityset.timedelta import Timedelta
+from featuretools.utils import is_string
 
 
 def _check_timedelta(td, entity_id=None, related_entity_id=None):
@@ -51,7 +51,7 @@ def _check_timedelta(td, entity_id=None, related_entity_id=None):
         if td.entity is not None and related_entity_id is not None and td.entity == related_entity_id:
             raise ValueError("Timedelta entity {} same as passed related entity {}".format(td.entity, related_entity_id))
         return td
-    elif not isinstance(td, (basestring, tuple, int, float)):
+    elif not (is_string(td) or isinstance(td, (tuple, int, float))):
         raise ValueError("Unable to parse timedelta: {}".format(td))
 
     # TODO: allow observations from an entity in string

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -4,7 +4,8 @@ from builtins import object
 
 import numpy as np
 import pandas as pd
-from past.builtins import basestring
+
+from featuretools.utils import is_string
 
 
 class Variable(object):
@@ -25,7 +26,7 @@ class Variable(object):
     _default_pandas_dtype = object
 
     def __init__(self, id, entity, name=None):
-        assert isinstance(id, basestring), "Variable id must be a string"
+        assert is_string(id), "Variable id must be a string"
         self.id = id
         self._name = name
         self.entity_id = entity.id


### PR DESCRIPTION
This PR replaces the python2 style `isinstance(value, basestring)` with a utils function `is_string(value)`. It replaces the import `from past.builtins import basestring` with our own function `from featuretools.utils import is_string`. The only other use of `past.builtins` is in `serialization.py` where we import `unicode`.

This is related to #255 and the associated issue #254.