### PR TITLE
use circleci docker images on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: source venv/bin/activate && make installdeps lint
       - run: source venv/bin/activate && make -C docs/ -e "SPHINXOPTS=-W" clean html
       - run:
-        - command: |
+        command: |
           source venv/bin/activate
           coverage erase
           make testcoverage && codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
       - run: virtualenv venv
       - run: source venv/bin/activate && make installdeps lint
       - run: source venv/bin/activate && make -C docs/ -e "SPHINXOPTS=-W" clean html
-      - run:
-        command: |
+      - run: |
           source venv/bin/activate
           coverage erase
           make testcoverage && codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,44 +3,48 @@ jobs:
   "python-2.7":
     working_directory: ~/featuretools
     docker:
-        - image: themattrix/tox
+        - image: circleci/python:2.7
     steps:
       - checkout
-      - run: pyenv local 2.7.15
-      - run: make installdeps lint
-      - run: make test
+      - run: virtualenv venv
+      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make test
 
   "python-3.5":
     working_directory: ~/featuretools
     docker:
-        - image: themattrix/tox
+        - image: circleci/python:3.5
     steps:
       - checkout
-      - run: pyenv local 3.5.6
-      - run: make installdeps lint
-      - run: make test
+      - run: virtualenv venv
+      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make test
 
   "python-3.6":
     working_directory: ~/featuretools
     docker:
-        - image: themattrix/tox
+        - image: circleci/python:3.6
     steps:
-      - run: apt update && apt install pandoc -y
+      - run: sudo apt update && sudo apt install pandoc -y
       - checkout
-      - run: pyenv local 3.6.6
-      - run: make installdeps lint
-      - run: make -C docs/ -e "SPHINXOPTS=-W" clean html
-      - run: coverage erase && make testcoverage && codecov
+      - run: virtualenv venv
+      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make -C docs/ -e "SPHINXOPTS=-W" clean html
+      - run:
+        - command: |
+          source venv/bin/activate
+          coverage erase
+          make testcoverage && codecov
 
   "python-3.7":
     working_directory: ~/featuretools
     docker:
-        - image: themattrix/tox
+        - image: circleci/python:3.7
     steps:
       - checkout
-      - run: pyenv local 3.7.0
-      - run: make installdeps lint
-      - run: make test
+      - run: virtualenv venv
+      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make test
 
 workflows:
   version: 2


### PR DESCRIPTION
Since we no longer use tox for testing this PR switches to using a different docker image for each set of tests to match the version of python being tested.