### PR TITLE
Pin pandas version to 0.23 until tests support 0.24

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r test-requirements.txt
 codecov==2.0.15
-autopep8
 flake8==3.6.0
+autopep8
 ipython==7.1.1; python_version>'3.4'
 ipython==5.8.0; python_version<'3'
 isort==4.3.4

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -75,7 +75,8 @@ def test_calc_feature_matrix(entityset):
     with pytest.raises(AssertionError, match=error_text):
         feature_matrix = calculate_feature_matrix([1, 2, 3], entityset, cutoff_time=cutoff_time)
 
-    error_text = ".*type object 17"
+    error_text = "cutoff_time times must be datetime type: try casting via "\
+        "pd\\.to_datetime\\(cutoff_time\\['time'\\]\\)"
     with pytest.raises(TypeError, match=error_text):
         calculate_feature_matrix([property_feature],
                                  entityset,
@@ -1023,7 +1024,8 @@ def test_integer_time_index_datetime_cutoffs(int_es):
     cutoff_df = pd.DataFrame({'time': times, 'instance_id': range(17)})
     property_feature = IdentityFeature(int_es['log']['value']) > 10
 
-    error_text = "Cannot compare type.*"
+    error_text = "cutoff_time times must be numeric: try casting via "\
+        "pd\\.to_numeric\\(cutoff_time\\['time'\\]\\)"
     with pytest.raises(TypeError, match=error_text):
         calculate_feature_matrix([property_feature],
                                  int_es,

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -63,7 +63,7 @@ def test_calc_feature_matrix(entityset):
                                               cutoff_time=cutoff_time,
                                               verbose=True)
 
-    assert (feature_matrix == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
     error_text = 'features must be a non-empty list of features'
     with pytest.raises(AssertionError, match=error_text):
@@ -240,7 +240,7 @@ def test_cutoff_time_correctly(entityset):
                                               cutoff_time=cutoff_time)
 
     labels = [0, 10, 5]
-    assert (feature_matrix == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 def test_cutoff_time_binning(entityset):
@@ -825,7 +825,7 @@ def test_verbose_cutoff_time_chunks(entityset):
                                               chunk_size="cutoff time",
                                               verbose=True)
 
-    assert (feature_matrix == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 def test_dask_kwargs(entityset):
@@ -849,7 +849,7 @@ def test_dask_kwargs(entityset):
                                                   dask_kwargs=dkwargs,
                                                   approximate='1 hour')
 
-    assert (feature_matrix == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 def test_dask_persisted_entityset(entityset, capsys):
@@ -872,7 +872,7 @@ def test_dask_persisted_entityset(entityset, capsys):
                                                   chunk_size=.13,
                                                   dask_kwargs=dkwargs,
                                                   approximate='1 hour')
-        assert (feature_matrix == labels).values.all()
+        assert (feature_matrix[property_feature.get_name()] == labels).values.all()
         feature_matrix = calculate_feature_matrix([property_feature],
                                                   entityset=entityset,
                                                   cutoff_time=cutoff_time,
@@ -882,7 +882,7 @@ def test_dask_persisted_entityset(entityset, capsys):
                                                   approximate='1 hour')
         captured = capsys.readouterr()
         assert "Using EntitySet persisted on the cluster as dataset " in captured[0]
-        assert (feature_matrix == labels).values.all()
+        assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 class TestCreateClientAndCluster(object):
@@ -1015,7 +1015,7 @@ def test_integer_time_index(int_es):
     time_level_vals = feature_matrix.index.get_level_values(1).values
     sorted_df = cutoff_df.sort_values(['time', 'instance_id'], kind='mergesort')
     assert (time_level_vals == sorted_df['time'].values).all()
-    assert (feature_matrix == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 def test_integer_time_index_datetime_cutoffs(int_es):

--- a/featuretools/tests/utils_tests/test_time_utils.py
+++ b/featuretools/tests/utils_tests/test_time_utils.py
@@ -7,9 +7,7 @@ from featuretools.utils import make_temporal_cutoffs
 
 def test_make_temporal_cutoffs():
     instance_ids = pd.Series(range(10))
-    cutoffs = pd.DatetimeIndex(start='1/2/2015',
-                               periods=10,
-                               freq='1d')
+    cutoffs = pd.date_range(start='1/2/2015', periods=10, freq='1d')
     temporal_cutoffs_by_nwindows = make_temporal_cutoffs(instance_ids,
                                                          cutoffs,
                                                          window_size='1h',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.9.51
 botocore>=1.12.51
 numpy>=1.13.3
-pandas>=0.23.0
+pandas>=0.23.0,<0.24
 tqdm>=4.19.2
 toolz>=0.8.2
 pyyaml>=3.12


### PR DESCRIPTION
Pandas released version 0.24.0 recently.  This PR contains some bugfixes to the tests to make the code more compatible with the new pandas version.  The way featuretools implements the LatLong type is incompatible with 0.24 currently (see pandas issue [#24986](https://github.com/pandas-dev/pandas/issues/24986)) so until that situation is resolved we're restricting featuretools to pandas 0.23.  Pandas 0.24 should work excluding latlongs.