### PR TITLE
check that agg_primitives and trans_primitives are right primitive type

### DIFF
--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -11,7 +11,11 @@ from featuretools.feature_base import (
     TransformFeature
 )
 from featuretools.primitives.api import Discrete
-from featuretools.primitives.base import PrimitiveBase
+from featuretools.primitives.base import (
+    AggregationPrimitive,
+    PrimitiveBase,
+    TransformPrimitive
+)
 from featuretools.utils import is_string
 from featuretools.variable_types import Boolean, Categorical, Numeric, Ordinal
 
@@ -138,6 +142,9 @@ class DeepFeatureSynthesis(object):
                                      " a list of available primitives")
                 a = agg_prim_dict[a.lower()]
             a = handle_primitive(a)
+            if not isinstance(a, AggregationPrimitive):
+                raise ValueError("Primitive {} is not an aggregation "
+                                 "primitive".format(a))
             self.agg_primitives.append(a)
 
         if trans_primitives is None:
@@ -154,6 +161,9 @@ class DeepFeatureSynthesis(object):
                                      " a list of available primitives")
                 t = trans_prim_dict[t.lower()]
             t = handle_primitive(t)
+            if not isinstance(t, TransformPrimitive):
+                raise ValueError("Primitive {} is not a transform "
+                                 "primitive".format(t))
             self.trans_primitives.append(t)
 
         if where_primitives is None:

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -143,8 +143,8 @@ class DeepFeatureSynthesis(object):
                 a = agg_prim_dict[a.lower()]
             a = handle_primitive(a)
             if not isinstance(a, AggregationPrimitive):
-                raise ValueError("Primitive {} is not an aggregation "
-                                 "primitive".format(a))
+                raise ValueError("Primitive {} in agg_primitives is not an "
+                                 "aggregation primitive".format(type(a)))
             self.agg_primitives.append(a)
 
         if trans_primitives is None:
@@ -162,8 +162,8 @@ class DeepFeatureSynthesis(object):
                 t = trans_prim_dict[t.lower()]
             t = handle_primitive(t)
             if not isinstance(t, TransformPrimitive):
-                raise ValueError("Primitive {} is not a transform "
-                                 "primitive".format(t))
+                raise ValueError("Primitive {} in trans_primitives is not a "
+                                 "transform primitive".format(type(t)))
             self.trans_primitives.append(t)
 
         if where_primitives is None:

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -683,7 +683,7 @@ def test_initialized_agg_prim(es):
     assert (feature_with_name(features, "N_MOST_COMMON(log.product_id)"))
 
 
-def test_checks_agg_primitives_are_aggs(es):
+def test_checks_primitives_correct_type(es):
     error_text = "Primitive .* is not an aggregation primitive"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id="sessions",

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -684,14 +684,18 @@ def test_initialized_agg_prim(es):
 
 
 def test_checks_primitives_correct_type(es):
-    error_text = "Primitive .* is not an aggregation primitive"
+    error_text = "Primitive <class \\'featuretools\\.primitives\\.standard\\."\
+                 "transform_primitive\\.Hour\\'> in agg_primitives is not an "\
+                 "aggregation primitive"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id="sessions",
                              entityset=es,
                              agg_primitives=[Hour],
                              trans_primitives=[])
 
-    error_text = "Primitive .* is not a transform primitive"
+    error_text = "Primitive <class \\'featuretools\\.primitives\\.standard\\."\
+                 "aggregation_primitives\\.Last\\'> in trans_primitives is "\
+                 "not a transform primitive"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id="sessions",
                              entityset=es,

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -681,3 +681,19 @@ def test_initialized_agg_prim(es):
                                    trans_primitives=[])
     features = dfs_obj.build_features()
     assert (feature_with_name(features, "N_MOST_COMMON(log.product_id)"))
+
+
+def test_checks_agg_primitives_are_aggs(es):
+    error_text = "Primitive .* is not an aggregation primitive"
+    with pytest.raises(ValueError, match=error_text):
+        DeepFeatureSynthesis(target_entity_id="sessions",
+                             entityset=es,
+                             agg_primitives=[Hour],
+                             trans_primitives=[])
+
+    error_text = "Primitive .* is not a transform primitive"
+    with pytest.raises(ValueError, match=error_text):
+        DeepFeatureSynthesis(target_entity_id="sessions",
+                             entityset=es,
+                             agg_primitives=[],
+                             trans_primitives=[Last])


### PR DESCRIPTION
This PR adds a check in DFS to `agg_primitives` and `trans_primitives` to give a clearer error when primitives are included in the wrong list (putting `Hour` in `agg_primitives`, for exmaple)