### PR TITLE
Clean up entity creation logic

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -249,17 +249,6 @@ Constructors
     Entity
     Relationship
 
-.. EntitySet attributes
-.. --------------------
-.. .. currentmodule:: featuretools.entityset
-.. .. autosummary::
-..     :toctree: generated/
-
-..     EntitySet.id
-..     EntitySet.name
-..     EntitySet.entities
-..     EntitySet.relationships
-
 EntitySet load and prepare data
 -------------------------------
 .. autosummary::
@@ -296,16 +285,6 @@ EntitySet query methods
     EntitySet.find_forward_path
     EntitySet.get_forward_entities
     EntitySet.get_backward_entities
-
-
-.. Entity attributes
-.. ----------------------
-.. .. autosummary::
-..     :toctree: generated/
-
-..     Entity.variables
-..     Entity.index
-..     Entity.time_index
 
 
 Entity methods

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -249,16 +249,16 @@ Constructors
     Entity
     Relationship
 
-EntitySet attributes
---------------------
-.. currentmodule:: featuretools.entityset
-.. autosummary::
-    :toctree: generated/
+.. EntitySet attributes
+.. --------------------
+.. .. currentmodule:: featuretools.entityset
+.. .. autosummary::
+..     :toctree: generated/
 
-    EntitySet.id
-    EntitySet.name
-    EntitySet.entities
-    EntitySet.relationships
+..     EntitySet.id
+..     EntitySet.name
+..     EntitySet.entities
+..     EntitySet.relationships
 
 EntitySet load and prepare data
 -------------------------------
@@ -298,14 +298,14 @@ EntitySet query methods
     EntitySet.get_backward_entities
 
 
-Entity attributes
-----------------------
-.. autosummary::
-    :toctree: generated/
+.. Entity attributes
+.. ----------------------
+.. .. autosummary::
+..     :toctree: generated/
 
-    Entity.variables
-    Entity.index
-    Entity.time_index
+..     Entity.variables
+..     Entity.index
+..     Entity.time_index
 
 
 Entity methods

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -69,25 +69,21 @@ class Entity(object):
         _validate_entity_params(id, df, time_index)
         created_index, index, df = _create_index(index, make_index, df)
 
-        self.data = {"df": df,
-                     "last_time_index": last_time_index,
-                     }
         self.encoding = encoding
         self._verbose = verbose
         self.created_index = created_index
         self.id = id
         self.entityset = entityset
+        self.data = {'df': df, 'last_time_index': last_time_index}
 
         variable_types = variable_types or {}
         secondary_time_index = secondary_time_index or {}
         self._create_variables(variable_types, index, time_index, secondary_time_index)
 
+        self.df = df[[v.id for v in self.variables]]
         self.set_index(index)
         self.set_time_index(time_index, already_sorted=already_sorted)
         self.set_secondary_time_index(secondary_time_index)
-        self.update_data(df=self.df,
-                         already_sorted=already_sorted,
-                         recalculate_last_time_indexes=False)
 
     def __repr__(self):
         repr_out = u"Entity: {}\n".format(self.id)

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -67,7 +67,7 @@ class Entity(object):
                 Otherwise, assume index exists in dataframe.
         """
         _validate_entity_params(id, df, time_index)
-        created_index, index, df = create_index(index, make_index, df)
+        created_index, index, df = _create_index(index, make_index, df)
         if index not in variable_types:
             variable_types[index] = vtypes.Index
 
@@ -675,7 +675,8 @@ def col_is_datetime(col):
     return False
 
 
-def create_index(index, make_index, df):
+def _create_index(index, make_index, df):
+    '''Handles index creation logic'''
     created_index = None
     if index is None:
         assert not make_index, "Must specify an index name if make_index is True"

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -66,15 +66,7 @@ class Entity(object):
                 dataframe, and create a new column of that name using integers the (0, len(dataframe)).
                 Otherwise, assume index exists in dataframe.
         """
-        assert is_string(id), "Entity id must be a string"
-        assert len(df.columns) == len(set(df.columns)), "Duplicate column names"
-        for c in df.columns:
-            if not is_string(c):
-                raise ValueError("All column names must be strings (Column {} "
-                                 "is not a string)".format(c))
-        if time_index is not None and time_index not in df.columns:
-            raise LookupError('Time index not found in dataframe')
-
+        _validate_entity_params(id, df, time_index)
         created_index, index, df = create_index(index, make_index, df)
         if index not in variable_types:
             variable_types[index] = vtypes.Index
@@ -699,3 +691,15 @@ def create_index(index, make_index, df):
         df.insert(0, index, range(0, len(df)))
         created_index = index
     return created_index, index, df
+
+
+def _validate_entity_params(id, df, time_index):
+    '''Validation checks for Entity inputs'''
+    assert is_string(id), "Entity id must be a string"
+    assert len(df.columns) == len(set(df.columns)), "Duplicate column names"
+    for c in df.columns:
+        if not is_string(c):
+            raise ValueError("All column names must be strings (Column {} "
+                             "is not a string)".format(c))
+    if time_index is not None and time_index not in df.columns:
+        raise LookupError('Time index not found in dataframe')

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -34,11 +34,6 @@ class Entity(object):
         :class:`.Relationship`, :class:`.Variable`, :class:`.EntitySet`
 
     """
-    id = None
-    variables = None
-    time_index = None
-    index = None
-
     def __init__(self, id, df, entityset, variable_types=None,
                  index=None, time_index=None, secondary_time_index=None,
                  last_time_index=None, encoding=None,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -116,9 +116,7 @@ class Entity(object):
 
         inferred_variable_types = self.infer_variable_types(ignore=list(variable_types.keys()),
                                                             link_vars=link_vars)
-
-        for var_id, desired_type in variable_types.items():
-            inferred_variable_types.update({var_id: desired_type})
+        inferred_variable_types.update(variable_types)
 
         self.variables = []
         for v in inferred_variable_types:

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -90,7 +90,7 @@ class Entity(object):
 
         variable_types = variable_types or {}
         secondary_time_index = secondary_time_index or {}
-        self.create_variables(variable_types, index, time_index, secondary_time_index)
+        self._create_variables(variable_types, index, time_index, secondary_time_index)
 
         self.set_index(index)
         self.set_time_index(time_index, already_sorted=already_sorted)
@@ -337,7 +337,7 @@ class Entity(object):
 
         return df
 
-    def create_variables(self, variable_types, index, time_index, secondary_time_index):
+    def _create_variables(self, variable_types, index, time_index, secondary_time_index):
         variables = []
         inferred_variable_types = self.infer_variable_types(variable_types,
                                                             time_index,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -75,11 +75,10 @@ class Entity(object):
         self.df = df[[v.id for v in self.variables]]
         self.set_index(index)
 
+        self.time_index = None
         if time_index:
             self.set_time_index(time_index, already_sorted=already_sorted)
-        else:
-            self.time_index = None
-            if not already_sorted:
+        elif not already_sorted:
                 self.df.sort_index(kind="mergesort", inplace=True)
         self.set_secondary_time_index(secondary_time_index)
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -69,12 +69,12 @@ class Entity(object):
         _validate_entity_params(id, df, time_index)
         created_index, index, df = _create_index(index, make_index, df)
 
-        self.encoding = encoding
-        self._verbose = verbose
-        self.created_index = created_index
         self.id = id
         self.entityset = entityset
         self.data = {'df': df, 'last_time_index': last_time_index}
+        self.created_index = created_index
+        self.encoding = encoding
+        self._verbose = verbose
 
         variable_types = variable_types or {}
         secondary_time_index = secondary_time_index or {}

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -36,8 +36,8 @@ class Entity(object):
     """
     def __init__(self, id, df, entityset, variable_types=None,
                  index=None, time_index=None, secondary_time_index=None,
-                 last_time_index=None, encoding=None,
-                 already_sorted=False, make_index=False, verbose=False):
+                 last_time_index=None, already_sorted=False, make_index=False,
+                 verbose=False):
         """ Create Entity
 
         Args:
@@ -55,8 +55,6 @@ class Entity(object):
                 in the dataframe to the time index column they are associated with.
             last_time_index (pd.Series): Time index of the last event for each
                 instance across all child entities.
-            encoding (str, optional)) : If None, will use 'ascii'. Another option is 'utf-8',
-                or any encoding supported by pandas.
             make_index (bool, optional) : If True, assume index does not exist as a column in
                 dataframe, and create a new column of that name using integers the (0, len(dataframe)).
                 Otherwise, assume index exists in dataframe.
@@ -68,7 +66,6 @@ class Entity(object):
         self.entityset = entityset
         self.data = {'df': df, 'last_time_index': last_time_index}
         self.created_index = created_index
-        self.encoding = encoding
         self._verbose = verbose
 
         variable_types = variable_types or {}

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -75,20 +75,9 @@ class Entity(object):
         if time_index is not None and time_index not in df.columns:
             raise LookupError('Time index not found in dataframe')
 
-        created_index = None
-        if index is None:
-            assert not make_index, "Must specify an index name if make_index is True"
-            logger.warning(("Using first column as index. ",
-                            "To change this, specify the index parameter"))
-            index = df.columns[0]
-        elif make_index and index in df.columns:
-            raise RuntimeError("Cannot make index: index variable already present")
-        elif make_index or index not in df.columns:
-            if index not in df.columns and not make_index:
-                logger.warning("index %s not found in dataframe, creating new "
-                               "integer column", index)
-            df.insert(0, index, range(0, len(df)))
-            created_index = index
+        created_index, index, df = create_index(index, make_index, df)
+        if index not in variable_types:
+            variable_types[index] = vtypes.Index
 
         self.data = {"df": df,
                      "last_time_index": last_time_index,
@@ -689,3 +678,21 @@ def col_is_datetime(col):
         else:
             return True
     return False
+
+
+def create_index(index, make_index, df):
+    created_index = None
+    if index is None:
+        assert not make_index, "Must specify an index name if make_index is True"
+        logger.warning(("Using first column as index. ",
+                        "To change this, specify the index parameter"))
+        index = df.columns[0]
+    elif make_index and index in df.columns:
+        raise RuntimeError("Cannot make index: index variable already present")
+    elif make_index or index not in df.columns:
+        if index not in df.columns and not make_index:
+            logger.warning("index %s not found in dataframe, creating new "
+                           "integer column", index)
+        df.insert(0, index, range(0, len(df)))
+        created_index = index
+    return created_index, index, df

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -79,7 +79,6 @@ class Entity(object):
         self.encoding = encoding
         self._verbose = verbose
         self.created_index = created_index
-        self.convert_all_variable_data(variable_types)
         self.id = id
         self.entityset = entityset
         variable_types = variable_types or {}
@@ -100,9 +99,8 @@ class Entity(object):
 
         inferred_variable_types = self.infer_variable_types(ignore=list(variable_types.keys()),
                                                             link_vars=link_vars)
+
         for var_id, desired_type in variable_types.items():
-            if isinstance(desired_type, tuple):
-                desired_type = desired_type[0]
             inferred_variable_types.update({var_id: desired_type})
 
         self.variables = []

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -70,6 +70,9 @@ class Entity(object):
             if not is_string(c):
                 raise ValueError("All column names must be strings (Column {} "
                                  "is not a string)".format(c))
+        if time_index is not None and time_index not in df.columns:
+            raise LookupError('Time index not found in dataframe')
+
         self.data = {"df": df,
                      "last_time_index": last_time_index,
                      }

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -361,12 +361,6 @@ class Entity(object):
             list[Variable]: A list of variables describing the
                 contents of the dataframe.
         """
-        # make sure time index is actually in the columns
-        secondary_time_index = secondary_time_index or {}
-        for ti, cols in secondary_time_index.items():
-            if ti not in cols:
-                cols.append(ti)
-
         link_relationships = [r for r in self.entityset.relationships
                               if r.parent_entity.id == self.id or
                               r.child_entity.id == self.id]
@@ -578,7 +572,7 @@ class Entity(object):
 
     def set_secondary_time_index(self, secondary_time_index):
         if secondary_time_index is not None:
-            for time_index in secondary_time_index:
+            for time_index, columns in secondary_time_index.items():
                 if self.df.empty:
                     time_to_check = vtypes.DEFAULT_DTYPE_VALUES[self[time_index]._default_pandas_dtype]
                 else:
@@ -591,6 +585,9 @@ class Entity(object):
                     raise TypeError("%s time index is %s type which differs from"
                                     " other entityset time indexes" %
                                     (self.id, time_type))
+                if time_index not in columns:
+                    columns.append(time_index)
+
         self.secondary_time_index = secondary_time_index or {}
 
     def _vals_to_series(self, instance_vals, variable_id):

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -669,21 +669,30 @@ def col_is_datetime(col):
 
 
 def _create_index(index, make_index, df):
-    '''Handles index creation logic'''
+    '''Handles index creation logic base on user input'''
     created_index = None
+
     if index is None:
+        # Case 1: user wanted to make index but did not specify column name
         assert not make_index, "Must specify an index name if make_index is True"
+        # Case 2: make_index not specified but no index supplied, use first column
         logger.warning(("Using first column as index. ",
                         "To change this, specify the index parameter"))
         index = df.columns[0]
     elif make_index and index in df.columns:
+        # Case 3: user wanted to make index but column already exists
         raise RuntimeError("Cannot make index: index variable already present")
-    elif make_index or index not in df.columns:
-        if index not in df.columns and not make_index:
+    elif index not in df.columns:
+        if not make_index:
+            # Case 4: user names index, it is not in df. does not specify
+            # make_index.  Make new index column and warn
             logger.warning("index %s not found in dataframe, creating new "
                            "integer column", index)
+        # Case 5: make_index with no errors or warnings
+        # (Case 4 also uses this code path)
         df.insert(0, index, range(0, len(df)))
         created_index = index
+    # Case 6: user specified index, which is already in df. No action needed.
     return created_index, index, df
 
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -67,7 +67,6 @@ class Entity(object):
         self.created_index = created_index
         self._verbose = verbose
 
-        variable_types = variable_types or {}
         secondary_time_index = secondary_time_index or {}
         self._create_variables(variable_types, index, time_index, secondary_time_index)
 
@@ -342,6 +341,7 @@ class Entity(object):
                 that each map to a list of columns that depend on that secondary time
         """
         variables = []
+        variable_types = variable_types or {}
         if index not in variable_types:
             variable_types[index] = vtypes.Index
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -404,7 +404,7 @@ class Entity(object):
             elif df[variable].dtype == "bool":
                 inferred_type = vtypes.Boolean
 
-            elif df[variable].dtype.name == "category":
+            elif pdtypes.is_categorical_dtype(df[variable].dtype):
                 inferred_type = vtypes.Categorical
 
             elif col_is_datetime(df[variable]):

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -68,8 +68,6 @@ class Entity(object):
         """
         _validate_entity_params(id, df, time_index)
         created_index, index, df = _create_index(index, make_index, df)
-        if index not in variable_types:
-            variable_types[index] = vtypes.Index
 
         self.data = {"df": df,
                      "last_time_index": last_time_index,
@@ -331,6 +329,9 @@ class Entity(object):
 
     def _create_variables(self, variable_types, index, time_index, secondary_time_index):
         variables = []
+        if index not in variable_types:
+            variable_types[index] = vtypes.Index
+
         inferred_variable_types = self.infer_variable_types(variable_types,
                                                             time_index,
                                                             secondary_time_index)

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -66,6 +66,10 @@ class Entity(object):
         """
         assert is_string(id), "Entity id must be a string"
         assert len(df.columns) == len(set(df.columns)), "Duplicate column names"
+        for c in df.columns:
+            if not is_string(c):
+                raise ValueError("All column names must be strings (Column {} "
+                                 "is not a string)".format(c))
         self.data = {"df": df,
                      "last_time_index": last_time_index,
                      }

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -464,7 +464,7 @@ class Entity(object):
         self.set_index(self.index)
         if self.time_index is not None:
             self.set_time_index(self.time_index, already_sorted=already_sorted)
-        elif already_sorted:
+        elif not already_sorted:
             self.df.sort_index(kind="mergesort", inplace=True)
         self.set_secondary_time_index(self.secondary_time_index)
         if recalculate_last_time_indexes and self.last_time_index is not None:

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -642,12 +642,11 @@ class Entity(object):
                         )
                     df = df[mask]
 
-        for secondary_time_index in self.secondary_time_index:
-                # should we use ignore time last here?
+        for secondary_time_index, columns in self.secondary_time_index.items():
+            # should we use ignore time last here?
             if time_last is not None and not df.empty:
                 mask = df[secondary_time_index] >= time_last
-                second_time_index_columns = self.secondary_time_index[secondary_time_index]
-                df.loc[mask, second_time_index_columns] = np.nan
+                df.loc[mask, columns] = np.nan
 
         return df
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1172,10 +1172,6 @@ class EntitySet(object):
             if not is_string(c):
                 raise ValueError("All column names must be strings (Column {} is not a string)".format(c))
 
-            if dataframe[c].dtype.name.find('category') > -1:
-                if c not in variable_types:
-                    variable_types[c] = vtypes.Categorical
-
         entity = Entity(entity_id,
                         dataframe,
                         self,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -34,11 +34,6 @@ class EntitySet(object):
         metadata
 
     """
-    id = None
-    entities = []
-    relationships = []
-    name = None
-
     def __init__(self, id=None, entities=None, relationships=None):
         """Creates EntitySet
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1141,12 +1141,6 @@ class EntitySet(object):
                 Defaults to False.
         """
         variable_types = variable_types or {}
-
-        # DFS TODO: confirm we want this if else block
-        if index is not None:
-            if index not in variable_types:
-                variable_types[index] = vtypes.Index
-
         entity = Entity(entity_id,
                         dataframe,
                         self,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -198,7 +198,6 @@ class EntitySet(object):
                 'index': e.index,
                 'time_index': e.time_index,
                 'secondary_time_index': e.secondary_time_index,
-                'encoding': e.encoding,
                 'variables': {
                     v.id: v.create_metadata_dict()
                     for v in e.variables
@@ -220,7 +219,6 @@ class EntitySet(object):
                                      index=entity['index'],
                                      time_index=entity['time_index'],
                                      secondary_time_index=entity['secondary_time_index'],
-                                     encoding=entity['encoding'],
                                      variable_types=variable_types)
             if entity['has_last_time_index']:
                 set_last_time_indexes = True
@@ -638,7 +636,6 @@ class EntitySet(object):
                               make_index=False,
                               time_index=None,
                               secondary_time_index=None,
-                              encoding=None,
                               already_sorted=False):
         """
         Load the data for a specified entity from a Pandas DataFrame.
@@ -665,9 +662,6 @@ class EntitySet(object):
 
             secondary_time_index (dict[str -> Variable]): Name of variable
                 containing time data to use a second time index for the entity.
-
-            encoding (str, optional): If None, will use 'ascii'. Another option is
-                'utf-8', or any encoding supported by pandas.
 
             already_sorted (bool, optional) : If True, assumes that input dataframe
                 is already sorted by time. Defaults to False.
@@ -696,13 +690,11 @@ class EntitySet(object):
                 es["transactions"].df
 
         """
-
         return self._import_from_dataframe(entity_id, dataframe.copy(), index=index,
                                            make_index=make_index,
                                            time_index=time_index,
                                            secondary_time_index=secondary_time_index,
                                            variable_types=variable_types,
-                                           encoding=encoding,
                                            already_sorted=already_sorted)
 
     def normalize_entity(self, base_entity_id, new_entity_id, index,
@@ -845,8 +837,7 @@ class EntitySet(object):
                                     time_index=new_entity_time_index,
                                     secondary_time_index=make_secondary_time_index,
                                     last_time_index=None,
-                                    variable_types=transfer_types,
-                                    encoding=base_entity.encoding)
+                                    variable_types=transfer_types)
 
         for v in additional_variables:
             self.entity_dict[base_entity_id].delete_variable(v)
@@ -1109,7 +1100,6 @@ class EntitySet(object):
                                time_index=None,
                                secondary_time_index=None,
                                last_time_index=None,
-                               encoding=None,
                                already_sorted=False):
         """
         Load the data for a specified entity from a pandas dataframe.
@@ -1129,9 +1119,6 @@ class EntitySet(object):
                 a Datetime or Numeric dtype.
             secondary_time_index (str, optional): Name of variable containing
                 time data to use a second time index for the entity.
-            encoding (str, optional) : If None, will use 'ascii'. Another option is 'utf-8',
-                or any encoding supported by pandas. Passed into underlying pandas.to_csv() calls,
-                so see Pandas documentation for more information.
             already_sorted (bool, optional) : If True, assumes that input dataframe is already sorted by time.
                 Defaults to False.
         """
@@ -1144,7 +1131,6 @@ class EntitySet(object):
                         time_index=time_index,
                         secondary_time_index=secondary_time_index,
                         last_time_index=last_time_index,
-                        encoding=encoding,
                         already_sorted=already_sorted,
                         make_index=make_index)
         self.entity_dict[entity.id] = entity

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1130,7 +1130,6 @@ class EntitySet(object):
             make_index (bool, optional) : If True, assume index does not exist as a column in
                 dataframe, and create a new column of that name using integers the (0, len(dataframe)).
                 Otherwise, assume index exists in dataframe.
-                An entity's variable_types dict maps string variable ids to types (:class:`.Variable`).
             time_index (str, optional) : Name of column to use as a time index for this entity. Must be
                 a Datetime or Numeric dtype.
             secondary_time_index (str, optional): Name of variable containing
@@ -1144,26 +1143,9 @@ class EntitySet(object):
         variable_types = variable_types or {}
 
         # DFS TODO: confirm we want this if else block
-        if index is None:
-            assert not make_index, "Must specify an index name if make_index is True"
-            logger.warning(("Using first column as index. ",
-                            "To change this, specify the index parameter"))
-            index = dataframe.columns[0]
-        else:
+        if index is not None:
             if index not in variable_types:
                 variable_types[index] = vtypes.Index
-
-        created_index = None
-
-        if make_index and index in dataframe.columns:
-            raise RuntimeError("Cannot make index: index variable already present")
-
-        if make_index or index not in dataframe.columns:
-            if not make_index:
-                logger.warning("index %s not found in dataframe, creating new integer column",
-                               index)
-            dataframe.insert(0, index, range(0, len(dataframe)))
-            created_index = index
 
         entity = Entity(entity_id,
                         dataframe,
@@ -1175,7 +1157,7 @@ class EntitySet(object):
                         last_time_index=last_time_index,
                         encoding=encoding,
                         already_sorted=already_sorted,
-                        created_index=created_index)
+                        make_index=make_index)
         self.entity_dict[entity.id] = entity
         self.reset_metadata()
         return self

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1165,9 +1165,6 @@ class EntitySet(object):
             dataframe.insert(0, index, range(0, len(dataframe)))
             created_index = index
 
-        if time_index is not None and time_index not in dataframe.columns:
-            raise LookupError('Time index not found in dataframe')
-
         entity = Entity(entity_id,
                         dataframe,
                         self,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -14,7 +14,7 @@ from .relationship import Relationship
 from .serialization import load_entity_data, write_entityset
 
 import featuretools.variable_types.variable as vtypes
-from featuretools.utils.gen_utils import is_string, make_tqdm_iterator
+from featuretools.utils.gen_utils import make_tqdm_iterator
 
 pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')
@@ -1167,10 +1167,6 @@ class EntitySet(object):
 
         if time_index is not None and time_index not in dataframe.columns:
             raise LookupError('Time index not found in dataframe')
-
-        for c in dataframe.columns:
-            if not is_string(c):
-                raise ValueError("All column names must be strings (Column {} is not a string)".format(c))
 
         entity = Entity(entity_id,
                         dataframe,

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -92,6 +92,6 @@ def test_update_data(es):
     df = es["customers"].df.copy(deep=True)
     df["signup_date"].iloc[0] = datetime(2011, 4, 11)
     es["customers"].update_data(df.copy(deep=True))
-    assert es["customers"].df["id"].iloc[0]== 0
+    assert es["customers"].df["id"].iloc[0] == 0
     es["customers"].update_data(df.copy(deep=True), already_sorted=True)
     assert es["customers"].df["id"].iloc[0] == 2

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import copy
+from datetime import datetime
 
 import pandas as pd
 import pytest
@@ -80,8 +80,18 @@ def test_update_data(es):
         es['customers'].update_data(df)
     assert 'Updated dataframe contains 13 columns, expecting 12' in str(excinfo)
 
-    es_copy = copy.deepcopy(es)
+    # test already_sorted on entity without time index
     df = es["sessions"].df.copy(deep=True)
     df["id"].iloc[1:3] = [2, 1]
-    es["sessions"].update_data(df)
-    assert es_copy.__eq__(es, deep=True)
+    es["sessions"].update_data(df.copy(deep=True))
+    assert es["sessions"].df["id"].iloc[1] == 1
+    es["sessions"].update_data(df.copy(deep=True), already_sorted=True)
+    assert es["sessions"].df["id"].iloc[1] == 2
+
+    # test already_sorted on entity with time index
+    df = es["customers"].df.copy(deep=True)
+    df["signup_date"].iloc[0] = datetime(2011, 4, 11)
+    es["customers"].update_data(df.copy(deep=True))
+    assert es["customers"].df["id"].iloc[0]== 0
+    es["customers"].update_data(df.copy(deep=True), already_sorted=True)
+    assert es["customers"].df["id"].iloc[0] == 2

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import copy
 
 import pandas as pd
 import pytest
@@ -78,3 +79,9 @@ def test_update_data(es):
     with pytest.raises(ValueError, match=error_text) as excinfo:
         es['customers'].update_data(df)
     assert 'Updated dataframe contains 13 columns, expecting 12' in str(excinfo)
+
+    es_copy = copy.deepcopy(es)
+    df = es["sessions"].df.copy(deep=True)
+    df["id"].iloc[1:3] = [2, 1]
+    es["sessions"].update_data(df)
+    assert es_copy.__eq__(es, deep=True)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -106,8 +106,7 @@ def test_add_relationship_errors_on_dtype_mismatch(entityset):
                                     dataframe=log_2_df,
                                     index='id',
                                     variable_types=log_variable_types,
-                                    time_index='datetime',
-                                    encoding='utf-8')
+                                    time_index='datetime')
 
     error_text = u'Unable to add relationship because id in customers is Pandas dtype category and session_id in log2 is Pandas dtype int64.'
     with pytest.raises(ValueError, match=error_text):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -582,6 +582,13 @@ def test_sets_time_when_adding_entity():
                                         time_index="signup_date")
 
 
+def test_checks_time_type_setting_time_index(entityset):
+    # set non time type as time index
+    error_text = 'log time index not recognized as numeric or datetime'
+    with pytest.raises(TypeError, match=error_text):
+        entityset['log'].set_time_index('purchased')
+
+
 def test_checks_time_type_setting_secondary_time_index(entityset):
     # entityset is timestamp time type
     assert entityset.time_type == variable_types.DatetimeTimeIndex
@@ -649,6 +656,11 @@ def test_checks_time_type_setting_secondary_time_index(entityset):
                   'fraud_decision_time': ['fraud_decision_time', 'fraud']}
     with pytest.raises(TypeError, match=error_text):
         card_es['transactions'].set_secondary_time_index(new_2nd_ti)
+
+    # add bool secondary time index
+    error_text = 'transactions time index not recognized as numeric or datetime'
+    with pytest.raises(TypeError, match=error_text):
+        card_es['transactions'].set_secondary_time_index({'fraud': ['fraud']})
 
 
 def test_related_instances_backward(entityset):

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -344,7 +344,6 @@ def make_ecommerce_entityset(with_integer_time_index=False, base_path=None, save
                                  df,
                                  index='id',
                                  variable_types=variable_types[entity],
-                                 encoding='utf-8',
                                  time_index=ti_name,
                                  secondary_time_index=secondary)
 


### PR DESCRIPTION
The idea behind this PR is to make it easier to find where in the code we handle data type and variable type conversion when creating a new entity.  Currently it's handled in two places: `EntitySet._import_from_dataframe` and `Entity.__init__`.  

This PR moves the relevant logic in `EntitySet._import_from_dataframe` into `Entity.__init__` and removes a couple statements that try to infer variable types that can be handled by `Entity.infer_variable_types` instead.