### PR TITLE
Primitive function name uniqueness

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -4,6 +4,7 @@ import pstats
 import sys
 import warnings
 from datetime import datetime
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -442,6 +443,11 @@ class PandasBackend(ComputationalBackend):
                     func = f.get_function()
                     funcname = func
                     if callable(func):
+                        # if the same function is being applied to the same
+                        # variable twice, wrap it in a partial to avoid
+                        # duplicate functions
+                        if u"{}-{}".format(variable_id, id(func)) in agg_rename:
+                            func = partial(func)
                         func.__name__ = str(id(func))
                         funcname = str(id(func))
 

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -442,9 +442,8 @@ class PandasBackend(ComputationalBackend):
                     func = f.get_function()
                     funcname = func
                     if callable(func):
-                        # make sure func has a unique name due to how pandas names aggregations
-                        func.__name__ = f.primitive.name
-                        funcname = f.primitive.name
+                        func.__name__ = str(id(func))
+                        funcname = str(id(func))
 
                     to_agg[variable_id].append(func)
                     # this is used below to rename columns that pandas names for us

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -441,6 +441,8 @@ class PandasBackend(ComputationalBackend):
                         to_agg[variable_id] = []
 
                     func = f.get_function()
+                    # funcname used in case f.get_function() returns a string
+                    # since strings don't have __name__
                     funcname = func
                     if callable(func):
                         # if the same function is being applied to the same

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -26,9 +26,12 @@ from featuretools.primitives import (  # NMostCommon,
     Mode,
     NMostCommon,
     NotEqualScalar,
+    NumTrue,
     Sum,
     Trend
 )
+from featuretools.primitives.base import AggregationPrimitive
+from featuretools.variable_types import Numeric
 
 
 @pytest.fixture(scope='module')
@@ -524,3 +527,84 @@ def test_empty_child_dataframe():
     fm2 = ft.calculate_feature_matrix(entityset=es, features=[count_where, trend_where], cutoff_time=pd.Timestamp("1/4/2018"))
     names = [count_where.get_name(), trend_where.get_name()]
     assert_array_equal(fm2[names], [[0, np.nan]])
+
+
+def test_handles_primitive_function_name_uniqueness(entityset):
+    class SumTimesN(AggregationPrimitive):
+        name = "sum_times_n"
+        input_types = [Numeric]
+        return_type = Numeric
+
+        def __init__(self, n):
+            self.n = n
+
+        def get_function(self):
+            def my_function(values):
+                return values.sum() * self.n
+
+            return my_function
+
+        def generate_name(self, base_feature_names, child_entity_id,
+                          parent_entity_id, where_str, use_prev_str):
+            base_features_str = ", ".join(base_feature_names)
+            return u"%s(%s.%s%s%s, n=%s)" % (self.name.upper(),
+                                             child_entity_id,
+                                             base_features_str,
+                                             where_str, use_prev_str, self.n)
+
+    # works as expected
+    f1 = ft.Feature(entityset["log"]["value"],
+                    parent_entity=entityset["customers"],
+                    primitive=SumTimesN(n=1))
+    fm = ft.calculate_feature_matrix(features=[f1], entityset=entityset)
+
+    # works as expected
+    f2 = ft.Feature(entityset["log"]["value"],
+                    parent_entity=entityset["customers"],
+                    primitive=SumTimesN(n=2))
+    fm = ft.calculate_feature_matrix(features=[f2], entityset=entityset)
+
+    # same primitive, same variable, different args
+    fm = ft.calculate_feature_matrix(features=[f1, f2], entityset=entityset)
+
+    # different primtives, same function returned by get_function,
+    # different base features
+    f3 = ft.Feature(entityset["log"]["value"],
+                    parent_entity=entityset["customers"],
+                    primitive=Sum)
+    f4 = ft.Feature(entityset["log"]["purchased"],
+                    parent_entity=entityset["customers"],
+                    primitive=NumTrue)
+    fm = ft.calculate_feature_matrix(features=[f3, f4], entityset=entityset)
+
+    # different primtives, same function returned by get_function,
+    # same base feature
+    class Sum1(AggregationPrimitive):
+        """Sums elements of a numeric or boolean feature."""
+        name = "sum1"
+        input_types = [Numeric]
+        return_type = Numeric
+        stack_on_self = False
+        stack_on_exclude = [Count]
+        default_value = 0
+
+        def get_function(self):
+            return np.sum
+
+    class Sum2(AggregationPrimitive):
+        """Sums elements of a numeric or boolean feature."""
+        name = "sum2"
+        input_types = [Numeric]
+        return_type = Numeric
+        stack_on_self = False
+        stack_on_exclude = [Count]
+        default_value = 0
+
+        def get_function(self):
+            return np.sum
+
+    f5 = ft.Feature(entityset["log"]["value"],
+                    parent_entity=entityset["customers"], primitive=Sum1)
+    f6 = ft.Feature(entityset["log"]["value"],
+                    parent_entity=entityset["customers"], primitive=Sum2)
+    fm = ft.calculate_feature_matrix(features=[f5, f6], entityset=entityset)


### PR DESCRIPTION
Fixes some errors related to when multiple primitives used same aggregation function or when two features with same primitive but different parameters were applied to the same base feature.