### PR TITLE
[WIP] Primitives with multiple columns

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -537,10 +537,9 @@ def agg_wrapper(feats, time_last):
 
             if f.expanding:
                 names = f.get_expanded_names()
-                for i, name in enumerate(names):
-                    d[name] = None
-                    if i < len(values):
-                        d[name] = values[i]
+                d.update({name: None for name in names})
+                assert len(values) <= len(names)
+                d.update({name: value for name, value in zip(names, values)})
             else:
                 d[f.get_name()] = values
         return pd.Series(d)

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -327,10 +327,9 @@ class PandasBackend(ComputationalBackend):
             if f.number_output_features > 1:
                 names = f.get_feature_names()
                 assert len(names) == len(values)
+                values = [strip_values_if_series(value) for value in values]
                 for name, value in zip(names, values):
-                    value = strip_values_if_series(value)
                     frame[name] = value
-
             else:
                 values = strip_values_if_series(values)
                 frame[f.get_name()] = values

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -360,9 +360,11 @@ class PandasBackend(ComputationalBackend):
             # Sometimes entityset._add_multigenerational_links adds link variables
             # that would ordinarily get calculated as direct features,
             # so we make sure not to attempt to calculate again
-            if f.get_name() in child_df.columns:
-                continue
-            col_map[f.base_features[0].get_name()] = f.get_name()
+            base_names = f.base_features[0].get_feature_names()
+            for name, base_name in zip(f.get_feature_names(), base_names):
+                if name in child_df.columns:
+                    continue
+                col_map[base_name] = name
 
         # merge the identity feature from the parent entity into the child
         merge_df = parent_df[list(col_map.keys())].rename(columns=col_map)

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -527,9 +527,8 @@ def agg_wrapper(feats, time_last):
 
             if f.number_output_features > 1:
                 names = f.get_feature_names()
-                d.update({name: None for name in names})
-                assert len(values) <= len(names)
-                d.update({name: value for name, value in zip(names, values)})
+                assert len(names) == len(values)
+                d.update(dict(zip(names, values)))
             else:
                 d[f.get_name()] = values
         return pd.Series(d)

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -537,8 +537,10 @@ def agg_wrapper(feats, time_last):
 
 
 def set_default_column(frame, f):
-    default = f.default_value
-    if hasattr(default, '__iter__'):
-        length = frame.shape[0]
-        default = [f.default_value] * length
-    frame[f.get_name()] = default
+    default = [f.default_value]
+    names = f.output_feature_names()
+    if len(names) > 1:
+        default = f.default_value
+
+    for name, value in zip(names, default):
+            frame[name] = value

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -319,10 +319,21 @@ class PandasBackend(ComputationalBackend):
                 values = feature_func(*variable_data)
 
             # if we don't get just the values, the assignment breaks when indexes don't match
-            if isinstance(values, pd.Series):
-                values = values.values
+            def strip_values_if_series(values):
+                if isinstance(values, pd.Series):
+                    values = values.values
+                return values
 
-            frame[f.get_name()] = values
+            if f.number_output_features > 1:
+                names = f.get_feature_names()
+                assert len(names) == len(values)
+                for name, value in zip(names, values):
+                    value = strip_values_if_series(value)
+                    frame[name] = value
+
+            else:
+                values = strip_values_if_series(values)
+                frame[f.get_name()] = values
         return frame
 
     def _calculate_direct_features(self, features, entity_frames):

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -252,7 +252,7 @@ class PandasBackend(ComputationalBackend):
         df.index.name = self.entityset[self.target_eid].index
         column_list = []
         for feat in self.features:
-            column_list.extend(feat.output_feature_names())
+            column_list.extend(feat.get_feature_names())
         return df[column_list]
 
     def generate_default_df(self, instance_ids, extra_columns=None):
@@ -260,7 +260,7 @@ class PandasBackend(ComputationalBackend):
         default_row = []
         default_cols = []
         for f in self.features:
-            for name in f.output_feature_names():
+            for name in f.get_feature_names():
                 default_cols.append(name)
                 default_row.append(f.default_value)
 
@@ -483,7 +483,7 @@ class PandasBackend(ComputationalBackend):
         fillna_dict = {}
         for f in features:
             feature_defaults = {name: f.default_value for
-                                name in f.output_feature_names()}
+                                name in f.get_feature_names()}
             fillna_dict.update(feature_defaults)
 
         frame.fillna(fillna_dict, inplace=True)
@@ -526,7 +526,7 @@ def agg_wrapper(feats, time_last):
                 values = func(*args)
 
             if f.number_output_features > 1:
-                names = f.output_feature_names()
+                names = f.get_feature_names()
                 d.update({name: None for name in names})
                 assert len(values) <= len(names)
                 d.update({name: value for name, value in zip(names, values)})
@@ -537,5 +537,5 @@ def agg_wrapper(feats, time_last):
 
 
 def set_default_column(frame, f):
-    for name in f.output_feature_names():
+    for name in f.get_feature_names():
         frame[name] = f.default_value

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -327,9 +327,8 @@ class PandasBackend(ComputationalBackend):
             if f.number_output_features > 1:
                 names = f.get_feature_names()
                 assert len(names) == len(values)
-                values = [strip_values_if_series(value) for value in values]
                 for name, value in zip(names, values):
-                    frame[name] = value
+                    frame[name] = strip_values_if_series(value)
             else:
                 values = strip_values_if_series(values)
                 frame[f.get_name()] = values

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -80,7 +80,8 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_exclude=None, base_of=None,
                        base_of_exclude=None, description='A custom primitive',
                        cls_attributes=None, uses_calc_time=False,
-                       commutative=False, number_output_features_keyword=None):
+                       commutative=False, number_output_features=1,
+                       number_output_features_keyword=None):
     '''Returns a new aggregation primitive class. The primitive infers default
     values by passing in empty data.
 
@@ -120,8 +121,13 @@ def make_agg_primitive(function, input_types, return_type, name=None,
         commutative (bool): If True, will only make one feature per unique set
             of base features.
 
-        number_output_features_keyword (str): The name of the keyword argument
-            that sets the number of output features.
+        number_output_features (int): The number of output features (columns in
+            the matrix) associated with this feature.
+
+        number_output_features_keyword (str): If the number of output features
+            can vary based on arguments in the feature init, this is the name
+            of the keyword argument in the init that correspaonds to the number
+            of output features.
 
     Example:
         .. ipython :: python
@@ -155,6 +161,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
     new_class.base_of = base_of
     new_class.base_of_exclude = base_of_exclude
     new_class.commutative = commutative
+    new_class.number_output_features = number_output_features
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -80,7 +80,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_exclude=None, base_of=None,
                        base_of_exclude=None, description='A custom primitive',
                        cls_attributes=None, uses_calc_time=False,
-                       commutative=False, number_output_features=1,
+                       commutative=False, number_output_features=None,
                        number_output_features_keyword=None):
     '''Returns a new aggregation primitive class. The primitive infers default
     values by passing in empty data.
@@ -147,6 +147,11 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                 uses_calc_time=True)
 
     '''
+    assert not (number_output_features is not None and
+                number_output_features_keyword is not None), "Either "\
+        "'number_output_features' or 'number_output_features_keyword' should "\
+        "be used, not both."
+
     cls = {"__doc__": description}
     if cls_attributes is not None:
         cls.update(cls_attributes)
@@ -161,7 +166,8 @@ def make_agg_primitive(function, input_types, return_type, name=None,
     new_class.base_of = base_of
     new_class.base_of_exclude = base_of_exclude
     new_class.commutative = commutative
-    new_class.number_output_features = number_output_features
+    if number_output_features is not None:
+        new_class.number_output_features = number_output_features
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -80,7 +80,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_exclude=None, base_of=None,
                        base_of_exclude=None, description='A custom primitive',
                        cls_attributes=None, uses_calc_time=False,
-                       commutative=False):
+                       commutative=False, number_output_features_keyword=None):
     '''Returns a new aggregation primitive class. The primitive infers default
     values by passing in empty data.
 
@@ -119,6 +119,9 @@ def make_agg_primitive(function, input_types, return_type, name=None,
 
         commutative (bool): If True, will only make one feature per unique set
             of base features.
+
+        number_output_features_keyword (str): The name of the keyword argument
+            that sets the number of output features.
 
     Example:
         .. ipython :: python
@@ -186,6 +189,8 @@ def make_agg_primitive(function, input_types, return_type, name=None,
             self.use_previous = use_previous
             self.kwargs = copy.deepcopy(self.default_kwargs)
             self.kwargs.update(kwargs)
+            if number_output_features_keyword in self.kwargs:
+                self.number_output_features = self.kwargs[number_output_features_keyword]
             self.partial = functools.partial(function, **self.kwargs)
             self.partial.__name__ = name
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -371,7 +371,7 @@ class PrimitiveBase(object):
             return self._name
         return self.generate_name()
 
-    def output_feature_names(self):
+    def get_feature_names(self):
         n = self.number_output_features
         if n == 1:
             names = [self.get_name()]

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -50,9 +50,8 @@ class PrimitiveBase(object):
     # downward from this feature's base features.
     max_stack_depth = None
     rolling_function = False
-    #: (bool): If True, feature will expand into multiple values during
-    # calculation
-    expanding = False
+    #: (int): Number of colums in feature matrix associated with this feature
+    number_output_features = 1
     _name = None
     # whitelist of primitives can have this primitive in input_types
     base_of = None
@@ -372,6 +371,14 @@ class PrimitiveBase(object):
             return self._name
         return self.generate_name()
 
+    def output_feature_names(self):
+        n = self.number_output_features
+        if n == 1:
+            names = [self.get_name()]
+        else:
+            names = [self.get_name() + "__{}".format(i) for i in range(n)]
+        return names
+
     def get_function(self):
         raise NotImplementedError("Implement in subclass")
 
@@ -472,8 +479,7 @@ class DirectFeature(PrimitiveBase):
 
     def __init__(self, base_feature, child_entity):
         base_feature = self._check_feature(base_feature)
-        if base_feature.expanding:
-            self.expanding = True
+        self.number_output_features = base_feature.number_output_features
 
         path = child_entity.entityset.find_forward_path(child_entity.id, base_feature.entity.id)
         if len(path) > 1:

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -505,6 +505,10 @@ class DirectFeature(PrimitiveBase):
         return u"%s.%s" % (self.parent_entity.id,
                            self.base_features[0].get_name())
 
+    def get_feature_names(self):
+        return [u"%s.%s" % (self.parent_entity.id, base_name)
+                for base_name in self.base_features[0].get_feature_names()]
+
 
 class Feature(PrimitiveBase):
     """

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -14,8 +14,8 @@ class TransformPrimitive(PrimitiveBase):
         # Any edits made to this method should also be made to the
         # new_class_init method in make_trans_primitive
         self.base_features = [self._check_feature(f) for f in base_features]
-        if any(bf.expanding for bf in self.base_features):
-            self.expanding = True
+        assert (bf.number_output_features == 1 for bf in self.base_features)
+
         assert len(set([f.entity for f in self.base_features])) == 1, \
             "More than one entity for base features"
         super(TransformPrimitive, self).__init__(self.base_features[0].entity,
@@ -107,8 +107,8 @@ def make_trans_primitive(function, input_types, return_type, name=None,
         def new_class_init(self, *args, **kwargs):
             self.kwargs = copy.deepcopy(self.default_kwargs)
             self.base_features = [self._check_feature(f) for f in args]
-            if any(bf.expanding for bf in self.base_features):
-                self.expanding = True
+            assert (bf.number_output_features == 1 for bf in self.base_features)
+
             assert len(set([f.entity for f in self.base_features])) == 1, \
                 "More than one entity for base features"
             self.kwargs.update(kwargs)

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -35,7 +35,7 @@ class TransformPrimitive(PrimitiveBase):
 def make_trans_primitive(function, input_types, return_type, name=None,
                          description='A custom transform primitive',
                          cls_attributes=None, uses_calc_time=False,
-                         commutative=False, number_output_features=1,
+                         commutative=False, number_output_features=None,
                          number_output_features_keyword=None):
     '''Returns a new transform primitive class
 
@@ -94,6 +94,11 @@ def make_trans_primitive(function, input_types, return_type, name=None,
                 "whether it is in a list that provided.",
                 cls_attributes={"generate_name": isin_generate_name})
     '''
+    assert not (number_output_features is not None and
+                number_output_features_keyword is not None), "Either "\
+        "'number_output_features' or 'number_output_features_keyword' should "\
+        "be used, not both."
+
     # dictionary that holds attributes for class
     cls = {"__doc__": description}
     if cls_attributes is not None:
@@ -106,7 +111,8 @@ def make_trans_primitive(function, input_types, return_type, name=None,
     new_class.input_types = input_types
     new_class.return_type = return_type
     new_class.commutative = commutative
-    new_class.number_output_features = number_output_features
+    if number_output_features is not None:
+        new_class.number_output_features = number_output_features
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -35,7 +35,7 @@ class TransformPrimitive(PrimitiveBase):
 def make_trans_primitive(function, input_types, return_type, name=None,
                          description='A custom transform primitive',
                          cls_attributes=None, uses_calc_time=False,
-                         commutative=False):
+                         commutative=False, number_output_features_keyword=None):
     '''Returns a new transform primitive class
 
     Args:
@@ -60,6 +60,9 @@ def make_trans_primitive(function, input_types, return_type, name=None,
 
         commutative (bool): If True, will only make one feature per unique set
             of base features.
+
+        number_output_features_keyword (str): The name of the keyword argument
+            that sets the number of output features.
 
     Example:
         .. ipython :: python
@@ -112,6 +115,8 @@ def make_trans_primitive(function, input_types, return_type, name=None,
             assert len(set([f.entity for f in self.base_features])) == 1, \
                 "More than one entity for base features"
             self.kwargs.update(kwargs)
+            if number_output_features_keyword in self.kwargs:
+                self.number_output_features = self.kwargs[number_output_features_keyword]
             self.partial = functools.partial(function, **self.kwargs)
             self.partial.__name__ = name
 

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -35,7 +35,8 @@ class TransformPrimitive(PrimitiveBase):
 def make_trans_primitive(function, input_types, return_type, name=None,
                          description='A custom transform primitive',
                          cls_attributes=None, uses_calc_time=False,
-                         commutative=False, number_output_features_keyword=None):
+                         commutative=False, number_output_features=1,
+                         number_output_features_keyword=None):
     '''Returns a new transform primitive class
 
     Args:
@@ -61,8 +62,13 @@ def make_trans_primitive(function, input_types, return_type, name=None,
         commutative (bool): If True, will only make one feature per unique set
             of base features.
 
-        number_output_features_keyword (str): The name of the keyword argument
-            that sets the number of output features.
+        number_output_features (int): The number of output features (columns in
+            the matrix) associated with this feature.
+
+        number_output_features_keyword (str): If the number of output features
+            can vary based on arguments in the feature init, this is the name
+            of the keyword argument in the init that correspaonds to the number
+            of output features.
 
     Example:
         .. ipython :: python
@@ -100,6 +106,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
     new_class.input_types = input_types
     new_class.return_type = return_type
     new_class.commutative = commutative
+    new_class.number_output_features = number_output_features
     new_class, default_kwargs = inspect_function_args(new_class,
                                                       function,
                                                       uses_calc_time)

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -158,7 +158,7 @@ class NMostCommon(AggregationPrimitive):
 
     @property
     def default_value(self):
-        return np.zeros(self.number_output_features) * np.nan
+        return np.nan
 
     def output_feature_names(self):
         names = []

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -160,7 +160,7 @@ class NMostCommon(AggregationPrimitive):
     def default_value(self):
         return np.nan
 
-    def output_feature_names(self):
+    def get_feature_names(self):
         names = []
         for i in range(1, self.number_output_features + 1):
             names.append(str(i) + self.get_name()[1:])

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -168,7 +168,11 @@ class NMostCommon(AggregationPrimitive):
 
     def get_function(self):
         def pd_topn(x, n=self.number_output_features):
-            return np.array(x.value_counts()[:n].index)
+            array = np.array(x.value_counts()[:n].index)
+            if len(array) < n:
+                filler = np.full(n - len(array), self.default_value)
+                array = np.append(array, filler)
+            return array
         return pd_topn
 
 

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -151,24 +151,23 @@ class NMostCommon(AggregationPrimitive):
     # max_stack_depth = 1
     stack_on = []
     stack_on_exclude = []
-    expanding = True
 
     def __init__(self, base_feature, parent_entity, n=3):
-        self.n = n
+        self.number_output_features = n
         super(NMostCommon, self).__init__(base_feature, parent_entity)
 
     @property
     def default_value(self):
-        return np.zeros(self.n) * np.nan
+        return np.zeros(self.number_output_features) * np.nan
 
-    def get_expanded_names(self):
+    def output_feature_names(self):
         names = []
-        for i in range(1, self.n + 1):
+        for i in range(1, self.number_output_features + 1):
             names.append(str(i) + self.get_name()[1:])
         return names
 
     def get_function(self):
-        def pd_topn(x, n=self.n):
+        def pd_topn(x, n=self.number_output_features):
             return np.array(x.value_counts()[:n].index)
         return pd_topn
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -536,11 +536,8 @@ class DeepFeatureSynthesis(object):
 
             new_f = DirectFeature(f, child_entity)
 
-            if f.number_output_features > 1:
-                continue
-            else:
-                self._handle_new_feature(all_features=all_features,
-                                         new_feature=new_f)
+            self._handle_new_feature(all_features=all_features,
+                                     new_feature=new_f)
 
     def _build_agg_features(self, all_features,
                             parent_entity, child_entity, max_depth=0):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -507,7 +507,7 @@ class DeepFeatureSynthesis(object):
 
             for matching_input in matching_inputs:
                 new_f = trans_prim(*matching_input)
-                if new_f.expanding:
+                if new_f.number_output_features > 1:
                     continue
 
                 self._handle_new_feature(all_features=all_features,
@@ -538,7 +538,7 @@ class DeepFeatureSynthesis(object):
 
             new_f = DirectFeature(f, child_entity)
 
-            if f.expanding:
+            if f.number_output_features > 1:
                 continue
             else:
                 self._handle_new_feature(all_features=all_features,
@@ -683,7 +683,7 @@ def check_stacking(primitive, input_types):
                 return False
 
     for f in input_types:
-        if f.expanding:
+        if f.number_output_features > 1:
             return False
 
     for f in input_types:

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -507,8 +507,6 @@ class DeepFeatureSynthesis(object):
 
             for matching_input in matching_inputs:
                 new_f = trans_prim(*matching_input)
-                if new_f.number_output_features > 1:
-                    continue
 
                 self._handle_new_feature(all_features=all_features,
                                          new_feature=new_f)

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -67,7 +67,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
     encoded = []
     feature_names = []
     for feature in features:
-        for fname in feature.output_feature_names():
+        for fname in feature.get_feature_names():
             assert fname in X.columns, (
                 "Feature %s not found in feature matrix" % (fname)
             )
@@ -120,7 +120,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
 
     new_columns = []
     for e in encoded:
-        new_columns.extend(e.output_feature_names())
+        new_columns.extend(e.get_feature_names())
 
     new_columns.extend(extra_columns)
     new_X = X[new_columns]

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -67,12 +67,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
     encoded = []
     feature_names = []
     for feature in features:
-        if feature.expanding:
-            names = feature.get_expanded_names()
-        else:
-            names = [feature.get_name()]
-
-        for fname in names:
+        for fname in feature.output_feature_names():
             assert fname in X.columns, (
                 "Feature %s not found in feature matrix" % (fname)
             )
@@ -91,7 +86,7 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
     for f in iterator:
         # TODO: features with multiple columns are not encoded by this method,
         # which can cause an "encoded" matrix non-numeric values
-        if (f.expanding or (not issubclass(f.variable_type, Discrete))):
+        if (f.number_output_features > 1 or (not issubclass(f.variable_type, Discrete))):
             encoded.append(f)
             continue
 
@@ -125,10 +120,8 @@ def encode_features(feature_matrix, features, top_n=10, include_unknown=True,
 
     new_columns = []
     for e in encoded:
-        if e.expanding:
-            new_columns.extend(e.get_expanded_names())
-        else:
-            new_columns.append(e.get_name())
+        new_columns.extend(e.output_feature_names())
+
     new_columns.extend(extra_columns)
     new_X = X[new_columns]
     iterator = new_X.columns

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -141,5 +141,5 @@ def test_encode_features_topn(entityset):
                                                      feature_defs,
                                                      include_unknown=True)
     assert topn.hash() in [feat.hash() for feat in feature_defs_enc]
-    for name in topn.output_feature_names():
+    for name in topn.get_feature_names():
         assert name in features_enc.columns

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -141,5 +141,5 @@ def test_encode_features_topn(entityset):
                                                      feature_defs,
                                                      include_unknown=True)
     assert topn.hash() in [feat.hash() for feat in feature_defs_enc]
-    for name in topn.get_expanded_names():
+    for name in topn.output_feature_names():
         assert name in features_enc.columns

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -140,6 +140,6 @@ def test_encode_features_topn(entityset):
     features_enc, feature_defs_enc = encode_features(features,
                                                      feature_defs,
                                                      include_unknown=True)
-    assert topn in feature_defs_enc
+    assert topn.hash() in [feat.hash() for feat in feature_defs_enc]
     for name in topn.get_expanded_names():
         assert name in features_enc.columns

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -4,7 +4,7 @@ import pytest
 from ..testing_utils import make_ecommerce_entityset
 
 from featuretools import EntitySet, calculate_feature_matrix, dfs
-from featuretools.primitives import IdentityFeature
+from featuretools.primitives import IdentityFeature, NMostCommon
 from featuretools.synthesis import encode_features
 
 
@@ -128,3 +128,13 @@ def test_encode_unknown_features():
                                                      include_unknown=True)
     assert list(features_enc.columns) == ['category = unknown', 'category = e', 'category = d',
                                           'category = c', 'category = b', 'category is unknown']
+
+
+def test_encode_features_topn(entityset):
+    features, feature_defs = dfs(entityset=entityset,
+                                 instance_ids=[0, 1, 2],
+                                 target_entity="customers",
+                                 agg_primitives=["n_most_common"])
+    features_enc, feature_defs_enc = encode_features(features,
+                                                     feature_defs,
+                                                     include_unknown=True)

--- a/featuretools/tests/computational_backend/test_encode_features.py
+++ b/featuretools/tests/computational_backend/test_encode_features.py
@@ -131,6 +131,8 @@ def test_encode_unknown_features():
 
 
 def test_encode_features_topn(entityset):
+    topn = NMostCommon(entityset['log']['product_id'],
+                       entityset['customers'], n=3)
     features, feature_defs = dfs(entityset=entityset,
                                  instance_ids=[0, 1, 2],
                                  target_entity="customers",
@@ -138,3 +140,6 @@ def test_encode_features_topn(entityset):
     features_enc, feature_defs_enc = encode_features(features,
                                                      feature_defs,
                                                      include_unknown=True)
+    assert topn in feature_defs_enc
+    for name in topn.get_expanded_names():
+        assert name in features_enc.columns

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -464,7 +464,7 @@ def test_topn(entityset, backend):
         ['coke zero', 'Haribo sugar-free gummy bears'],
         ['taco clock', np.nan]
     ])
-    assert ([name in df.columns for name in topn.output_feature_names()])
+    assert ([name in df.columns for name in topn.get_feature_names()])
     for i in range(df.shape[0]):
         if i == 0:
             # coke zero and toothpaste have same number of occurrences

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -464,7 +464,7 @@ def test_topn(entityset, backend):
         ['coke zero', 'Haribo sugar-free gummy bears'],
         ['taco clock', np.nan]
     ])
-    assert ([name in df.columns for name in topn.get_expanded_names()])
+    assert ([name in df.columns for name in topn.output_feature_names()])
     for i in range(df.shape[0]):
         if i == 0:
             # coke zero and toothpaste have same number of occurrences

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -459,14 +459,20 @@ def test_topn(entityset, backend):
     df = pandas_backend.calculate_all_features(instance_ids=[0, 1, 2],
                                                time_last=None)
 
-    true_results = [
-        ['toothpaste', 'coke zero'],
+    true_results = pd.DataFrame([
+        ['coke zero', 'toothpaste'],
         ['coke zero', 'Haribo sugar-free gummy bears'],
-        ['taco clock']
-    ]
-    assert (topn.get_name() in df.columns)
-    for i, values in enumerate(df[topn.get_name()].values):
-        assert set(true_results[i]) == set(values)
+        ['taco clock', np.nan]
+    ])
+    assert ([name in df.columns for name in topn.get_expanded_names()])
+    for i in range(df.shape[0]):
+        if i == 0:
+            # coke zero and toothpaste have same number of occurrences
+            # so just check that the top two match
+            assert set(true_results.loc[i].values) == set(df.loc[i].values)
+        else:
+            for i1, i2 in zip(true_results.iloc[i], df.iloc[i]):
+                assert (pd.isnull(i1) and pd.isnull(i2)) or (i1 == i2)
 
 
 def test_trend(entityset, backend):

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -450,17 +450,10 @@ def test_make_n_most_common(es):
 
 
 def test_make_mulit_output_custom_agg_bad_kwargs(es):
-    def pd_topn(x, n=3):
-        array = np.array(x.value_counts()[:n].index)
-        if len(array) < n:
-            filler = np.full(n - len(array), np.nan)
-            array = np.append(array, filler)
-        return array
-
     error_text = "Either 'number_output_features' or "\
         "'number_output_features_keyword' should be used, not both."
     with pytest.raises(AssertionError, match=error_text):
-        make_agg_primitive(function=pd_topn,
+        make_agg_primitive(function=lambda x: x,
                            input_types=[Discrete],
                            return_type=Discrete,
                            number_output_features=3,

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -447,3 +447,21 @@ def test_make_n_most_common(es):
         else:
             for i1, i2 in zip(true_results.iloc[i], df.iloc[i]):
                 assert (pd.isnull(i1) and pd.isnull(i2)) or (i1 == i2)
+
+
+def test_make_mulit_output_custom_agg_bad_kwargs(es):
+    def pd_topn(x, n=3):
+        array = np.array(x.value_counts()[:n].index)
+        if len(array) < n:
+            filler = np.full(n - len(array), np.nan)
+            array = np.append(array, filler)
+        return array
+
+    error_text = "Either 'number_output_features' or "\
+        "'number_output_features_keyword' should be used, not both."
+    with pytest.raises(AssertionError, match=error_text):
+        make_agg_primitive(function=pd_topn,
+                           input_types=[Discrete],
+                           return_type=Discrete,
+                           number_output_features=3,
+                           number_output_features_keyword="n")

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -63,6 +63,7 @@ from featuretools.variable_types import (
     Variable
 )
 
+
 # some tests change the entityset values, so we have to create it fresh
 # for each test (rather than setting scope='module')
 @pytest.fixture
@@ -1290,11 +1291,12 @@ def test_multi_column_transform_variable_columns(es):
         def x_most_common(text, x):
             from collections import Counter
             counts = Counter(text.split(" "))
-            return counts.most_common(x)[x-1][0]
+            return counts.most_common(x)[x - 1][0]
 
         x_series = pd.Series(x)
         if n > 1:
-            out = [x_series.apply(x_most_common, args=(i,)) for i in range(1, n+1)]
+            out = [x_series.apply(x_most_common, args=(i,))
+                   for i in range(1, n + 1)]
         else:
             out = x_series.apply(x_most_common, args=(1,))
         return out

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1258,8 +1258,8 @@ def test_make_transform_multiple_output_features(es):
         function=test_f,
         input_types=[Datetime],
         return_type=Numeric,
-        cls_attributes={"number_output_features": 6,
-                        "get_feature_names": gen_feat_names},
+        number_output_features=6,
+        cls_attributes={"get_feature_names": gen_feat_names},
     )
 
     join_time_split = TestTime(es["log"]["datetime"])

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1263,7 +1263,7 @@ def test_make_transform_multiple_output_features(es):
     )
 
     join_time_split = TestTime(es["log"]["datetime"])
-    backend = PandasBackend(es,  [join_time_split])
+    backend = PandasBackend(es, [join_time_split])
     df = backend.calculate_all_features(range(17), None)
 
     alt_features = [Year(es["log"]["datetime"]),

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1291,6 +1291,30 @@ def test_make_transform_multiple_output_features(es):
             assert base_feature.hash() != join_time_split.hash()
 
 
+def test_make_transform_multiple_output_bad_kwargs(es):
+    def test_f(x):
+        times = pd.Series(x)
+        units = ["year", "month", "day", "hour", "minute", "second"]
+        return [times.apply(lambda x: getattr(x, unit)) for unit in units]
+
+    def gen_feat_names(self):
+        subnames = ["Year", "Month", "Day", "Hour", "Minute", "Second"]
+        return ["Now.%s(%s)" % (subname, self.base_features[0].get_name())
+                for subname in subnames]
+
+    error_text = "Either 'number_output_features' or "\
+        "'number_output_features_keyword' should be used, not both."
+    with pytest.raises(AssertionError, match=error_text):
+        make_trans_primitive(
+            function=test_f,
+            input_types=[Datetime],
+            return_type=Numeric,
+            number_output_features=6,
+            number_output_features_keyword="x",
+            cls_attributes={"get_feature_names": gen_feat_names}
+        )
+
+
 def test_dfs_direct_of_multi_output_transform_feat(es):
     def test_f(x):
         times = pd.Series(x)

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1336,11 +1336,9 @@ def test_multi_column_transform_variable_columns(es):
             return counts.most_common(x)[x - 1][0]
 
         x_series = pd.Series(x)
-        if n > 1:
-            out = [x_series.apply(x_most_common, args=(i,))
-                   for i in range(1, n + 1)]
-        else:
-            out = x_series.apply(x_most_common, args=(1,))
+        # this would break if n<2 but we only use n=3 in the test
+        out = [x_series.apply(x_most_common, args=(i,))
+               for i in range(1, n + 1)]
         return out
 
     MostCommonWord = make_trans_primitive(function=most_common,

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1292,26 +1292,15 @@ def test_make_transform_multiple_output_features(es):
 
 
 def test_make_transform_multiple_output_bad_kwargs(es):
-    def test_f(x):
-        times = pd.Series(x)
-        units = ["year", "month", "day", "hour", "minute", "second"]
-        return [times.apply(lambda x: getattr(x, unit)) for unit in units]
-
-    def gen_feat_names(self):
-        subnames = ["Year", "Month", "Day", "Hour", "Minute", "Second"]
-        return ["Now.%s(%s)" % (subname, self.base_features[0].get_name())
-                for subname in subnames]
-
     error_text = "Either 'number_output_features' or "\
         "'number_output_features_keyword' should be used, not both."
     with pytest.raises(AssertionError, match=error_text):
         make_trans_primitive(
-            function=test_f,
+            function=lambda x: x,
             input_types=[Datetime],
             return_type=Numeric,
             number_output_features=6,
             number_output_features_keyword="x",
-            cls_attributes={"get_feature_names": gen_feat_names}
         )
 
 


### PR DESCRIPTION
This pull request updates the API for handling features that output multiple columns of values.  In the past these were referred to in the code as "expanding" features.  A brief rundown of the changes:

* **Multiple columns in the feature matrix can now correspond to the same feature.**  Where before a feature with multiple outputs would have a list of values per instance, these features now get one column per value.

* **Column names do not always match a feature name.**  With features having multiple columns it's necessary to modify the column names to distinguish between the various output columns of a feature.  

* **feature.expanding (bool) replaced with feature.number_output_features (int).** Instead of a feature either being expanding or not, it has an integer corresponding to the number of output features (columns) it has.

* **feature.get_expanded_names() replaced with feature.get_feature_names().**  Feature.get_feature_names is now the method to call when generating a feature matrix's column names.

* **feature.default_value is a singular value that becomes the default for all output features.**  Instead of a list of default values, one for each output feature, each output features shares the same default value.
* **two new keyword arguments for make_primitive functions**
    * number_output_features (int): sets the number of output features for a custom primitive
    * number_output_features_keyword (str): if the number of output features a custom primitive has is set by a keyword argument when the feature is initialized, providing the name of that keyword argument here will allow featuretools to set the correct number of output features.

* **features with multiple outputs can now be used as direct features**