### PR TITLE
Mean primitive changes

### DIFF
--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -59,13 +59,28 @@ class Mean(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
 
-    def __init__(self, ignore_nans=False):
+    def __init__(self, ignore_nans=True):
         self.ignore_nans = ignore_nans
 
     def get_function(self):
         if self.ignore_nans:
-            return np.nanmean
-        return np.mean
+            # np.mean of series is functionally nanmean
+            return np.mean
+
+        def mean(series):
+            return np.mean(series.values)
+        return mean
+
+    def generate_name(self, base_feature_names, child_entity_id,
+                      parent_entity_id, where_str, use_prev_str):
+        name = "MEAN"
+        if self.ignore_nans:
+            name = "NANMEAN"
+        base_features_str = ", ".join(base_feature_names)
+        return u"%s(%s.%s%s%s)" % (name,
+                                   child_entity_id,
+                                   base_features_str,
+                                   where_str, use_prev_str)
 
 
 class Mode(AggregationPrimitive):

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -126,7 +126,7 @@ def test_check_input_types(es):
     assert mean._check_input_types()
 
 
-def test_mean_nan():
+def test_mean_nan(es):
     array = pd.Series([5, 5, 5, 5, 5])
     mean_func_nans_default = Mean().get_function()
     mean_func_nans_false = Mean(ignore_nans=False).get_function()
@@ -142,6 +142,20 @@ def test_mean_nan():
     assert isnan(mean_func_nans_default(array_nans))
     assert isnan(mean_func_nans_false(array_nans))
     assert isnan(mean_func_nans_true(array_nans))
+
+    # test naming
+    default_feat = ft.Feature(es["log"]["value"],
+                              parent_entity=es["customers"],
+                              primitive=Mean)
+    assert default_feat.get_name() == "NANMEAN(log.value)"
+    ignore_nan_feat = ft.Feature(es["log"]["value"],
+                                 parent_entity=es["customers"],
+                                 primitive=Mean(ignore_nans=True))
+    assert ignore_nan_feat.get_name() == "NANMEAN(log.value)"
+    include_nan_feat = ft.Feature(es["log"]["value"],
+                                  parent_entity=es["customers"],
+                                  primitive=Mean(ignore_nans=False))
+    assert include_nan_feat.get_name() == "MEAN(log.value)"
 
 
 def test_base_of_and_stack_on_heuristic(es, test_primitive):

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -127,19 +127,19 @@ def test_check_input_types(es):
 
 
 def test_mean_nan():
-    array = np.array([5, 5, 5, 5, 5])
+    array = pd.Series([5, 5, 5, 5, 5])
     mean_func_nans_default = Mean().get_function()
     mean_func_nans_false = Mean(ignore_nans=False).get_function()
     mean_func_nans_true = Mean(ignore_nans=True).get_function()
     assert mean_func_nans_default(array) == 5
     assert mean_func_nans_false(array) == 5
     assert mean_func_nans_true(array) == 5
-    array = np.array([5, np.nan, np.nan, np.nan, np.nan, 10])
-    assert isnan(mean_func_nans_default(array))
+    array = pd.Series([5, np.nan, np.nan, np.nan, np.nan, 10])
+    assert mean_func_nans_default(array) == 7.5
     assert isnan(mean_func_nans_false(array))
     assert mean_func_nans_true(array) == 7.5
-    array_nans = np.array([np.nan, np.nan, np.nan, np.nan])
-    assert isnan(mean_func_nans_default(array))
+    array_nans = pd.Series([np.nan, np.nan, np.nan, np.nan])
+    assert isnan(mean_func_nans_default(array_nans))
     assert isnan(mean_func_nans_false(array_nans))
     assert isnan(mean_func_nans_true(array_nans))
 


### PR DESCRIPTION
Fixes #393 and makes `ignore_nans=True` by default