### PR TITLE
Haversine Unit argument

### DIFF
--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -299,8 +299,8 @@ class Not(TransformPrimitive):
 
 
 class Percentile(TransformPrimitive):
-    """For each value of the base feature, determines the percentile in relation
-    to the rest of the feature.
+    """For each value of the base feature, determines the percentile in
+        relation to the rest of the feature.
     """
     name = 'percentile'
     uses_full_entity = True
@@ -336,12 +336,19 @@ class Longitude(TransformPrimitive):
 
 
 class Haversine(TransformPrimitive):
-    """Calculate the approximate haversine distance in miles between two LatLong variable types.
+    """Calculate the approximate haversine distance between two LatLong
+        variable types. Defaults to computing in miles.
+
     """
     name = 'haversine'
     input_types = [LatLong, LatLong]
     return_type = Numeric
     commutative = True
+
+    def __init__(self, unit='miles'):
+        if unit not in ['miles', 'kilometers']:
+            raise ValueError("Invalid unit given")
+        self.unit = unit
 
     def get_function(self):
         def haversine(latlong1, latlong2):
@@ -355,6 +362,9 @@ class Haversine(TransformPrimitive):
             dlat = lat2 - lat1
             a = np.sin(dlat / 2.0) ** 2 + np.cos(lat1) * \
                 np.cos(lat2) * np.sin(dlon / 2.0)**2
-            mi = 3950 * 2 * np.arcsin(np.sqrt(a))
-            return mi
+            radius_earth = 3950
+            if self.unit == 'kilometers':
+                radius_earth = 6373
+            distance = radius_earth * 2 * np.arcsin(np.sqrt(a))
+            return distance
         return haversine

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -339,6 +339,17 @@ class Haversine(TransformPrimitive):
     """Calculate the approximate haversine distance between two LatLong
         variable types. Defaults to computing in miles.
 
+        Args:
+            unit (str): Determines the unit value to output. Could
+                be `miles` or `kilometers`. Default is `miles.
+
+        Example:
+
+           .. code-block:: python
+
+                from featuretools.primitives import Haversine
+                haversine_miles = Haversine(unit='miles')
+
     """
     name = 'haversine'
     input_types = [LatLong, LatLong]

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -357,8 +357,10 @@ class Haversine(TransformPrimitive):
     commutative = True
 
     def __init__(self, unit='miles'):
-        if unit not in ['miles', 'kilometers']:
-            raise ValueError("Invalid unit given")
+        valid_units = ['miles', 'kilometers']
+        if unit not in valid_units:
+            error_message = 'Invalid unit %s provided. Must be one of %s' % (unit, valid_units)
+            raise ValueError(error_message)
         self.unit = unit
 
     def get_function(self):

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -368,3 +368,11 @@ class Haversine(TransformPrimitive):
             distance = radius_earth * 2 * np.arcsin(np.sqrt(a))
             return distance
         return haversine
+
+    def generate_name(self, base_feature_names):
+        name = u"{}(".format(self.name.upper())
+        name += u", ".join(base_feature_names)
+        if self.unit != 'miles':
+            name += u", unit={}".format(self.unit)
+        name += u")"
+        return name

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -415,8 +415,7 @@ def test_haversine(es):
             413.07563177, 0., 0., 524.15585776,
             0., 739.93819145, 1464.27975511]
     assert len(values) == 15
-    for i, v in enumerate(real):
-        assert v - values[i] < .0001
+    assert np.allclose(values, real, atol=0.0001)
 
     haversine = ft.Feature([log_latlong_feat, log_latlong_feat2],
                            primitive=Haversine(unit='kilometers'))
@@ -424,13 +423,14 @@ def test_haversine(es):
     df = ft.calculate_feature_matrix(entityset=es, features=features,
                                      instance_ids=range(15))
     values = df[haversine.get_name()].values
-    real_km = [0, 843.5470847509094, 1678.5594029785998, 2496.287761337906,
-               3287.5653521281192, 0, 221.86417805050752, 443.52549697015303,
-               664.7807895352589, 0, 0, 843.5470847509094, 0,
-               1190.8150887809088, 2356.529838207748]
+    real_km = [0, 845.68234976, 1682.80832898, 2502.60659757, 3295.88714394,
+               0, 222.42578133, 444.64819005, 666.46354463, 0, 0,
+               845.68234976, 0, 1193.82939092, 2362.49490616]
     assert len(values) == 15
-    for i, v in enumerate(real_km):
-        assert v - values[i] < .0001
+    assert np.allclose(values, real_km, atol=0.0001)
+    error_text = 'Invalid unit given'
+    with pytest.raises(ValueError, match=error_text):
+        Haversine(unit='inches')
 
 
 class TestCumCount:

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -433,7 +433,6 @@ def test_haversine(es):
         assert v - values[i] < .0001
 
 
-
 class TestCumCount:
 
     primitive = CumCount

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -403,10 +403,12 @@ def test_latlong(es):
 def test_haversine(es):
     log_latlong_feat = es['log']['latlong']
     log_latlong_feat2 = es['log']['latlong2']
-    haversine = ft.Feature([log_latlong_feat, log_latlong_feat2], primitive=Haversine)
+    haversine = ft.Feature([log_latlong_feat, log_latlong_feat2],
+                           primitive=Haversine)
     features = [haversine]
 
-    df = ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(15))
+    df = ft.calculate_feature_matrix(entityset=es, features=features,
+                                     instance_ids=range(15))
     values = df[haversine.get_name()].values
     real = [0., 524.15585776, 1043.00845747, 1551.12130243,
             2042.79840241, 0., 137.86000883, 275.59396684,
@@ -415,6 +417,21 @@ def test_haversine(es):
     assert len(values) == 15
     for i, v in enumerate(real):
         assert v - values[i] < .0001
+
+    haversine = ft.Feature([log_latlong_feat, log_latlong_feat2],
+                           primitive=Haversine(unit='kilometers'))
+    features = [haversine]
+    df = ft.calculate_feature_matrix(entityset=es, features=features,
+                                     instance_ids=range(15))
+    values = df[haversine.get_name()].values
+    real_km = [0, 843.5470847509094, 1678.5594029785998, 2496.287761337906,
+               3287.5653521281192, 0, 221.86417805050752, 443.52549697015303,
+               664.7807895352589, 0, 0, 843.5470847509094, 0,
+               1190.8150887809088, 2356.529838207748]
+    assert len(values) == 15
+    for i, v in enumerate(real_km):
+        assert v - values[i] < .0001
+
 
 
 class TestCumCount:

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -428,7 +428,7 @@ def test_haversine(es):
                845.68234976, 0, 1193.82939092, 2362.49490616]
     assert len(values) == 15
     assert np.allclose(values, real_km, atol=0.0001)
-    error_text = 'Invalid unit given'
+    error_text = "Invalid unit inches provided. Must be one of"
     with pytest.raises(ValueError, match=error_text):
         Haversine(unit='inches')
 


### PR DESCRIPTION
- Added a unit argument to the `Haversine` primitive to specify `miles` or `kilometers`
- Added a test case which checks this calculation. 