### PR TITLE
Update how standard primitives are imported internally

### DIFF
--- a/featuretools/primitives/api.py
+++ b/featuretools/primitives/api.py
@@ -1,8 +1,5 @@
 # flake8: noqa
-from .standard.aggregation_primitives import *
-from .standard.binary_transform import *
-from .standard.cum_transform_feature import *
-from .standard.transform_primitive import *
+from .standard import *
 from .utils import (
     get_aggregation_primitives,
     get_transform_primitives,

--- a/featuretools/primitives/standard/__init__.py
+++ b/featuretools/primitives/standard/__init__.py
@@ -1,0 +1,4 @@
+from .aggregation_primitives import *
+from .binary_transform import *
+from .cum_transform_feature import *
+from .transform_primitive import *


### PR DESCRIPTION
This PR updates how the standard primitives are imported to better support loading extra primitives from entry points. 

As things stand, if a primitive is loaded from an entry point it overwrites the standard primitive. 

With this PR, a user can still access the standard primitives using `from featuretools.primitives.standard import PrimitiveName`