### PR TITLE
Remove redundant relationships parameter from Entity constructor

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -41,7 +41,7 @@ class Entity(object):
 
     def __init__(self, id, df, entityset, variable_types=None,
                  index=None, time_index=None, secondary_time_index=None,
-                 last_time_index=None, encoding=None, relationships=None,
+                 last_time_index=None, encoding=None,
                  already_sorted=False, created_index=None, verbose=False):
         """ Create Entity
 
@@ -62,8 +62,6 @@ class Entity(object):
                 instance across all child entities.
             encoding (str, optional)) : If None, will use 'ascii'. Another option is 'utf-8',
                 or any encoding supported by pandas.
-            relationships (list): List of known relationships to other entities,
-                used for inferring variable types.
 
         """
         assert is_string(id), "Entity id must be a string"
@@ -86,7 +84,10 @@ class Entity(object):
             if ti not in cols:
                 cols.append(ti)
 
-        relationships = relationships or []
+        relationships = [r for r in entityset.relationships
+                         if r.parent_entity.id == id or
+                         r.child_entity.id == id]
+
         link_vars = [v.id for rel in relationships for v in [rel.parent_variable, rel.child_variable]
                      if v.entity.id == self.id]
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1206,10 +1206,6 @@ class EntitySet(object):
             for c in parse_date_cols:
                 variable_types[c] = vtypes.Datetime
 
-        current_relationships = [r for r in self.relationships
-                                 if r.parent_entity.id == entity_id or
-                                 r.child_entity.id == entity_id]
-
         for c in dataframe.columns:
             if not is_string(c):
                 raise ValueError("All column names must be strings (Column {} is not a string)".format(c))
@@ -1227,7 +1223,6 @@ class EntitySet(object):
                         secondary_time_index=secondary_time_index,
                         last_time_index=last_time_index,
                         encoding=encoding,
-                        relationships=current_relationships,
                         already_sorted=already_sorted,
                         created_index=created_index)
         self.entity_dict[entity.id] = entity


### PR DESCRIPTION
This PR removes the  relationships parameter from Entity constructor. The information in it can be determined from the EntitySet argument, so this isn't needed. 