### PR TITLE
v0.4.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,22 @@
 
 Changelog
 ---------
+**v0.4.0** Oct 31, 2018
+    * Remove ft.utils.gen_utils.getsize and make pympler a test requirement (:pr:`299`)
+    * Update requirements.txt (:pr:`298`)
+    * Refactor EntitySet.find_path(...) (:pr:`295`)
+    * Clean up unused methods (:pr:`293`)
+    * Remove unused parents property of Entity (:pr:`283`)
+    * Removed relationships parameter (:pr:`284`)
+    * Improve time index validation (:pr:`285`)
+    * Encode features with "unknown" class in categorical (:pr:`287`)
+    * Allow where clauses on direct features in Deep Feature Synthesis (:pr:`279`)
+    * Change to fullargsspec (:pr:`288`)
+    * Parallel verbose fixes (:pr:`282`)
+    * Update tests for python 3.7 (:pr:`277`)
+    * Check duplicate rows cutoff times (:pr:`276`)
+    * Load retail demo data using compressed file (:pr:`271`)
+
 **v0.3.1** Sept 28, 2018
     * Handling time rewrite (:pr:`245`)
     * Update deep_feature_synthesis.py (:pr:`249`)

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -12,4 +12,4 @@ from .utils.pickle_utils import *
 from .utils.time_utils import *
 import featuretools.demo
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class build_ext(_build_ext):
 
 setup(
     name='featuretools',
-    version='0.3.1',
+    version='0.4.0',
     packages=find_packages(),
     description='a framework for automated feature engineering',
     url='http://featuretools.com',


### PR DESCRIPTION
**v0.4.0** Oct 31, 2018
* Remove ft.utils.gen_utils.getsize and make pympler a test requirement (#299)
* Update requirements.txt (#298)
* Refactor EntitySet.find_path(...) (#295)
* Clean up unused methods (#293)
* Remove unused parents property of Entity (#283)
* Removed relationships parameter (#284)
* Improve time index validation (#285)
* Encode features with "unknown" class in categorical (#287)
* Allow where clauses on direct features in Deep Feature Synthesis (#279)
* Change to fullargsspec (#288)
* Parallel verbose fixes (#282)
* Update tests for python 3.7 (#277)
* Check duplicate rows cutoff times (#276)
* Load retail demo data using compressed file (#271)