### PR TITLE
v0.4.1

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,20 @@
 
 Changelog
 ---------
+**v0.4.1** Nov 29, 2018
+    * Resolve bug preventing using first column as index by default (:pr:`308`)
+    * Handle return type when creating features from Id variables (:pr:`318`)
+    * Make id an optional parameter of EntitySet constructor (:pr:`324`)
+    * Handle primitives with same function being applied to same column (:pr:`321`)
+    * Update requirements (:pr:`328`)
+    * Clean up DFS arguments (:pr:`319`)
+    * Clean up Pandas Backend (:pr:`302`)
+    * Update properties of cumulative transform primitives (:pr:`320`)
+    * Feature stability between versions documentation (:pr:`316`)
+    * Add download count to GitHub readme (:pr:`310`)
+    * Fixed #297 update tests to check error strings (:pr:`303`)
+    * Remove usage of fixtures in agg primitive tests (:pr:`325`)
+
 **v0.4.0** Oct 31, 2018
     * Remove ft.utils.gen_utils.getsize and make pympler a test requirement (:pr:`299`)
     * Update requirements.txt (:pr:`298`)

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -12,4 +12,4 @@ from .utils.pickle_utils import *
 from .utils.time_utils import *
 import featuretools.demo
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class build_ext(_build_ext):
 
 setup(
     name='featuretools',
-    version='0.4.0',
+    version='0.4.1',
     packages=find_packages(),
     description='a framework for automated feature engineering',
     url='http://featuretools.com',


### PR DESCRIPTION
**v0.4.1** Nov 29, 2018
    * Resolve bug preventing using first column as index by default (#308)
    * Handle return type when creating features from Id variables (#318)
    * Make id an optional parameter of EntitySet constructor (#324)
    * Handle primitives with same function being applied to same column (#321)
    * Update requirements (#328)
    * Clean up DFS arguments (#319)
    * Clean up Pandas Backend (#302)
    * Update properties of cumulative transform primitives (#320)
    * Feature stability between versions documentation (#316)
    * Add download count to GitHub readme (#310)
    * Fixed #297 update tests to check error strings (#303)
    * Remove usage of fixtures in agg primitive tests (#325)