### PR TITLE
Primitive call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	flake8 featuretools && isort --check-only --recursive featuretools
 
 lint-fix:
-	autopep8 --in-place --recursive --max-line-length=100 --exclude="*/migrations/*" --select="E225,E303,E302,E203,E128,E231,E251,E271,E127,E126,E301,W293,E226" featuretools
+	autopep8 --in-place --recursive --max-line-length=100 --exclude="*/migrations/*" --select="E225,E303,E302,E203,E128,E231,E251,E271,E127,E126,E301,W291,W293,E226,E306" featuretools
 	isort --recursive featuretools
 
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,7 @@ Before starting major work, you should touch base with the maintainers of Featur
 * Before submitting to GitHub, verify the tests run and the code lints properly
   ```bash
   # runs test
-  make tests
+  make test
 
   # runs linting
   make lint
@@ -53,7 +53,7 @@ Before starting major work, you should touch base with the maintainers of Featur
 
 #### 3. Submit your Pull Request
 
-* Once your changes are ready to be submitted, make sure to push your changes to GitHub before creating a pull request. Create a pull reuest, and our continuous integration will run automatically. We will review your changes, and you will most likely be asked to make additional changes before it is finally ready to merge. However, once it's reviewed by a maintainer of Featuretools, passes continuous integration, we will merge it, and you will have successfully contributed to Featuretools!
+* Once your changes are ready to be submitted, make sure to push your changes to GitHub before creating a pull request. Create a pull request, and our continuous integration will run automatically. We will review your changes, and you will most likely be asked to make additional changes before it is finally ready to merge. However, once it's reviewed by a maintainer of Featuretools, passes continuous integration, we will merge it, and you will have successfully contributed to Featuretools!
 
 ## Report issues
 When reporting issues please include as much detail as possible about your operating system, featuretools version and python version. Whenever possible, please also include a brief, self-contained code example that demonstrates the problem.

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -34,6 +34,15 @@ class PrimitiveBase(object):
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
 
+    def __call__(self,data):
+        # We only want to call get_function once, when __call__ is run for the
+        # first time. Since we know that we don't need to call get_function after
+        # that, we can redefine the __call__ function instead of checking for if
+        # it is the first time __call__ has been called 
+        self.__call__ = self.get_function()
+        return self.__call__(data)
+
+
     def generate_name(self):
         raise NotImplementedError("Subclass must implement")
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os
 
 import numpy as np
+import pandas as pd
 
 from featuretools import config
 
@@ -39,7 +40,8 @@ class PrimitiveBase(object):
         # first time. Since we know that we don't need to call get_function after
         # that, we can redefine the __call__ function instead of checking for if
         # it is the first time __call__ has been called
-        self.__call__ = self.get_function()
+        method = self.get_function()
+        self.__call__ = lambda data: method(pd.Series(data))
         return self.__call__(data)
 
     def generate_name(self):

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -35,14 +35,13 @@ class PrimitiveBase(object):
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
 
-    def __call__(self, data):
-        # We only want to call get_function once, when __call__ is run for the
-        # first time. Since we know that we don't need to call get_function after
-        # that, we can redefine the __call__ function instead of checking for if
-        # it is the first time __call__ has been called
-        method = self.get_function()
-        self.__call__ = lambda data: method(pd.Series(data))
-        return self.__call__(data)
+    def __call__(self, *args, **kwargs):
+        series_args = [pd.Series(arg) for arg in args]
+        try:
+            return self.method(*series_args, **kwargs)
+        except AttributeError:
+            self.method = self.get_function()
+            return self.method(*series_args, **kwargs)
 
     def generate_name(self):
         raise NotImplementedError("Subclass must implement")

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -34,14 +34,13 @@ class PrimitiveBase(object):
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
 
-    def __call__(self,data):
+    def __call__(self, data):
         # We only want to call get_function once, when __call__ is run for the
         # first time. Since we know that we don't need to call get_function after
         # that, we can redefine the __call__ function instead of checking for if
-        # it is the first time __call__ has been called 
+        # it is the first time __call__ has been called
         self.__call__ = self.get_function()
         return self.__call__(data)
-
 
     def generate_name(self):
         raise NotImplementedError("Subclass must implement")

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -41,12 +41,9 @@ def test_call_multiple_args():
     class TestPrimitive(PrimitiveBase):
         def get_function(self):
             def test(x, y):
-                print("x", x)
-                print("y", y)
                 return y
             return test
     primitive = TestPrimitive()
-    print("Output", primitive(range(1), range(2)))
     assert pd.Series([0, 1]).equals(primitive(range(1), range(2)))
     assert pd.Series([0, 1]).equals(primitive(range(1), range(2)))
 

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -1,0 +1,8 @@
+from featuretools.primitives import Max
+
+def test_call():
+    primitive = Max()
+
+    #the assert is run twice on purpose
+    assert 5 == primitive(range(6))
+    assert 5 == primitive(range(6))

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -1,9 +1,69 @@
-from featuretools.primitives import Max
+from datetime import datetime
+
+import pandas as pd
+
+from featuretools.primitives import IsNull, Max
+from featuretools.primitives.base import PrimitiveBase, make_agg_primitive
+from featuretools.variable_types import DatetimeTimeIndex, Numeric
 
 
-def test_call():
+def test_call_agg():
     primitive = Max()
 
     # the assert is run twice on purpose
     assert 5 == primitive(range(6))
     assert 5 == primitive(range(6))
+
+
+def test_call_trans():
+    primitive = IsNull()
+    assert pd.Series([False for i in range(6)]).equals(primitive(range(6)))
+    assert pd.Series([False for i in range(6)]).equals(primitive(range(6)))
+
+
+def test_uses_calc_time():
+    def time_since_last(values, time=None):
+        time_since = time - values.iloc[0]
+        return time_since.total_seconds()
+
+    TimeSinceLast = make_agg_primitive(time_since_last,
+                                       [DatetimeTimeIndex],
+                                       Numeric,
+                                       name="time_since_last",
+                                       uses_calc_time=True)
+    primitive = TimeSinceLast()
+    datetimes = pd.Series([datetime(2015, 6, 7), datetime(2015, 6, 6)])
+    answer = 86400.0
+    assert answer == primitive(datetimes, time=datetime(2015, 6, 8))
+
+
+def test_call_multiple_args():
+    class TestPrimitive(PrimitiveBase):
+        def get_function(self):
+            def test(x, y):
+                print("x", x)
+                print("y", y)
+                return y
+            return test
+    primitive = TestPrimitive()
+    print("Output", primitive(range(1), range(2)))
+    assert pd.Series([0, 1]).equals(primitive(range(1), range(2)))
+    assert pd.Series([0, 1]).equals(primitive(range(1), range(2)))
+
+
+def test_get_function_called_once():
+    class TestPrimitive(PrimitiveBase):
+        def __init__(self):
+            self.get_function_call_count = 0
+
+        def get_function(self):
+            self.get_function_call_count += 1
+
+            def test(x):
+                return x
+            return test
+
+    primitive = TestPrimitive()
+    primitive(range(6))
+    primitive(range(6))
+    assert primitive.get_function_call_count == 1

--- a/featuretools/tests/primitive_tests/test_primitive_base.py
+++ b/featuretools/tests/primitive_tests/test_primitive_base.py
@@ -1,8 +1,9 @@
 from featuretools.primitives import Max
 
+
 def test_call():
     primitive = Max()
 
-    #the assert is run twice on purpose
+    # the assert is run twice on purpose
     assert 5 == primitive(range(6))
     assert 5 == primitive(range(6))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ mock==2.0.0
 pympler==0.5
 pytest-xdist==1.26.1
 pytest-cov==2.6.1
+llvmlite==0.27.0
 fastparquet>=0.1.6
 graphviz>=0.8.4
 s3fs>=0.1.5


### PR DESCRIPTION
We don't want to call get_function in the init.

We could store the output of self.get_function() and check if that exists every time in the call function. 
``` python
def __call__(self,data):
    if not hasattr(self,method):
        self.method = self.get_function()
    return self.method(data)
```
That goes against the pythonic "it's Easier to Ask for Forgiveness than Permission" (EAFP) *in this case we're using "Look Before You  Leap" (LBYL)*. To fix this we can use a try except instead.

```python
def __call__(self,data):
    try:
        return self.method(data)
    except AttributeError:
        self.method = self.get_function()
        return self.method(data)
```
We already know when we need to call `get_function` , and it's on the first time` __call__` is run. So instead of using the try except function we can call `get_function` in the `__call__` function, and then redefine `__call__` to be the output of `get_function` This way there are no unnecessary checks

```python
def __call__(self,data):
    self.__call__ = self.get_function()
    return self.__call__(data)
```

This approach doesn't work because `__call__` is a special  method. When a class instance, for example `primitive` gets called like `primitive(data)`, python under the hood runs `type(primitive).__call__(primitive,data)` instead of `primitive.__call__data`

We can get around this by using a non special method as an intermediate.

```python
def __call__(self,*args,**kwargs):
    self._temp_call(*args,**kwargs)

def _temp_call(self, *args, **kwargs):
    self._temp_call = self.get_function().__get__(self)
    return self._temp_call(*args,**kwargs)
```
This way the second time `_temp_call` has been called, it's set to the output of `get_function`. 

Note that the `self.get_function()` has `__get__(self)` also. This is because to add a function to an instance of a class, and not the class itself, you have to bind the instance to the function, aka add `self` as the first parameter always. I don't fully understand how this works, but it's done using `__get__(x)`

Given that we can't overwrite __call__, and that it isn't standard to add/update the methods of an instance, it feels like the if statement, or the try except would be the better solution

Fixes #460 