### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyyaml>=3.12
 cloudpickle>=0.4.0
 future>=0.16.0
 dask>=0.19.4
-distributed>=1.23.3
+distributed>=1.24.2
 psutil>=5.4.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pytest==3.8.2
 mock==2.0.0
-pympler==0.6
+pympler==0.5
 pytest-xdist==1.23.2
 pytest-cov==2.6.0
 fastparquet>=0.1.6


### PR DESCRIPTION
This updates the required versions of two dependencies, distributed and pympler.  This PR downgrades Pympler from 0.6 to 0.5 because 0.6 is not available on conda.  This PR upgrades the distributed requirement to 1.24.2, which includes the bugfix that addresses #313 