### PR TITLE
fixed tests and plot func

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1150,7 +1150,7 @@ class EntitySet(object):
 
         # Draw entities
         for entity in self.entities:
-            variables_string = '\l'.join([var.id + ' : ' + var.dtype  # noqa: W605
+            variables_string = '\l'.join([var.id + ' : ' + var._dtype_repr  # noqa: W605
                                           for var in entity.variables])
             label = '{%s|%s\l}' % (entity.id, variables_string)  # noqa: W605
             graph.node(entity.id, shape='record', label=label)

--- a/featuretools/tests/entityset_tests/test_plotting.py
+++ b/featuretools/tests/entityset_tests/test_plotting.py
@@ -7,8 +7,6 @@ import pytest
 
 from ..testing_utils import make_ecommerce_entityset
 
-import featuretools as ft
-
 
 @pytest.fixture()
 def entityset():
@@ -16,38 +14,33 @@ def entityset():
 
 
 def test_returns_digraph_object(entityset):
-    new_es = ft.EntitySet()
-
-    graph = new_es.plot()
+    graph = entityset.plot()
 
     assert isinstance(graph, graphviz.Digraph)
 
 
 def test_saving_png_file(entityset):
-    new_es = ft.EntitySet()
     output_path = 'test1.png'
 
-    new_es.plot(to_file=output_path)
+    entityset.plot(to_file=output_path)
 
     assert os.path.isfile(output_path)
     os.remove(output_path)
 
 
 def test_missing_file_extension(entityset):
-    new_es = ft.EntitySet()
     output_path = 'test1'
 
     with pytest.raises(ValueError) as excinfo:
-        new_es.plot(to_file=output_path)
+        entityset.plot(to_file=output_path)
 
     assert str(excinfo.value).startswith('Please use a file extension')
 
 
 def test_invalid_format(entityset):
-    new_es = ft.EntitySet()
     output_path = 'test1.xzy'
 
     with pytest.raises(ValueError) as excinfo:
-        new_es.plot(to_file=output_path)
+        entityset.plot(to_file=output_path)
 
     assert str(excinfo.value).startswith('Unknown format')


### PR DESCRIPTION
- Fixes the plotting function error `AttributeError: 'Index' object has no attribute 'dtype'`
- Fixes the test so that it uses an actual filled EntitySet