### PR TITLE
Update tests for python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
         - image: themattrix/tox
     steps:
       - checkout
-      - run: pyenv local 2.7.15 3.5.6 3.6.6
+      - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0
       - run: make installdeps
       - run: tox && make lint && codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/featuretools
     docker:
-        - image: themattrix/tox
+        - image: painless/tox:latest
     steps:
       - checkout
       - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/featuretools
     docker:
-        - image: painless/tox:latest
+        - image: themattrix/tox
     steps:
       - checkout
       - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -313,7 +313,7 @@ def test_training_window_recent_time_index(entityset):
     old_df.index = old_df.index.astype("int")
     old_df["id"] = old_df["id"].astype(int)
 
-    df = pd.concat([old_df, to_add_df])
+    df = pd.concat([old_df, to_add_df], sort=True)
 
     # convert back after
     df.index = df.index.astype("category")

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,9 @@ test=pytest
 [tool:pytest]
 addopts = -m "not requires_training_data and not requires_credentials"
 python_files = featuretools/tests/*
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
 [flake8]
 exclude = docs/*
 ignore = E501 # line too long error

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
          'Programming Language :: Python :: 2.7',
          'Programming Language :: Python :: 3',
          'Programming Language :: Python :: 3.5',
-         'Programming Language :: Python :: 3.6'
+         'Programming Language :: Python :: 3.6',
+         'Programming Language :: Python :: 3.7'
     ],
     install_requires=open('requirements.txt').readlines(),
     setup_requires=open('setup-requirements.txt').readlines(),

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ mock==2.0.0
 pytest-xdist==1.23.2
 pytest-cov==2.6.0
 pyarrow>=0.10.0; python_version != '3.7'
-fastparquet>=0.10.0; python_version == '3.7'
+fastparquet>=0.1.6; python_version == '3.7'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
-pytest==3.5.1
+pytest==3.8.2
 mock==2.0.0
-pytest-xdist==1.20.1
-pytest-cov==2.5.1
-pyarrow>=0.9.0
+pytest-xdist==1.23.2
+pytest-cov==2.6.0
+pyarrow>=0.10.0; python_version != '3.7'
+fastparquet>=0.10.0; python_version == '3.7'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
-pytest==3.8.2
+pytest==3.5.1
 mock==2.0.0
-pytest-xdist==1.23.2
-pytest-cov==2.6.0
-pyarrow>=0.10.0; python_version != '3.7'
-fastparquet>=0.1.6; python_version == '3.7'
+pytest-xdist==1.20.1
+pytest-cov==2.5.1
+fastparquet>=0.1.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-pytest==3.5.1
+pytest==3.8.2
 mock==2.0.0
-pytest-xdist==1.20.1
-pytest-cov==2.5.1
+pytest-xdist==1.23.2
+pytest-cov==2.6.0
 fastparquet>=0.1.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = {env:TOXBUILD:false}
-envlist = clean,py27,py35,py36
+envlist = clean,py27,py35,py36,py37
 
 [testenv]
 commands= py.test --cov=featuretools


### PR DESCRIPTION
- CircleCi will now run tests in python 3.7
- use `fastparquet` instead of `pyarrow` for tests because `pyarrow` does not currently support python 3.7
- fix warning for `pd.concat`
- updated test_requirements.txt package versions to most recent. 
 - ignore `DeprecationWarning` and `PendingDeprecationWarning` in pytest