### PR TITLE
(WIP) Handling return type when creating features from DatetimeTimeIndex

### DIFF
--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -11,7 +11,7 @@ from featuretools.utils.wrangle import (
     _check_time_against_column,
     _check_timedelta
 )
-from featuretools.variable_types import Variable
+from featuretools.variable_types import Variable, Datetime, DatetimeTimeIndex
 
 logger = logging.getLogger('featuretools')
 
@@ -100,6 +100,10 @@ class PrimitiveBase(object):
         while return_type is None:
             feature = feature.base_features[0]
             return_type = feature.return_type
+
+            if isinstance(return_type, DatetimeTimeIndex):
+                return_type = Datetime
+
 
         return return_type
 


### PR DESCRIPTION
This PR fixes the issue reported in #265. 

That issue surfaced as a calculation error, but the the underlying problem was incorrectly stacking features that shouldn’t exist. This PR updates the return type so the invalid feature doesn’t get created. 