### PR TITLE
Update python versions to match docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
         - image: themattrix/tox
     steps:
       - checkout
-      - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0
+      - run: pyenv local 2.7.15 3.5.6 3.6.6
       - run: make installdeps
       - run: tox && make lint && codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
         - image: themattrix/tox
     steps:
       - checkout
-      - run: pyenv local 2.7.15 3.5.6 3.6.6, 3.7.0
+      - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0
       - run: make installdeps
       - run: tox && make lint && codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,7 @@ jobs:
     docker:
         - image: themattrix/tox
     steps:
-      - run: apt update && apt install git -y
       - checkout
-      - run: pyenv local 2.7.13 3.5.2 3.6.0
+      - run: pyenv local 2.7.15 3.5.6 3.6.6, 3.7.0
       - run: make installdeps
       - run: tox && make lint && codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = {env:TOXBUILD:false}
-envlist = clean,py27,py35,py36,py37
+envlist = clean,py27,py35,py36
 
 [testenv]
 commands= py.test --cov=featuretools

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = {env:TOXBUILD:false}
-envlist = clean,py27,py35,py36
+envlist = clean,py27,py35,py36,py37
 
 [testenv]
 commands= py.test --cov=featuretools


### PR DESCRIPTION
Due to [upstream changes](https://github.com/themattrix/docker-pyenv), our circle ci config is out of date. We now test

- Python 2.7.15 (up from 2.7.13)
- Python 3.5.6 (up from 3.5.2)
- Python 3.6.6 (up from 3.6.0) and
- ~~Python 3.7.0 (previously untested)~~ [pyarrow does not support 3.7](https://issues.apache.org/jira/browse/ARROW-1661)

We can also remove the line `apt update && apt install git -y` which installs git.


