### PR TITLE
change to fullargsspec

### DIFF
--- a/docs/source/upload.py
+++ b/docs/source/upload.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
-from builtins import input
-from builtins import str
+
 import sys
+from builtins import input, str
 from subprocess import call
 
 from conf import release

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -7,10 +7,11 @@ from .primitive_base import PrimitiveBase
 import featuretools.primitives
 from featuretools.utils import is_string
 
-# python 3.7 deprecated getargspec, import allows backwards compability
 try:
+    # python 3.7 deprecated getargspec
     from inspect import getfullargspec as getargspec
 except ImportError:
+    # python 2.7 - 3.6 backwards compatibility import
     from inspect import getargspec
 
 

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,4 +1,4 @@
-from inspect import getargspec, isclass
+from inspect import getfullargspec, isclass
 
 import pandas as pd
 
@@ -97,7 +97,7 @@ def ensure_compatible_dtype(left, right):
 
 def inspect_function_args(new_class, function, uses_calc_time):
     # inspect function to see if there are keyword arguments
-    argspec = getargspec(function)
+    argspec = getfullargspec(function)
     kwargs = {}
     if argspec.defaults is not None:
         lowest_kwargs_position = len(argspec.args) - len(argspec.defaults)

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,4 +1,8 @@
-from inspect import getfullargspec, isclass
+from inspect import isclass
+try:
+    from inspect import getargspec as getargspec
+except ImportError:
+    from inspect import getfullargspec as getargspec
 
 import pandas as pd
 
@@ -97,7 +101,7 @@ def ensure_compatible_dtype(left, right):
 
 def inspect_function_args(new_class, function, uses_calc_time):
     # inspect function to see if there are keyword arguments
-    argspec = getfullargspec(function)
+    argspec = getargspec(function)
     kwargs = {}
     if argspec.defaults is not None:
         lowest_kwargs_position = len(argspec.args) - len(argspec.defaults)

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -13,9 +13,6 @@ except ImportError:
     from inspect import getargspec
 
 
-
-
-
 def apply_dual_op_from_feat(f, array_1, array_2=None):
     left = f.left
     right = f.right

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,8 +1,4 @@
 from inspect import isclass
-try:
-    from inspect import getfullargspec as getargspec
-except ImportError:
-    from inspect import getargspec
 
 import pandas as pd
 
@@ -10,6 +6,14 @@ from .primitive_base import PrimitiveBase
 
 import featuretools.primitives
 from featuretools.utils import is_string
+
+try:
+    from inspect import getfullargspec as getargspec
+except ImportError:
+    from inspect import getargspec
+
+
+
 
 
 def apply_dual_op_from_feat(f, array_1, array_2=None):

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -7,6 +7,7 @@ from .primitive_base import PrimitiveBase
 import featuretools.primitives
 from featuretools.utils import is_string
 
+# python 3.7 deprecated getargspec, import allows backwards compability
 try:
     from inspect import getfullargspec as getargspec
 except ImportError:

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,8 +1,8 @@
 from inspect import isclass
 try:
-    from inspect import getargspec as getargspec
-except ImportError:
     from inspect import getfullargspec as getargspec
+except ImportError:
+    from inspect import getargspec
 
 import pandas as pd
 


### PR DESCRIPTION
- This fixes the following warning in python 3.7
> primitives/utils.py:100 
DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
```