### PR TITLE
Pin Numpy Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.9.51
 botocore>=1.12.51
-numpy>=1.13.3
+numpy==1.15.0
 pandas>=0.23.0
 tqdm>=4.19.2
 toolz>=0.8.2


### PR DESCRIPTION
The 1.16.0 release of numpy is breaking the dask import in python 2.7. This has been fixed in dask, but hasn't been released yet. Here is the PR: https://github.com/dask/dask/pull/4346. 

To workaround this for the time being, this PR pins Featuretools to the previous version of Numpy.

Once next release of dask goes out with the fix we can unpin this.