### PR TITLE
Add missing dependencies 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include LICENSE
 include README.md
+include featuretools/tests/primitive_tests/primitives_to_install.tar.gz
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psutil>=5.4.8
 click>=7.0.0
 smart_open>=1.7.1
 s3fs>=0.1.5
+scikit-learn>=0.20.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,3 @@ pympler==0.5
 pytest-xdist==1.23.2
 pytest-cov==2.6.0
 fastparquet>=0.1.6
-scikit-learn>=0.20.0


### PR DESCRIPTION
The last release of Featuretools as missing sklearn as a dependency in `requirements.txt` and one of the test files in `MANIFEST.ini`