### PR TITLE
Feature stability between versions documentation

### DIFF
--- a/docs/source/guides/deployment.rst
+++ b/docs/source/guides/deployment.rst
@@ -10,7 +10,7 @@ Deployment of machine learning models requires repeating feature engineering ste
 Saving Features
 ***************
 
-First, let's build some generate some training and test data in the same format. We use a random seed to generate different data for the test.
+First, let's build some generate some training and test data in the same format. We use a random seed to generate different data for the test. **Note**: features created in one version of Featuretools are not guaranteed to work in another. This means the features might need to be re-created after upgrading Featuretools.
 
 .. ipython:: python
 

--- a/featuretools/utils/pickle_utils.py
+++ b/featuretools/utils/pickle_utils.py
@@ -2,7 +2,7 @@ import cloudpickle
 
 
 def save_features(features, filepath):
-    """Saves the features list to a specificed filepath. 
+    """Saves the features list to a specificed filepath.
 
     Args:
         features (list[:class:`.PrimitiveBase`]): List of Feature definitions.

--- a/featuretools/utils/pickle_utils.py
+++ b/featuretools/utils/pickle_utils.py
@@ -50,6 +50,10 @@ def load_features(filepath):
 
     Returns:
         features (list[:class:`.PrimitiveBase`]): Feature definitions list.
+        
+    Note:
+        Features saved in one version of Featuretools are not guaranteed to work in another.
+        After upgrading Featuretools, features may need to be generated again.
 
     Example:
         .. ipython:: python

--- a/featuretools/utils/pickle_utils.py
+++ b/featuretools/utils/pickle_utils.py
@@ -2,13 +2,18 @@ import cloudpickle
 
 
 def save_features(features, filepath):
-    """Saves the features list to a specificed filepath.
+    """Saves the features list to a specificed filepath. 
 
     Args:
         features (list[:class:`.PrimitiveBase`]): List of Feature definitions.
 
         filepath (str): The location of where to save the pickled features list
              filepath. This must include the name of the file.
+             
+    Note:
+        Features saved in one version of Featuretools are not guaranteed to work in another.
+        After upgrading Featuretools, features may need to be generated again.
+        
     Example:
         .. ipython:: python
             :suppress:

--- a/featuretools/utils/pickle_utils.py
+++ b/featuretools/utils/pickle_utils.py
@@ -9,11 +9,11 @@ def save_features(features, filepath):
 
         filepath (str): The location of where to save the pickled features list
              filepath. This must include the name of the file.
-             
+
     Note:
         Features saved in one version of Featuretools are not guaranteed to work in another.
         After upgrading Featuretools, features may need to be generated again.
-        
+
     Example:
         .. ipython:: python
             :suppress:
@@ -50,7 +50,7 @@ def load_features(filepath):
 
     Returns:
         features (list[:class:`.PrimitiveBase`]): Feature definitions list.
-        
+
     Note:
         Features saved in one version of Featuretools are not guaranteed to work in another.
         After upgrading Featuretools, features may need to be generated again.


### PR DESCRIPTION
Temporarily addresses #315 and #311 by alerting users that features created in one version of Featuretools are not necessarily compatible with other versions. A longer-term fix would be advised. 