### PR TITLE
Change groupby_transform_primitives parameter name to groupby_trans_primitives

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Breaking Changes:
 
-* ``ft.dfs`` now has a ``groupby_transform_primitives`` parameter that DFS uses to automatically construct features that group by an ID column and then apply a transform primitive to search group. This change applies to the following primitives: ``CumSum``, ``CumCount``, ``CumMean``, ``CumMin``, and ``CumMax``.
+* ``ft.dfs`` now has a ``groupby_trans_primitives`` parameter that DFS uses to automatically construct features that group by an ID column and then apply a transform primitive to search group. This change applies to the following primitives: ``CumSum``, ``CumCount``, ``CumMean``, ``CumMin``, and ``CumMax``.
 
     Previous behavior
 
@@ -22,7 +22,7 @@ Breaking Changes:
 
         ft.dfs(entityset=es,
                target_entity='customers',
-               groupby_transform_primitives=["cum_mean"])
+               groupby_trans_primitives=["cum_mean"])
 
 * Related to the above change, cumulative transform features are now defined using a new feature class, ``GroupByTransformFeature``.
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -48,7 +48,7 @@ class DeepFeatureSynthesis(object):
 
                     ["count"]
 
-            groupby_transform_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
+            groupby_trans_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
                 list of Transform primitives to make GroupByTransformFeatures with
 
             max_depth (int, optional) : maximum allowed depth of features.
@@ -89,7 +89,7 @@ class DeepFeatureSynthesis(object):
                  agg_primitives=None,
                  trans_primitives=None,
                  where_primitives=None,
-                 groupby_transform_primitives=None,
+                 groupby_trans_primitives=None,
                  max_depth=2,
                  max_hlevel=2,
                  max_features=-1,
@@ -175,12 +175,12 @@ class DeepFeatureSynthesis(object):
             p = handle_primitive(p)
             self.where_primitives.append(p)
 
-        if groupby_transform_primitives is None:
-            groupby_transform_primitives = []
-        self.groupby_transform_primitives = []
-        for p in groupby_transform_primitives:
+        if groupby_trans_primitives is None:
+            groupby_trans_primitives = []
+        self.groupby_trans_primitives = []
+        for p in groupby_trans_primitives:
             p = check_trans_primitive(p)
-            self.groupby_transform_primitives.append(p)
+            self.groupby_trans_primitives.append(p)
 
         self.seed_features = seed_features or []
         self.drop_exact = drop_exact or []
@@ -507,7 +507,7 @@ class DeepFeatureSynthesis(object):
                     self._handle_new_feature(all_features=all_features,
                                              new_feature=new_f)
 
-        for groupby_prim in self.groupby_transform_primitives:
+        for groupby_prim in self.groupby_trans_primitives:
             # Normally input_types is a list of what inputs can be supplied to
             # the primitive function.  Here we temporarily add `Id` as an extra
             # item in input_types so that the matching function will also look
@@ -796,6 +796,6 @@ def check_trans_primitive(primitive):
     primitive = handle_primitive(primitive)
     if not isinstance(primitive, TransformPrimitive):
         raise ValueError("Primitive {} in trans_primitives or "
-                         "groupby_transform_primitives is not a transform "
+                         "groupby_trans_primitives is not a transform "
                          "primitive".format(type(primitive)))
     return primitive

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -15,7 +15,7 @@ def dfs(entities=None,
         instance_ids=None,
         agg_primitives=None,
         trans_primitives=None,
-        groupby_transform_primitives=None,
+        groupby_trans_primitives=None,
         allowed_paths=None,
         max_depth=2,
         ignore_entities=None,
@@ -75,7 +75,7 @@ def dfs(entities=None,
 
                 Default: ["day", "year", "month", "weekday", "haversine", "num_words", "num_characters"]
 
-        groupby_transform_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
+        groupby_trans_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
             list of Transform primitives to make GroupByTransformFeatures with
 
         allowed_paths (list[list[str]]): Allowed entity paths on which to make
@@ -191,7 +191,7 @@ def dfs(entities=None,
     dfs_object = DeepFeatureSynthesis(target_entity, entityset,
                                       agg_primitives=agg_primitives,
                                       trans_primitives=trans_primitives,
-                                      groupby_transform_primitives=groupby_transform_primitives,
+                                      groupby_trans_primitives=groupby_trans_primitives,
                                       max_depth=max_depth,
                                       where_primitives=where_primitives,
                                       allowed_paths=allowed_paths,

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -269,7 +269,7 @@ def test_make_groupby_features(es):
                                    entityset=es,
                                    agg_primitives=[],
                                    trans_primitives=[],
-                                   groupby_transform_primitives=['cum_sum'])
+                                   groupby_trans_primitives=['cum_sum'])
     features = dfs_obj.build_features()
     assert (feature_with_name(features,
                               "CUM_SUM(value) by session_id"))
@@ -280,7 +280,7 @@ def test_make_groupby_features_with_agg(es):
                                    entityset=es,
                                    agg_primitives=['sum'],
                                    trans_primitives=[],
-                                   groupby_transform_primitives=['cum_sum'])
+                                   groupby_trans_primitives=['cum_sum'])
     features = dfs_obj.build_features()
     agg_on_groupby_name = u"SUM(customers.CUM_SUM(age) by région_id)"
     assert (feature_with_name(features, agg_on_groupby_name))
@@ -293,7 +293,7 @@ def test_bad_groupby_feature(es):
                              entityset=es,
                              agg_primitives=['sum'],
                              trans_primitives=[],
-                             groupby_transform_primitives=['max'])
+                             groupby_trans_primitives=['max'])
 
 
 def test_abides_by_max_depth_param(es):
@@ -775,7 +775,7 @@ def test_checks_primitives_correct_type(es):
 
     error_text = "Primitive <class \\'featuretools\\.primitives\\.standard\\."\
                  "aggregation_primitives\\.Last\\'> in trans_primitives or "\
-                 "groupby_transform_primitives is not a transform primitive"
+                 "groupby_trans_primitives is not a transform primitive"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id="sessions",
                              entityset=es,

--- a/featuretools/tests/dfs_tests/test_dfs_method.py
+++ b/featuretools/tests/dfs_tests/test_dfs_method.py
@@ -109,7 +109,7 @@ def test_all_variables(entities, relationships):
                                    instance_ids=instance_ids,
                                    agg_primitives=[Max, Mean, Min, Sum],
                                    trans_primitives=[],
-                                   groupby_transform_primitives=["cum_sum"],
+                                   groupby_trans_primitives=["cum_sum"],
                                    max_depth=3,
                                    allowed_paths=None,
                                    ignore_entities=None,


### PR DESCRIPTION
Changes the DeepFeatureSynthesis paramater to match the shortened naming style used with `agg_primitives` and `trans_primitives`