### PR TITLE
Improve time index validation

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1200,8 +1200,9 @@ class EntitySet(object):
         elif index is None:
             index = dataframe.columns[0]
 
-        elif time_index is not None and time_index not in dataframe.columns:
+        if time_index is not None and time_index not in dataframe.columns:
             raise LookupError('Time index not found in dataframe')
+
         if parse_date_cols is not None:
             for c in parse_date_cols:
                 variable_types[c] = vtypes.Datetime

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -222,17 +222,25 @@ def test_unknown_index():
     assert entityset['test_entity'].df['id'].tolist() == list(range(3))
 
 
-def test_bad_index_variables():
+def test_doesnt_remake_index():
     # more variables
     df = pd.DataFrame({'id': [0, 1, 2], 'category': ['a', 'b', 'a']})
-    vtypes = {'id': variable_types.Categorical,
-              'category': variable_types.Categorical}
 
-    with pytest.raises(LookupError):
+    with pytest.raises(RuntimeError, match="Cannot make index: index variable already present"):
         entityset = EntitySet(id='test')
         entityset.entity_from_dataframe(entity_id='test_entity',
                                         index='id',
-                                        variable_types=vtypes,
+                                        make_index=True,
+                                        dataframe=df)
+
+
+def test_bad_time_index_variable():
+    df = pd.DataFrame({'category': ['a', 'b', 'a']})
+
+    with pytest.raises(LookupError, match="Time index not found in dataframe"):
+        entityset = EntitySet(id='test')
+        entityset.entity_from_dataframe(entity_id='test_entity',
+                                        index="id",
                                         dataframe=df,
                                         time_index='time')
 


### PR DESCRIPTION
Minor fix converting an `elif` to `if`. In the current code, if the code paths related to index were taken, the `elif` to handle the time index wouldn't get called. 

Our test case for this didn't check error message so it was passing. This has been updated. Also added another test related to another unchecked message. 