### PR TITLE
Move pympler to test requirements

### DIFF
--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+from pympler.asizeof import asizeof
 
 from ..testing_utils import feature_with_name, make_ecommerce_entityset
 
@@ -30,7 +31,6 @@ from featuretools.primitives import (
     make_agg_primitive
 )
 from featuretools.synthesis import DeepFeatureSynthesis
-from featuretools.utils.gen_utils import getsize
 from featuretools.utils.pickle_utils import save_obj_pickle
 from featuretools.variable_types import Numeric
 
@@ -623,7 +623,7 @@ def test_pickle_features(es):
         assert feat_1.entityset == feat_2.entityset
 
     # file is smaller than entityset in memory
-    assert os.path.getsize(filepath) < getsize(es)
+    assert os.path.getsize(filepath) < asizeof(es)
 
     # file is smaller than entityset pickled
     assert os.path.getsize(filepath) < os.path.getsize(es_filepath)
@@ -660,7 +660,7 @@ def test_pickle_features_with_custom_primitive(es):
         assert feat_1.entityset == feat_2.entityset
 
     # file is smaller than entityset in memory
-    assert os.path.getsize(filepath) < getsize(es)
+    assert os.path.getsize(filepath) < asizeof(es)
 
     # file is smaller than entityset pickled
     assert os.path.getsize(filepath) < os.path.getsize(es_filepath)

--- a/featuretools/tests/feature_function_tests/test_primitive_base.py
+++ b/featuretools/tests/feature_function_tests/test_primitive_base.py
@@ -1,9 +1,9 @@
 import pytest
+from pympler.asizeof import asizeof
 
 from ..testing_utils import make_ecommerce_entityset
 
 from featuretools.primitives import Feature, IdentityFeature, Last, Mode, Sum
-from featuretools.utils.gen_utils import getsize
 from featuretools.variable_types import Datetime, Numeric
 
 
@@ -27,9 +27,9 @@ def test_copy_features_does_not_copy_entityset(es):
                                  where=IdentityFeature(es['log']['value']) == 2,
                                  use_previous='4 days')
     features = [agg, agg_where, agg_use_previous, agg_use_previous_where]
-    in_memory_size = getsize(locals())
+    in_memory_size = asizeof(locals())
     copied = [f.copy() for f in features]
-    new_in_memory_size = getsize(locals())
+    new_in_memory_size = asizeof(locals())
     assert new_in_memory_size < 2 * in_memory_size
 
     for f, c in zip(features, copied):

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -1,6 +1,5 @@
 import sys
 
-from pympler.asizeof import asizeof as getsize  # noqa
 from tqdm import tqdm
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ toolz>=0.8.2
 pyyaml>=3.12
 cloudpickle>=0.4.0
 future>=0.16.0
-pympler>=0.5
 dask>=0.19.4
 distributed>=1.23.3
 psutil>=5.4.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 pytest==3.8.2
 mock==2.0.0
+pympler==0.6
 pytest-xdist==1.23.2
 pytest-cov==2.6.0
 fastparquet>=0.1.6


### PR DESCRIPTION
* Remove pympler import in `gen_utils` file and import it directly in testing files that use it
* Move pympler requirement from general requirements to testing requirements.