### PR TITLE
Temporary update circle python 2.7 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - checkout
       - run: virtualenv venv
       - run: source venv/bin/activate && make installdeps lint
+      - run: pip install numpy==1.5.1
       - run: source venv/bin/activate && make test
 
   "python-3.5":


### PR DESCRIPTION
Until the next dask release, we need to force the version of numpy for the python 2.7 tests.

Once dask is released, we can undo this change.