### PR TITLE
Generate controllable name

### DIFF
--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -16,10 +16,11 @@ class AggregationPrimitive(PrimitiveBase):
     def generate_name(self, base_feature_names, child_entity_id,
                       parent_entity_id, where_str, use_prev_str):
         base_features_str = ", ".join(base_feature_names)
-        return u"%s(%s.%s%s%s)" % (self.name.upper(),
-                                   child_entity_id,
-                                   base_features_str,
-                                   where_str, use_prev_str)
+        return u"%s(%s.%s%s%s)%s" % (self.name.upper(),
+                                     child_entity_id,
+                                     base_features_str,
+                                     where_str, use_prev_str,
+                                     self.get_args_string())
 
 
 def make_agg_primitive(function, input_types, return_type, name=None,

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -16,11 +16,16 @@ class AggregationPrimitive(PrimitiveBase):
     def generate_name(self, base_feature_names, child_entity_id,
                       parent_entity_id, where_str, use_prev_str):
         base_features_str = ", ".join(base_feature_names)
-        return u"%s(%s.%s%s%s)%s" % (self.name.upper(),
-                                     child_entity_id,
-                                     base_features_str,
-                                     where_str, use_prev_str,
-                                     self.get_args_string())
+        output = u"%s(%s.%s%s%s" % (self.name.upper(),
+                                    child_entity_id,
+                                    base_features_str,
+                                    where_str, use_prev_str)
+        arg_string = self.get_args_string()
+        if len(arg_string):
+            output += ', ' + arg_string
+
+        output += ')'
+        return output
 
 
 def make_agg_primitive(function, input_types, return_type, name=None,

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -45,7 +45,9 @@ class PrimitiveBase(object):
         return os.path.join(config.get("primitive_data_folder"), filename)
 
     def get_args_string(self):
-        arguments, *_, defaults = inspect.getargspec(self.__init__)
+        temp = inspect.getargspec(self.__init__)
+        arguments = temp[0]
+        defaults = temp[:-1]
         if defaults is None:
             defaults = []
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import inspect
 import os
 
 import numpy as np
@@ -42,3 +43,23 @@ class PrimitiveBase(object):
 
     def get_filepath(self, filename):
         return os.path.join(config.get("primitive_data_folder"), filename)
+
+    def get_args_string(self):
+        arguments, *_, defaults = inspect.getargspec(self.__init__)
+        args = arguments[1:-len(defaults)]
+        kwargs = arguments[len(defaults) + 1:]
+        print(args, kwargs, defaults)
+        controllable_format = "{0}={1},"
+        controllable_name = ""
+
+        variables = self.__dict__
+        for arg in args:
+            val = variables[arg]
+            controllable_name += controllable_format.format(arg, val)
+
+        for kwarg, default in zip(kwargs, defaults):
+            val = variables[kwarg]
+            if val != default and (not np.isnan(val) or not np.isnan(default)):
+                controllable_name += controllable_format.format(kwarg, val)
+
+        return controllable_name[:-1]

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -45,7 +45,7 @@ class PrimitiveBase(object):
         return os.path.join(config.get("primitive_data_folder"), filename)
 
     def get_args_string(self):
-        if not callable(self.__init__):
+        if not isfunction(self.__init__):
             return ""
 
         temp = inspect.getargspec(self.__init__)

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -47,7 +47,7 @@ class PrimitiveBase(object):
     def get_args_string(self):
         if not callable(self.__init__):
             return ""
-        
+
         temp = inspect.getargspec(self.__init__)
         arguments = temp[0]
         defaults = temp[-1]

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -47,7 +47,7 @@ class PrimitiveBase(object):
     def get_args_string(self):
         temp = inspect.getargspec(self.__init__)
         arguments = temp[0]
-        defaults = temp[:-1]
+        defaults = temp[-1]
         if defaults is None:
             defaults = []
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -45,10 +45,11 @@ class PrimitiveBase(object):
         return os.path.join(config.get("primitive_data_folder"), filename)
 
     def get_args_string(self):
-        if not inspect.isfunction(self.__init__):
+        try:
+            temp = inspect.getargspec(self.__init__)
+        except:
             return ""
-
-        temp = inspect.getargspec(self.__init__)
+            
         arguments = temp[0]
         defaults = temp[-1]
         if defaults is None:

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -46,9 +46,11 @@ class PrimitiveBase(object):
 
     def get_args_string(self):
         arguments, *_, defaults = inspect.getargspec(self.__init__)
+        if defaults is None:
+            defaults = []
+
         args = arguments[1:-len(defaults)]
         kwargs = arguments[len(defaults) + 1:]
-        print(args, kwargs, defaults)
         controllable_format = "{0}={1},"
         controllable_name = ""
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -49,7 +49,7 @@ class PrimitiveBase(object):
             temp = inspect.getargspec(self.__init__)
         except:
             return ""
-            
+
         arguments = temp[0]
         defaults = temp[-1]
         if defaults is None:

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -45,7 +45,7 @@ class PrimitiveBase(object):
         return os.path.join(config.get("primitive_data_folder"), filename)
 
     def get_args_string(self):
-        if not isfunction(self.__init__):
+        if not inspect.isfunction(self.__init__):
             return ""
 
         temp = inspect.getargspec(self.__init__)

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -45,6 +45,9 @@ class PrimitiveBase(object):
         return os.path.join(config.get("primitive_data_folder"), filename)
 
     def get_args_string(self):
+        if not callable(self.__init__):
+            return ""
+        
         temp = inspect.getargspec(self.__init__)
         arguments = temp[0]
         defaults = temp[-1]

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -47,7 +47,7 @@ class PrimitiveBase(object):
     def get_args_string(self):
         try:
             temp = inspect.getargspec(self.__init__)
-        except:
+        except TypeError:
             return ""
 
         arguments = temp[0]

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -16,6 +16,7 @@ class TransformPrimitive(PrimitiveBase):
         name = u"{}(".format(self.name.upper())
         name += u", ".join(base_feature_names)
         name += u")"
+        name += self.get_args_string()
         return name
 
 

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -15,8 +15,10 @@ class TransformPrimitive(PrimitiveBase):
     def generate_name(self, base_feature_names):
         name = u"{}(".format(self.name.upper())
         name += u", ".join(base_feature_names)
+        arg_string = self.get_args_string()
+        if len(arg_string):
+            name += ', ' + arg_string
         name += u")"
-        name += self.get_args_string()
         return name
 
 

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from featuretools.primitives.base import PrimitiveBase
+from featuretools.primitives.base import (
+    AggregationPrimitive,
+    PrimitiveBase,
+    TransformPrimitive
+)
 
 
 class PrimitiveBaseTest(PrimitiveBase):
@@ -14,19 +18,19 @@ class PrimitiveBaseTest(PrimitiveBase):
 
 def test_get_args_string():
     example = PrimitiveBaseTest(1, 2, 3, 4).get_args_string()
-    assert example == "a=1,b=2,c=3,d=4"
+    assert example == "a=1, b=2, c=3, d=4"
 
     example = PrimitiveBaseTest(1, 2, c=3, d=4).get_args_string()
-    assert example == "a=1,b=2,c=3,d=4"
+    assert example == "a=1, b=2, c=3, d=4"
 
     example = PrimitiveBaseTest(1, 2, c=5, d=np.nan).get_args_string()
-    assert example == "a=1,b=2"
+    assert example == "a=1, b=2"
 
     example = PrimitiveBaseTest(1, 2).get_args_string()
-    assert example == "a=1,b=2"
+    assert example == "a=1, b=2"
 
     example = PrimitiveBaseTest(1, 2, c=np.nan, d=np.nan).get_args_string()
-    assert example == "a=1,b=2,c=nan"
+    assert example == "a=1, b=2, c=nan"
 
 
 class PrimitiveBaseTest2(PrimitiveBase):
@@ -36,3 +40,48 @@ class PrimitiveBaseTest2(PrimitiveBase):
 
 def test_empty_args_string():
     assert PrimitiveBaseTest2().get_args_string() == ''
+
+
+# We use transform primitive in primitive base as args_string is
+# used in generate_name which is defined in transform and agg
+class TransformBaseTest(TransformPrimitive):
+    name = "TestTransformPrimitive"
+
+    def __init__(self, a, b, c=0, d=1):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+
+
+def test_generate_trans_name():
+
+    name = "TestTransformPrimitive".upper()
+    name += "(base_feature1, base_feature2, base_feature3, "
+    name += "a=1, b=1, c=1)"
+    base_features = ["base_feature" + str(i + 1) for i in range(3)]
+    assert TransformBaseTest(1, 1, 1, 1).generate_name(base_features) == name
+
+
+# We use transform primitive in primitive base as args_string is
+# used in generate_name which is defined in transform and agg
+class AggBaseTest(AggregationPrimitive):
+    name = "TestAggPrimitive"
+
+    def __init__(self, a, b, c=0, d=1):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+
+
+def test_generate_agg_name():
+
+    name = "TestAggPrimitive".upper()
+    name += "(a.base_feature1, base_feature2, base_feature3cd, "
+    name += "a=1, b=1, c=1)"
+
+    base_features = ["base_feature" + str(i + 1) for i in range(3)]
+    primitive = AggBaseTest(1, 1, 1, 1)
+    generated_name = primitive.generate_name(base_features, 'a', 'b', 'c', 'd')
+    assert name == generated_name

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from featuretools.primitives.base import PrimitiveBase
+
+
+class PrimitiveBaseTest(PrimitiveBase):
+
+    def __init__(self, a, b, c=5, d=np.nan):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+
+
+def test_get_args_string():
+    example = PrimitiveBaseTest(1, 2, 3, 4).get_args_string()
+    assert example == "a=1,b=2,c=3,d=4"
+
+    example = PrimitiveBaseTest(1, 2, c=3, d=4).get_args_string()
+    assert example == "a=1,b=2,c=3,d=4"
+
+    example = PrimitiveBaseTest(1, 2, c=5, d=np.nan).get_args_string()
+    assert example == "a=1,b=2"
+
+    example = PrimitiveBaseTest(1, 2).get_args_string()
+    assert example == "a=1,b=2"
+
+    example = PrimitiveBaseTest(1, 2, c=np.nan, d=np.nan).get_args_string()
+    assert example == "a=1,b=2,c=nan"

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -27,3 +27,12 @@ def test_get_args_string():
 
     example = PrimitiveBaseTest(1, 2, c=np.nan, d=np.nan).get_args_string()
     assert example == "a=1,b=2,c=nan"
+
+
+class PrimitiveBaseTest2(PrimitiveBase):
+    def __init__(self):
+        pass
+
+
+def test_empty_args_string():
+    assert PrimitiveBaseTest2().get_args_string() == ''


### PR DESCRIPTION
For controllable primitives, the name of the primitive needs to be unique, even if the primitive is instantiated twice. aka (ExamplePrimitive(a=5), ExamplePrimitive(a=6)). In those cases, the names for the primitive should include "a=5" and "a=6" respectively