### PR TITLE
Add seed features later in DFS process

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -198,12 +198,6 @@ class DeepFeatureSynthesis(object):
             if e not in self.ignore_entities:
                 all_features[e.id] = {}
 
-        # add seed features, if any, for dfs to build on top of
-        if self.seed_features is not None:
-            for f in self.seed_features:
-                self._handle_new_feature(all_features=all_features,
-                                         new_feature=f)
-
         self.where_clauses = defaultdict(set)
         self._run_dfs(self.es[self.target_entity_id], [],
                       all_features, max_depth=self.max_depth)
@@ -316,7 +310,7 @@ class DeepFeatureSynthesis(object):
         backward_entities = [b_id for b_id in backward_entities
                              if b_id not in self.ignore_entities]
         for b_entity_id in backward_entities:
-            # if in path, we've alrady built features
+            # if in path, we've already built features
             if b_entity_id in entity_path:
                 continue
 
@@ -447,6 +441,12 @@ class DeepFeatureSynthesis(object):
             self._handle_new_feature(all_features=all_features,
                                      new_feature=new_f)
 
+        # add seed features, if any, for dfs to build on top of
+        for f in self.seed_features:
+            if f.entity.id == entity.id:
+                self._handle_new_feature(all_features=all_features,
+                                         new_feature=f)
+
     def _build_where_clauses(self, all_features, entity):
         """Traverses all identity features and creates a Compare for
             each one, based on some heuristics
@@ -529,6 +529,7 @@ class DeepFeatureSynthesis(object):
         for f in features:
             if self._feature_in_relationship_path([relationship], f):
                 continue
+
             # limits allowing direct features of agg_feats with where clauses
             if isinstance(f, AggregationPrimitive):
                 deep_base_features = [f] + f.get_deep_dependencies()

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -352,7 +352,6 @@ def test_seed_features_added_with_identity_features(es):
                                    agg_primitives=[Last],
                                    trans_primitives=[],
                                    max_depth=2,
-                                   ignore_entities=["régions", "cohorts"],
                                    seed_features=[count_sessions])
     features = dfs_obj.build_features()
     # this feature is meaningless because customers.COUNT(sessions) is already defined on

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -345,6 +345,21 @@ def test_seed_features(es):
     assert session_agg.get_name() in [f.get_name() for f in features]
 
 
+def test_seed_features_added_with_identity_features(es):
+    count_sessions = Count(es['sessions']["id"], es['customers'])
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='customers',
+                                   entityset=es,
+                                   agg_primitives=[Last],
+                                   trans_primitives=[],
+                                   max_depth=2,
+                                   ignore_entities=["régions", "cohorts"],
+                                   seed_features=[count_sessions])
+    features = dfs_obj.build_features()
+    # this feature is meaningless because customers.COUNT(sessions) is already defined on
+    # the customers entity
+    assert not feature_with_name(features, 'LAST(sessions.customers.COUNT(sessions))')
+
+
 def test_dfs_builds_on_seed_features_more_than_max_depth(es):
     seed_feature_sessions = Count(es['log']["id"], es['sessions']) > 2
     seed_feature_log = Hour(es['log']['datetime'])


### PR DESCRIPTION
Currently we add the seed features to our running list of synthesized features at the beginning of DFS. 

This PR moves seed features so they get added when the other identity features for a particular are added.

This prevents a seed feature from being stacked on prematurely, creating meaningless features

For example, before this PR the following feature would get created for the customer entity when `customers.COUNT(sessions)` is a seed feature

```LAST(sessions.customers.COUNT(sessions))```