### PR TITLE
Update properties of cumulative transform primitives

### DIFF
--- a/featuretools/primitives/cum_transform_feature.py
+++ b/featuretools/primitives/cum_transform_feature.py
@@ -19,7 +19,7 @@ class CumFeature(TransformPrimitive):
     allow_where = True
     agg_feature = None
     rolling_function = True
-    needs_all_values = True
+    uses_full_entity = True
 
     # Note: Any row with a nan value in the group by feature will have a
     # NaN value in the cumfeat

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -617,6 +617,18 @@ def test_cum_sum_use_previous_and_where_absolute(es):
         assert v == cvalues[i]
 
 
+def test_cum_handles_uses_full_entity(es):
+    log_value_feat = es['log']['value']
+    for primitive in [CumSum, CumMean, CumMax, CumMax]:
+        features = [primitive(log_value_feat, es['log']['session_id'])]
+        pandas_backend = PandasBackend(es, features)
+        df_1 = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2], time_last=None)
+        df_2 = pandas_backend.calculate_all_features(instance_ids=[2], time_last=None)
+
+        # check that the value for instance id 2 matches
+        assert (df_2.loc[2] == df_1.loc[2]).all()
+
+
 def test_cum_mean(es):
     log_value_feat = es['log']['value']
     cum_mean = CumMean(log_value_feat, es['log']['session_id'])

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -618,15 +618,18 @@ def test_cum_sum_use_previous_and_where_absolute(es):
 
 
 def test_cum_handles_uses_full_entity(es):
-    log_value_feat = es['log']['value']
-    for primitive in [CumSum, CumMean, CumMax, CumMin]:
-        features = [primitive(log_value_feat, es['log']['session_id'])]
-        pandas_backend = PandasBackend(es, features)
+    def check(feature):
+        pandas_backend = PandasBackend(es, [feature])
         df_1 = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2], time_last=None)
         df_2 = pandas_backend.calculate_all_features(instance_ids=[2], time_last=None)
 
         # check that the value for instance id 2 matches
         assert (df_2.loc[2] == df_1.loc[2]).all()
+
+    for primitive in [CumSum, CumMean, CumMax, CumMin]:
+        check(primitive(es['log']['value'], es['log']['session_id']))
+
+    check(CumCount(es['log']['id'], es['log']['session_id']))
 
 
 def test_cum_mean(es):

--- a/featuretools/tests/feature_function_tests/test_transform_features.py
+++ b/featuretools/tests/feature_function_tests/test_transform_features.py
@@ -619,7 +619,7 @@ def test_cum_sum_use_previous_and_where_absolute(es):
 
 def test_cum_handles_uses_full_entity(es):
     log_value_feat = es['log']['value']
-    for primitive in [CumSum, CumMean, CumMax, CumMax]:
+    for primitive in [CumSum, CumMean, CumMax, CumMin]:
         features = [primitive(log_value_feat, es['log']['session_id'])]
         pandas_backend = PandasBackend(es, features)
         df_1 = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2], time_last=None)


### PR DESCRIPTION
Cumulative transform primitives had an incorrectly define property. It was named `needs_all_values` when it should have been `uses_full_entity`. 

This PR fixes that and adds a test.

fixes #317  reported by @MarekHauzr