### PR TITLE
Encode features with "unknown" class in categorical

### DIFF
--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -5,20 +5,23 @@ from featuretools.variable_types.variable import Discrete
 
 
 def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
-                    to_encode=None, inplace=False, verbose=False):
+                    to_encode=None, inplace=False, verbose=False,
+                    unknown_token='unknown'):
     """Encode categorical features
 
         Args:
             feature_matrix (pd.DataFrame): Dataframe of features.
             features (list[PrimitiveBase]): Feature definitions in feature_matrix.
             top_n (pd.DataFrame): Number of top values to include.
-            include_unknown (pd.DataFrame): Add feature encoding an unkwown class.
+            include_unknown (pd.DataFrame): Add feature encoding an unknown class.
                 defaults to True
             to_encode (list[str]): List of feature names to encode.
                 features not in this list are unencoded in the output matrix
                 defaults to encode all necessary features.
             inplace (bool): Encode feature_matrix in place. Defaults to False.
             verbose (str): Print progress info.
+            unknown_token (str): token used to replace unknown class in categorical column.
+               defaults to 'unknown'. Must be changed in 'unknown' is one of the classes.
 
         Returns:
             (pd.Dataframe, list) : encoded feature_matrix, encoded features
@@ -110,7 +113,10 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
             X[add.get_name()] = (X[f.get_name()] == label).astype(int)
 
         if include_unknown:
-            unknown = f.isin(unique).NOT().rename(f.get_name() + " = unknown")
+            assert(unknown_token not in list(X[f.get_name()].unique())), \
+                f""""%s" category in categorical "%s". This will cause duplicated columns.
+                        Please supply different unknown_token""" % (unknown_token, f.get_name())
+            unknown = f.isin(unique).NOT().rename(f.get_name() + " = %s" % unknown_token)
             encoded.append(unknown)
             X[unknown.get_name()] = (~X[f.get_name()].isin(unique)).astype(int)
 

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -5,8 +5,7 @@ from featuretools.variable_types.variable import Discrete
 
 
 def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
-                    to_encode=None, inplace=False, verbose=False,
-                    unknown_token='unknown'):
+                    to_encode=None, inplace=False, verbose=False):
     """Encode categorical features
 
         Args:
@@ -113,10 +112,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
             X[add.get_name()] = (X[f.get_name()] == label).astype(int)
 
         if include_unknown:
-            assert(unknown_token not in list(X[f.get_name()].unique())), \
-                f""""%s" category in categorical "%s". This will cause duplicated columns.
-                        Please supply different unknown_token""" % (unknown_token, f.get_name())
-            unknown = f.isin(unique).NOT().rename(f.get_name() + " = %s" % unknown_token)
+            unknown = f.isin(unique).NOT().rename(f.get_name() + " is unknown")
             encoded.append(unknown)
             X[unknown.get_name()] = (~X[f.get_name()].isin(unique)).astype(int)
 

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -19,8 +19,6 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
                 defaults to encode all necessary features.
             inplace (bool): Encode feature_matrix in place. Defaults to False.
             verbose (str): Print progress info.
-            unknown_token (str): token used to replace unknown class in categorical column.
-               defaults to 'unknown'. Must be changed in 'unknown' is one of the classes.
 
         Returns:
             (pd.Dataframe, list) : encoded feature_matrix, encoded features

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -3,7 +3,7 @@ import pytest
 
 from ..testing_utils import make_ecommerce_entityset
 
-from featuretools import calculate_feature_matrix, EntitySet, dfs
+from featuretools import calculate_feature_matrix, dfs, EntitySet
 from featuretools.primitives import IdentityFeature
 from featuretools.synthesis import encode_features
 

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -122,11 +122,8 @@ def test_encode_unknown_features():
     es.entity_from_dataframe(entity_id='a', dataframe=df, index='index', make_index=True)
     features, feature_defs = dfs(entityset=es, target_entity='a')
 
-    # Test to make sure caught
-    with pytest.raises(AssertionError):
-        features_enc, feature_defs_enc = encode_features(features, feature_defs,
-                                                         include_unknown=True)
     # Specify unknown token for replacement
     features_enc, feature_defs_enc = encode_features(features, feature_defs,
-                                                     include_unknown=True, unknown_token='un')
-    assert 'category = un' in list(features_enc.columns)
+                                                     include_unknown=True)
+    assert list(features_enc.columns) == ['category = unknown', 'category = e', 'category = d',
+                                          'category = c', 'category = b', 'category is unknown']

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -3,7 +3,7 @@ import pytest
 
 from ..testing_utils import make_ecommerce_entityset
 
-from featuretools import calculate_feature_matrix, dfs, EntitySet
+from featuretools import EntitySet, calculate_feature_matrix, dfs
 from featuretools.primitives import IdentityFeature
 from featuretools.synthesis import encode_features
 


### PR DESCRIPTION
Addresses #280 by checking for `"unknown"` class in a categorical column to be encoded and adding an `unknown_token` parameter to specify the string used to stand in for the unknown class. If "unknown" is present in the column and `unknown_token="unknown"`, an `AssertionError` is raised telling the user to change the `unknown_token` parameter. 