### PR TITLE
Refactor EntitySet.find_path(...)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,55 @@
 version: 2
 jobs:
-  build:
+  "python-2.7":
     working_directory: ~/featuretools
     docker:
         - image: themattrix/tox
     steps:
       - checkout
-      - run: pyenv local 2.7.15 3.5.6 3.6.6 3.7.0
+      - run: pyenv local 2.7.15
       - run: make installdeps
-      - run: tox && make lint && codecov
+      - run: make lint
+      - run: tox -e py27
+
+  "python-3.5":
+    working_directory: ~/featuretools
+    docker:
+        - image: themattrix/tox
+    steps:
+      - checkout
+      - run: pyenv local 3.5.6
+      - run: make installdeps
+      - run: make lint
+      - run: tox -e py35
+
+
+  "python-3.6":
+    working_directory: ~/featuretools
+    docker:
+        - image: themattrix/tox
+    steps:
+      - checkout
+      - run: pyenv local 3.6.6
+      - run: make installdeps
+      - run: make lint
+      - run: tox -e py36
+
+  "python-3.7":
+    working_directory: ~/featuretools
+    docker:
+        - image: themattrix/tox
+    steps:
+      - checkout
+      - run: pyenv local 3.7.0
+      - run: make installdeps
+      - run: make lint
+      - run: tox -e clean,py37 && codecov
+
+workflows:
+  version: 2
+  test_all_python_versions:
+    jobs:
+      - "python-2.7"
+      - "python-3.5"
+      - "python-3.6"
+      - "python-3.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,7 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 2.7.15
-<<<<<<< HEAD
-      - run: make installdeps && make lint
-=======
       - run: make installdeps lint
->>>>>>> master
       - run: tox -e py27
 
   "python-3.5":
@@ -21,11 +17,7 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.5.6
-<<<<<<< HEAD
-      - run: make installdeps && make lint
-=======
       - run: make installdeps lint
->>>>>>> master
       - run: tox -e py35
 
   "python-3.6":
@@ -35,13 +27,8 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.6.6
-<<<<<<< HEAD
-      - run: make installdeps && make lint
-      - run: tox -e py36
-=======
       - run: make installdeps lint
       - run: tox -e clean,py36 && codecov
->>>>>>> master
 
   "python-3.7":
     working_directory: ~/featuretools
@@ -50,13 +37,8 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.7.0
-<<<<<<< HEAD
-      - run: make installdeps && make lint
-      - run: tox -e clean,py37 && codecov
-=======
       - run: make installdeps lint
       - run: tox -e py37
->>>>>>> master
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 2.7.15
-      - run: make installdeps
-      - run: make lint
+      - run: make installdeps && make lint
       - run: tox -e py27
 
   "python-3.5":
@@ -18,10 +17,8 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.5.6
-      - run: make installdeps
-      - run: make lint
+      - run: make installdeps && make lint
       - run: tox -e py35
-
 
   "python-3.6":
     working_directory: ~/featuretools
@@ -30,8 +27,7 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.6.6
-      - run: make installdeps
-      - run: make lint
+      - run: make installdeps && make lint
       - run: tox -e py36
 
   "python-3.7":
@@ -41,8 +37,7 @@ jobs:
     steps:
       - checkout
       - run: pyenv local 3.7.0
-      - run: make installdeps
-      - run: make lint
+      - run: make installdeps && make lint
       - run: tox -e clean,py37 && codecov
 
 workflows:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -485,9 +485,8 @@ class EntitySet(object):
                 queue.append(current_path + [r])
 
             visited.add(next_entity_id)
-
-        raise ValueError(("No path from {} to {}. Check that all entities are \
-            connected by relationships".format(start_entity_id, goal_entity_id)))
+        e = "No path from {} to {}. Check that all entities are connected by relationships".format(start_entity_id, goal_entity_id)
+        raise ValueError(e)
 
     def find_forward_path(self, start_entity_id, goal_entity_id):
         """Find a forward path between a start and goal entity

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -439,7 +439,7 @@ class EntitySet(object):
             else:
                 return []
 
-        # Search for bath using BFS to get the shortest path.
+        # Search for path using BFS to get the shortest path.
         # Start by initializing the queue with all relationships from start entity
         queue = [[r] for r in self.get_forward_relationships(start_entity_id)] + \
                 [[r] for r in self.get_backward_relationships(start_entity_id)]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -486,9 +486,8 @@ class EntitySet(object):
 
             visited.add(next_entity_id)
 
-        raise ValueError(("No path from {} to {}! Check that all entities "
-                          .format(start_entity_id, goal_entity_id)),
-                         "are connected by relationships")
+        raise ValueError(("No path from {} to {}. Check that all entities are \
+            connected by relationships".format(start_entity_id, goal_entity_id)))
 
     def find_forward_path(self, start_entity_id, goal_entity_id):
         """Find a forward path between a start and goal entity

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -426,12 +426,12 @@ class EntitySet(object):
         Returns:
             List of relationships that go from start entity to goal
                 entity. None is returned if no path exists.
-            If include_forward_distance is True,
+            If include_num_forward is True,
                 returns a tuple of (relationship_list, forward_distance).
 
         See Also:
-            :func:`BaseEntitySet.find_forward_path`
-            :func:`BaseEntitySet.find_backward_path`
+            :func:`EntitySet.find_forward_path`
+            :func:`EntitySet.find_backward_path`
         """
         if start_entity_id == goal_entity_id:
             if include_num_forward:

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -120,9 +120,7 @@ def test_find_path_same_entity(es):
     assert len(path) == 0
 
 
-def test_find_path_no_path_found():
-    # don't use fixture because we modify the relationships
-    es = make_ecommerce_entityset()
+def test_find_path_no_path_found(es):
     es.relationships = []
     error_text = "No path from products to customers. Check that all entities are connected by relationships"
     with pytest.raises(ValueError, match=error_text):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -108,6 +108,25 @@ def test_find_path(es):
     assert path[2].parent_entity.id == 'customers'
 
 
+def test_find_path_same_entity(es):
+    path, forward = es.find_path('products', 'products',
+                                 include_num_forward=True)
+    assert len(path) == 0
+    assert forward == 0
+
+    # also test include_num_forward==False
+    path = es.find_path('products', 'products',
+                        include_num_forward=False)
+    assert len(path) == 0
+
+
+def test_find_path_no_path_found(es):
+    es.relationships = []
+    error_text = "No path from products to customers. Check that all entities are connected by relationships"
+    with pytest.raises(ValueError, match=error_text):
+        es.find_path('products', 'customers')
+
+
 def test_raise_key_error_missing_entity(es):
     with pytest.raises(KeyError):
         es["this entity doesn't exist"]

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -120,7 +120,9 @@ def test_find_path_same_entity(es):
     assert len(path) == 0
 
 
-def test_find_path_no_path_found(es):
+def test_find_path_no_path_found():
+    # don't use fixture because we modify the relationships
+    es = make_ecommerce_entityset()
     es.relationships = []
     error_text = "No path from products to customers. Check that all entities are connected by relationships"
     with pytest.raises(ValueError, match=error_text):


### PR DESCRIPTION
This PR simply rewrites the bread first search algorithm we use to find a path between two nodes. 

Our existing approach defined an new class to do it, which resulted in bloated code. 

The changes here remove that extra class and adds comments to create cleaner and more understandable code. 
