### PR TITLE
Handle no child data when calculating aggregation features with multiple arguments

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -378,7 +378,7 @@ class PandasBackend(ComputationalBackend):
 
         # handle where
         where = test_feature.where
-        if where is not None:
+        if where is not None and not base_frame.empty:
             base_frame = base_frame.loc[base_frame[where.get_name()]]
 
         # when no child data, just add all the features to frame with nan

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -376,15 +376,16 @@ class PandasBackend(ComputationalBackend):
         if not len(features):
             return frame
 
+        # handle where
+        where = test_feature.where
+        if where is not None:
+            base_frame = base_frame.loc[base_frame[where.get_name()]]
+
         # when no child data, just add all the features to frame with nan
         if base_frame.empty:
             for f in features:
                 frame[f.get_name()] = np.nan
         else:
-            where = test_feature.where
-            if where is not None:
-                base_frame = base_frame.loc[base_frame[where.get_name()]]
-
             relationship_path = self.entityset.find_backward_path(entity.id,
                                                                   child_entity.id)
 

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -13,7 +13,6 @@ from featuretools import Timedelta
 from featuretools.computational_backends.pandas_backend import PandasBackend
 from featuretools.primitives import (
     And,
-    Trend,
     Count,
     DirectFeature,
     Equals,
@@ -516,15 +515,14 @@ def test_empty_child_dataframe():
     es.entity_from_dataframe(entity_id="child", dataframe=child_df, index="id", time_index="time_index")
     es.add_relationship(ft.Relationship(es["parent"]["id"], es["child"]["parent_id"]))
 
-
     # create regular agg
     count = Count(es["child"]['id'], es["parent"])
 
-    # create a feature  with where
+    # create a agg with where
     where = ft.Feature(es["child"]["value"]) == 1
     count_where = Count(es["child"]['id'], es["parent"], where=where)
 
-    # create a aggregation feature that requires multiple arguments
+    # create agg feature that requires multiple arguments
     trend = Trend([es["child"]['value'], es["child"]['time_index']], es["parent"])
 
     # cutoff time before all rows

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -519,18 +519,20 @@ def test_empty_child_dataframe():
     # create regular agg
     count = Count(es["child"]['id'], es["parent"])
 
-    # create a agg with where
-    where = ft.Feature(es["child"]["value"]) == 1
-    count_where = Count(es["child"]['id'], es["parent"], where=where)
-
     # create agg feature that requires multiple arguments
     trend = Trend([es["child"]['value'], es["child"]['time_index']], es["parent"])
 
+    # create aggs with where
+    where = ft.Feature(es["child"]["value"]) == 1
+    count_where = Count(es["child"]['id'], es["parent"], where=where)
+    trend_where = Trend([es["child"]['value'], es["child"]['time_index']], es["parent"], where=where)
+
     # cutoff time before all rows
-    fm = ft.calculate_feature_matrix(entityset=es, features=[count, count_where, trend], cutoff_time=pd.Timestamp("12/31/2017"))
-    names = [count.get_name(), count_where.get_name(), trend.get_name()]
-    assert_array_equal(fm[names], [[0, 0, np.nan]])
+    fm = ft.calculate_feature_matrix(entityset=es, features=[count, count_where, trend, trend_where], cutoff_time=pd.Timestamp("12/31/2017"))
+    names = [count.get_name(), count_where.get_name(), trend.get_name(), trend_where.get_name()]
+    assert_array_equal(fm[names], [[0, 0, np.nan, np.nan]])
 
     # cutoff time after all rows, but where clause filters all rows
-    fm2 = ft.calculate_feature_matrix(entityset=es, features=[count_where], cutoff_time=pd.Timestamp("1/4/2018"))
-    assert_array_equal(fm2[[count_where.get_name()]], [[0]])
+    fm2 = ft.calculate_feature_matrix(entityset=es, features=[count_where, trend_where], cutoff_time=pd.Timestamp("1/4/2018"))
+    names = [count_where.get_name(), trend_where.get_name()]
+    assert_array_equal(fm2[names], [[0, np.nan]])

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
 
 from ..testing_utils import make_ecommerce_entityset
 
@@ -526,7 +527,10 @@ def test_empty_child_dataframe():
     trend = Trend([es["child"]['value'], es["child"]['time_index']], es["parent"])
 
     # cutoff time before all rows
-    ft.calculate_feature_matrix(entityset=es, features=[count, count_where, trend], cutoff_time=pd.Timestamp("12/31/2017"))
+    fm = ft.calculate_feature_matrix(entityset=es, features=[count, count_where, trend], cutoff_time=pd.Timestamp("12/31/2017"))
+    names = [count.get_name(), count_where.get_name(), trend.get_name()]
+    assert_array_equal(fm[names], [[0, 0, np.nan]])
 
     # cutoff time after all rows, but where clause filters all rows
-    ft.calculate_feature_matrix(entityset=es, features=[count, count_where, trend], cutoff_time=pd.Timestamp("1/4/2018"))
+    fm2 = ft.calculate_feature_matrix(entityset=es, features=[count_where], cutoff_time=pd.Timestamp("1/4/2018"))
+    assert_array_equal(fm2[[count_where.get_name()]], [[0]])


### PR DESCRIPTION
This pull requests updates how we handle calculating aggregation features when there is no child data. We fixed this for aggregations with where features in #258, but this fixes it for when there are multiple arguments to the agg feature.

This PR fixes the second issue reported in #252 