### PR TITLE
put make lint on separate run command for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - run: sudo apt update && sudo apt install -y graphviz
       - checkout
       - run: virtualenv venv
-      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make installdeps
+      - run: source venv/bin/activate && make lint
       - run: source venv/bin/activate && make test
 
   "python-3.5":
@@ -19,7 +20,8 @@ jobs:
       - run: sudo apt update && sudo apt install -y graphviz
       - checkout
       - run: virtualenv venv
-      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make installdeps
+      - run: source venv/bin/activate && make lint
       - run: source venv/bin/activate && make test
 
   "python-3.6":
@@ -30,7 +32,8 @@ jobs:
       - run: sudo apt update && sudo apt install -y graphviz pandoc
       - checkout
       - run: virtualenv venv
-      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make installdeps
+      - run: source venv/bin/activate && make lint
       - run: source venv/bin/activate && make -C docs/ -e "SPHINXOPTS=-W" clean html
       - run: |
           source venv/bin/activate
@@ -45,7 +48,8 @@ jobs:
       - run: sudo apt update && sudo apt install -y graphviz
       - checkout
       - run: virtualenv venv
-      - run: source venv/bin/activate && make installdeps lint
+      - run: source venv/bin/activate && make installdeps
+      - run: source venv/bin/activate && make lint
       - run: source venv/bin/activate && make test
 
 workflows:


### PR DESCRIPTION
Since the pip installation and linting output happen on the same set for circleci the pip output obscures the linting results, making it necessary to download the output as a file to check the linting output.  This makes the lint test a separate action to make it more convenient to check.