### PR TITLE
Add tests for Entity methods

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -111,10 +111,6 @@ class Entity(object):
         # do one last conversion of data once we've inferred
         self.convert_all_variable_data(inferred_variable_types)
 
-        # todo check the logic of this. can index not be in variable types?
-        if self.index is not None and self.index not in inferred_variable_types:
-            self.add_variable(self.index, vtypes.Index)
-
         # make sure index is at the beginning
         index_variable = [v for v in self.variables
                           if v.id == self.index][0]
@@ -534,28 +530,6 @@ class Entity(object):
                             break
 
         self.entityset.reset_metadata()
-
-    def add_variable(self, new_id, type=None, data=None):
-        """Add variable to entity
-
-        Args:
-            new_id (str) : Id of variable to be added.
-            type (Variable) : Class of variable.
-            data (pd.Series) : Variable's data to be placed in entity's dataframe
-        """
-        if new_id in [v.id for v in self.variables]:
-            logger.warning("Not adding duplicate variable: %s", new_id)
-            return
-        if data is not None:
-            self.df[new_id] = data
-
-        if type is None:
-            assert new_id in self.df.columns, "Must provide data to infer type"
-            existing_columns = [c for c in self.df.columns if c != new_id]
-            type = self.infer_variable_types(ignore=existing_columns)[new_id]
-
-        new_v = type(new_id, entity=self)
-        self.variables.append(new_v)
 
     def delete_variable(self, variable_id):
         """

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -550,8 +550,8 @@ class Entity(object):
             self.df[new_id] = data
 
         if type is None:
-            assert data in self.df.columns, "Must provide data to infer type"
-            existing_columns = [c for c in self.df.columns if c.id != new_id]
+            assert new_id in self.df.columns, "Must provide data to infer type"
+            existing_columns = [c for c in self.df.columns if c != new_id]
             type = self.infer_variable_types(ignore=existing_columns)[new_id]
 
         new_v = type(new_id, entity=self)

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -82,16 +82,3 @@ def test_update_data(es):
     with pytest.raises(ValueError) as excinfo:
         es['customers'].update_data(df)
     assert 'Updated dataframe contains 13 columns, expecting 12' in str(excinfo)
-
-
-def test_add_variable(es):
-
-    es['customers'].add_variable('age')
-    assert es['customers'].shape[1] == 12
-
-    with pytest.raises(AssertionError) as excinfo:
-        es['customers'].add_variable('new')
-    assert 'Must provide data to infer type' in str(excinfo)
-
-    es['customers'].add_variable('new', data=[1, 2, 3])
-    assert es['customers'].variable_types['new'] == variable_types.Numeric

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -82,3 +82,16 @@ def test_update_data(es):
     with pytest.raises(ValueError) as excinfo:
         es['customers'].update_data(df)
     assert 'Updated dataframe contains 13 columns, expecting 12' in str(excinfo)
+
+
+def test_add_variable(es):
+
+    es['customers'].add_variable('age')
+    assert es['customers'].shape[1] == 12
+
+    with pytest.raises(AssertionError) as excinfo:
+        es['customers'].add_variable('new')
+    assert 'Must provide data to infer type' in str(excinfo)
+
+    es['customers'].add_variable('new', data=[1, 2, 3])
+    assert es['customers'].variable_types['new'] == variable_types.Numeric

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -72,5 +72,13 @@ def test_parents(es):
 
 
 def test_update_data(es):
-    # TODO: write test for this method, since it has new functionality
-    pass
+    df = es['customers'].df.copy()
+    df['new'] = [1, 2, 3]
+
+    with pytest.raises(ValueError) as excinfo:
+        es['customers'].update_data(df.drop(columns=['cohort']))
+    assert 'Updated dataframe is missing new cohort column' in str(excinfo)
+
+    with pytest.raises(ValueError) as excinfo:
+        es['customers'].update_data(df)
+    assert 'Updated dataframe contains 13 columns, expecting 12' in str(excinfo)

--- a/featuretools/tests/entityset_tests/test_timedelta.py
+++ b/featuretools/tests/entityset_tests/test_timedelta.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 from toolz import merge
@@ -5,6 +6,7 @@ from toolz import merge
 from ..testing_utils import make_ecommerce_entityset
 
 from featuretools.entityset import Timedelta
+from featuretools.entityset.timedelta import add_td
 from featuretools.exceptions import NotEnoughData
 from featuretools.primitives import Count  # , SlidingMean
 from featuretools.utils.wrangle import _check_timedelta
@@ -154,3 +156,18 @@ def test_deltas_week(es):
     delta_days = Timedelta(7, "d")
 
     assert all_times[0] + delta_days == all_times[0] + delta_week
+
+
+def test_deltas_year():
+    start_list = pd.to_datetime(['2014-01-01', '2016-01-01'])
+    start_array = np.array(start_list)
+    new_time_1 = add_td(start_list, 2, 'Y')
+    new_time_2 = add_td(start_array, 2, 'Y')
+    values = [2016, 2018]
+    for i, value in enumerate(values):
+        assert new_time_1.dt.year.values[i] == value
+        assert np.datetime_as_string(new_time_2[i])[:4] == str(value)
+
+    with pytest.raises(ValueError) as excinfo:
+        add_td(start_list, 2, 'M')
+    assert 'Invalid Unit' in str(excinfo)


### PR DESCRIPTION
This PR adds three tests and fixes the `add_variable` method for Entity.

+ Fixes a faulty assertion and expected column types in `entity.add_variable`
+ Test `entity.add_variable`
+ Adds tests for two value errors in `entity.update_data`
+ Test the previously untested `elif unit == 'Y'` block in `add_td`