### PR TITLE
Handle primitives with same function being applied to same column

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -429,7 +429,7 @@ class PandasBackend(ComputationalBackend):
                     if callable(func):
                         # make sure func has a unique name due to how pandas names aggregations
                         func.__name__ = f.name
-                        funcname = func.__name__
+                        funcname = f.name
 
                     to_agg[variable_id].append(func)
                     # this is used below to rename columns that pandas names for us

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -427,6 +427,8 @@ class PandasBackend(ComputationalBackend):
                     func = f.get_function()
                     funcname = func
                     if callable(func):
+                        # make sure func has a unique name due to how pandas names aggregations
+                        func.__name__ = f.name
                         funcname = func.__name__
 
                     to_agg[variable_id].append(func)

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -8,7 +8,7 @@ import pytest
 
 from ..testing_utils import feature_with_name, make_ecommerce_entityset
 
-from featuretools import calculate_feature_matrix, dfs
+import featuretools as ft
 from featuretools.primitives import (
     AggregationPrimitive,
     Count,
@@ -148,7 +148,7 @@ def test_count_null_and_make_agg_primitive(es):
                                name="count", stack_on_self=False,
                                cls_attributes={"generate_name": count_generate_name})
     count_null = Count(es['log']['value'], es['sessions'], count_null=True)
-    feature_matrix = calculate_feature_matrix([count_null], entityset=es)
+    feature_matrix = ft.calculate_feature_matrix([count_null], entityset=es)
     values = [5, 4, 1, 2, 3, 2]
     assert (values == feature_matrix[count_null.get_name()]).all()
 
@@ -241,7 +241,6 @@ def test_stack_expanding(es, test_primitive, parent_entity):
 #     assert grandparent.can_apply(parent_entity, 'customers')
 
 def test_init_and_name(es):
-    from featuretools import calculate_feature_matrix
     session = es['sessions']
     log = es['log']
 
@@ -263,12 +262,12 @@ def test_init_and_name(es):
 
                 # try to get name and calculate
                 instance.get_name()
-                calculate_feature_matrix([instance], entityset=es).head(5)
+                ft.calculate_feature_matrix([instance], entityset=es).head(5)
 
 
 def test_time_since_last(es):
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
-    fm = calculate_feature_matrix([f],
+    fm = ft.calculate_feature_matrix([f],
                                   entityset=es,
                                   instance_ids=[0, 1, 2],
                                   cutoff_time=datetime(2015, 6, 8))
@@ -280,7 +279,7 @@ def test_time_since_last(es):
 
 def test_median(es):
     f = Median(es["log"]["value_many_nans"], es["customers"])
-    fm = calculate_feature_matrix([f],
+    fm = ft.calculate_feature_matrix([f],
                                   entityset=es,
                                   instance_ids=[0, 1, 2],
                                   cutoff_time=datetime(2015, 6, 8))
@@ -300,7 +299,7 @@ def test_time_since_last_custom(es):
                                        name="time_since_last",
                                        uses_calc_time=True)
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
-    fm = calculate_feature_matrix([f],
+    fm = ft.calculate_feature_matrix([f],
                                   entityset=es,
                                   instance_ids=[0, 1, 2],
                                   cutoff_time=datetime(2015, 6, 8))
@@ -328,7 +327,7 @@ def test_custom_primitive_time_as_arg(es):
                                        uses_calc_time=True)
     assert TimeSinceLast.name == "time_since_last"
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
-    fm = calculate_feature_matrix([f],
+    fm = ft.calculate_feature_matrix([f],
                                   entityset=es,
                                   instance_ids=[0, 1, 2],
                                   cutoff_time=datetime(2015, 6, 8))
@@ -358,10 +357,10 @@ def test_custom_primitive_multiple_inputs(es):
                                     input_types=[Numeric, Datetime],
                                     return_type=Numeric)
 
-    fm, features = dfs(entityset=es,
-                       target_entity="sessions",
-                       agg_primitives=[MeanSunday],
-                       trans_primitives=[])
+    fm, features = ft.dfs(entityset=es,
+                          target_entity="sessions",
+                          agg_primitives=[MeanSunday],
+                          trans_primitives=[])
     mean_sunday_value = pd.Series([None, None, None, 2.5, 7, None])
     iterator = zip(fm["MEAN_SUNDAY(log.value, datetime)"], mean_sunday_value)
     for x, y in iterator:
@@ -369,11 +368,11 @@ def test_custom_primitive_multiple_inputs(es):
 
     es.add_interesting_values()
     mean_sunday_value_priority_0 = pd.Series([None, None, None, 2.5, 0, None])
-    fm, features = dfs(entityset=es,
-                       target_entity="sessions",
-                       agg_primitives=[MeanSunday],
-                       trans_primitives=[],
-                       where_primitives=[MeanSunday])
+    fm, features = ft.dfs(entityset=es,
+                          target_entity="sessions",
+                          agg_primitives=[MeanSunday],
+                          trans_primitives=[],
+                          where_primitives=[MeanSunday])
     where_feat = "MEAN_SUNDAY(log.value, datetime WHERE priority_level = 0)"
     for x, y in zip(fm[where_feat], mean_sunday_value_priority_0):
         assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -268,9 +268,9 @@ def test_init_and_name(es):
 def test_time_since_last(es):
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
     fm = ft.calculate_feature_matrix([f],
-                                  entityset=es,
-                                  instance_ids=[0, 1, 2],
-                                  cutoff_time=datetime(2015, 6, 8))
+                                     entityset=es,
+                                     instance_ids=[0, 1, 2],
+                                     cutoff_time=datetime(2015, 6, 8))
 
     correct = [131376600, 131289600, 131287800]
     # note: must round to nearest second
@@ -280,9 +280,9 @@ def test_time_since_last(es):
 def test_median(es):
     f = Median(es["log"]["value_many_nans"], es["customers"])
     fm = ft.calculate_feature_matrix([f],
-                                  entityset=es,
-                                  instance_ids=[0, 1, 2],
-                                  cutoff_time=datetime(2015, 6, 8))
+                                     entityset=es,
+                                     instance_ids=[0, 1, 2],
+                                     cutoff_time=datetime(2015, 6, 8))
 
     correct = [1, 3, np.nan]
     np.testing.assert_equal(fm[f.get_name()].values, correct)
@@ -291,8 +291,9 @@ def test_median(es):
 def test_agg_same_method_name(es):
     """
         Pandas relies on the function name when calculating aggregations. This means if a two
-        primitives are  applied to the same column, pandas can't differentiate them. We have a
-        work around to this based on the name property that we test here.
+        primitives with the same function name are applied to the same column, pandas
+        can't differentiate them. We have a work around to this based on the name property
+        that we test here.
     """
 
     # test with normally defined functions
@@ -311,7 +312,8 @@ def test_agg_same_method_name(es):
     f_sum = Sum(es["log"]["value"], es["customers"])
     f_max = Max(es["log"]["value"], es["customers"])
 
-    fm = ft.calculate_feature_matrix([f_max], entityset=es)
+    fm = ft.calculate_feature_matrix([f_sum, f_max], entityset=es)
+    assert fm.columns.tolist() == [f_sum.get_name(), f_max.get_name()]
 
     # test with lambdas
     Sum = make_agg_primitive(lambda x: x.sum(), input_types=[Numeric],
@@ -322,8 +324,7 @@ def test_agg_same_method_name(es):
     f_sum = Sum(es["log"]["value"], es["customers"])
     f_max = Max(es["log"]["value"], es["customers"])
     fm = ft.calculate_feature_matrix([f_sum, f_max], entityset=es)
-
-
+    assert fm.columns.tolist() == [f_sum.get_name(), f_max.get_name()]
 
 
 def test_time_since_last_custom(es):
@@ -338,9 +339,9 @@ def test_time_since_last_custom(es):
                                        uses_calc_time=True)
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
     fm = ft.calculate_feature_matrix([f],
-                                  entityset=es,
-                                  instance_ids=[0, 1, 2],
-                                  cutoff_time=datetime(2015, 6, 8))
+                                     entityset=es,
+                                     instance_ids=[0, 1, 2],
+                                     cutoff_time=datetime(2015, 6, 8))
 
     correct = [131376600, 131289600, 131287800]
     # note: must round to nearest second
@@ -366,9 +367,9 @@ def test_custom_primitive_time_as_arg(es):
     assert TimeSinceLast.name == "time_since_last"
     f = TimeSinceLast(es["log"]["datetime"], es["customers"])
     fm = ft.calculate_feature_matrix([f],
-                                  entityset=es,
-                                  instance_ids=[0, 1, 2],
-                                  cutoff_time=datetime(2015, 6, 8))
+                                     entityset=es,
+                                     instance_ids=[0, 1, 2],
+                                     cutoff_time=datetime(2015, 6, 8))
 
     correct = [131376600, 131289600, 131287800]
     # note: must round to nearest second

--- a/featuretools/tests/feature_function_tests/test_agg_feats.py
+++ b/featuretools/tests/feature_function_tests/test_agg_feats.py
@@ -288,6 +288,44 @@ def test_median(es):
     np.testing.assert_equal(fm[f.get_name()].values, correct)
 
 
+def test_agg_same_method_name(es):
+    """
+        Pandas relies on the function name when calculating aggregations. This means if a two
+        primitives are  applied to the same column, pandas can't differentiate them. We have a
+        work around to this based on the name property that we test here.
+    """
+
+    # test with normally defined functions
+    def custom_primitive(x):
+        return x.sum()
+
+    Sum = make_agg_primitive(custom_primitive, input_types=[Numeric],
+                             return_type=Numeric, name="sum")
+
+    def custom_primitive(x):
+        return x.max()
+
+    Max = make_agg_primitive(custom_primitive, input_types=[Numeric],
+                             return_type=Numeric, name="max")
+
+    f_sum = Sum(es["log"]["value"], es["customers"])
+    f_max = Max(es["log"]["value"], es["customers"])
+
+    fm = ft.calculate_feature_matrix([f_max], entityset=es)
+
+    # test with lambdas
+    Sum = make_agg_primitive(lambda x: x.sum(), input_types=[Numeric],
+                             return_type=Numeric, name="sum")
+    Max = make_agg_primitive(lambda x: x.max(), input_types=[Numeric],
+                             return_type=Numeric, name="max")
+
+    f_sum = Sum(es["log"]["value"], es["customers"])
+    f_max = Max(es["log"]["value"], es["customers"])
+    fm = ft.calculate_feature_matrix([f_sum, f_max], entityset=es)
+
+
+
+
 def test_time_since_last_custom(es):
     def time_since_last(values, time=None):
         time_since = time - values.iloc[0]


### PR DESCRIPTION
Pandas relies on the function name when calculating aggregations. This means if a two primitives with same function name are applied to the same column, pandas can't differentiate them. We have a work around to this based on the name property that we test here.