### PR TITLE
Handle return type when creating features from Id variables

### DIFF
--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -12,8 +12,10 @@ from featuretools.utils.wrangle import (
     _check_timedelta
 )
 from featuretools.variable_types import (
+    Categorical,
     Datetime,
     DatetimeTimeIndex,
+    Id,
     Numeric,
     NumericTimeIndex,
     Variable
@@ -113,6 +115,8 @@ class PrimitiveBase(object):
                 return_type = Datetime
             elif return_type == NumericTimeIndex:
                 return_type = Numeric
+            elif return_type == Id:
+                return_type = Categorical
 
         return return_type
 

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -102,12 +102,14 @@ class PrimitiveBase(object):
     # P TODO: this should get refactored to return_type
     @property
     def variable_type(self):
+        from . import direct_feature
         feature = self
         return_type = self.return_type
 
         while return_type is None:
-            feature = feature.base_features[0]
-            return_type = feature.return_type
+            # get return type of first base feature
+            base_feature = feature.base_features[0]
+            return_type = base_feature.return_type
 
             # only the original time index should exist
             # so make this feature's return type just a Datetime
@@ -115,8 +117,13 @@ class PrimitiveBase(object):
                 return_type = Datetime
             elif return_type == NumericTimeIndex:
                 return_type = Numeric
-            elif return_type == Id:
+
+            # direct features should keep the Id return type, but all other features should get
+            # converted to Categorical
+            if not isinstance(feature, direct_feature.DirectFeature) and return_type == Id:
                 return_type = Categorical
+
+            feature = base_feature
 
         return return_type
 

--- a/featuretools/tests/feature_function_tests/test_primitive_base.py
+++ b/featuretools/tests/feature_function_tests/test_primitive_base.py
@@ -4,7 +4,7 @@ from pympler.asizeof import asizeof
 from ..testing_utils import make_ecommerce_entityset
 
 from featuretools.primitives import Feature, IdentityFeature, Last, Mode, Sum
-from featuretools.variable_types import Datetime, Numeric
+from featuretools.variable_types import Categorical, Datetime, Numeric
 
 
 @pytest.fixture(scope='module')
@@ -106,3 +106,8 @@ def test_return_type_inference_datetime_time_index(es):
 def test_return_type_inference_numeric_time_index(es_numeric):
     last = Last(es_numeric["log"]["datetime"], es_numeric["customers"])
     assert last.variable_type == Numeric
+
+
+def test_return_type_inference_id(es_numeric):
+    mode = Mode(es_numeric["log"]["session_id"], es_numeric["customers"])
+    assert mode.variable_type == Categorical


### PR DESCRIPTION
When we create a feature from an Id variable, its return type should get converted to a Categorical because it is no longer an Id variable unless it is a direct feature. 

This will remove features like `CUM_SUM(SUM(order_products.total) by MODE(order_products.product_id))`

Same as #266, but for Id variable types