### PR TITLE
Remove primitives that return strings instead of functions

### DIFF
--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -492,17 +492,17 @@ class PandasBackend(ComputationalBackend):
                     elif func == pd.Series.count:
                         func = "count"
 
-                    # funcname used in case func is a string
-                    # since strings don't have __name__
                     funcname = func
                     if callable(func):
                         # if the same function is being applied to the same
                         # variable twice, wrap it in a partial to avoid
                         # duplicate functions
-                        if u"{}-{}".format(variable_id, id(func)) in agg_rename:
-                            func = partial(func)
-                        func.__name__ = str(id(func))
                         funcname = str(id(func))
+                        if u"{}-{}".format(variable_id, funcname) in agg_rename:
+                            func = partial(func)
+                            funcname = str(id(func))
+
+                        func.__name__ = funcname
 
                     to_agg[variable_id].append(func)
                     # this is used below to rename columns that pandas names for us

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -13,7 +13,6 @@ import pandas.api.types as pdtypes
 from .base_backend import ComputationalBackend
 from .feature_tree import FeatureTree
 
-from featuretools.utils import is_python_2
 from featuretools import variable_types
 from featuretools.exceptions import UnknownFeature
 from featuretools.feature_base import (
@@ -23,6 +22,7 @@ from featuretools.feature_base import (
     IdentityFeature,
     TransformFeature
 )
+from featuretools.utils import is_python_2
 from featuretools.utils.gen_utils import (
     get_relationship_variable_id,
     make_tqdm_iterator

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from ..base.aggregation_primitive_base import AggregationPrimitive
 
-import featuretools as ft
+from featuretools.utils import is_python_2
 from featuretools.variable_types import (
     Boolean,
     DatetimeTimeIndex,
@@ -27,9 +27,9 @@ class Count(AggregationPrimitive):
     default_value = 0
 
     def get_function(self):
-        # note: returning pd.Series.nunique errors for python2,
+        # note: returning class instance method errors for python2,
         # so using this branching code path while we support python2
-        if ft.utils.is_python_2():
+        if is_python_2():
             return pd.Series.count.__func__
         else:
             return pd.Series.count
@@ -140,9 +140,9 @@ class NUnique(AggregationPrimitive):
     stack_on_self = False
 
     def get_function(self):
-        # note: returning pd.Series.nunique errors for python2,
+        # note: returning class instance method errors for python2,
         # so using this branching code path while we support python2
-        if ft.utils.is_python_2():
+        if is_python_2():
             return pd.Series.nunique.__func__
         else:
             return pd.Series.nunique
@@ -264,9 +264,9 @@ class Skew(AggregationPrimitive):
     stack_on_self = False
 
     def get_function(self):
-        # note: returning pd.Series.nunique errors for python2,
+        # note: returning class instance method errors for python2,
         # so using this branching code path while we support python2
-        if ft.utils.is_python_2():
+        if is_python_2():
             return pd.Series.skew.__func__
         else:
             return pd.Series.skew

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -27,6 +27,8 @@ class Count(AggregationPrimitive):
     default_value = 0
 
     def get_function(self):
+        # note: returning pd.Series.nunique errors for python2,
+        # so using this branching code path while we support python2
         if ft.utils.is_python_2():
             return pd.Series.count.__func__
         else:
@@ -262,6 +264,8 @@ class Skew(AggregationPrimitive):
     stack_on_self = False
 
     def get_function(self):
+        # note: returning pd.Series.nunique errors for python2,
+        # so using this branching code path while we support python2
         if ft.utils.is_python_2():
             return pd.Series.skew.__func__
         else:

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from ..base.aggregation_primitive_base import AggregationPrimitive
 
+import featuretools as ft
 from featuretools.variable_types import (
     Boolean,
     DatetimeTimeIndex,
@@ -26,7 +27,10 @@ class Count(AggregationPrimitive):
     default_value = 0
 
     def get_function(self):
-        return 'count'
+        if ft.utils.is_python_2():
+            return pd.Series.count.__func__
+        else:
+            return pd.Series.count
 
     def generate_name(self, base_feature_names, child_entity_id,
                       parent_entity_id, where_str, use_prev_str):
@@ -136,11 +140,8 @@ class NUnique(AggregationPrimitive):
     def get_function(self):
         # note: returning pd.Series.nunique errors for python2,
         # so using this branching code path while we support python2
-        from sys import version_info
-        if version_info.major < 3:
-            def nunique(x):
-                return pd.Series(x).nunique()
-            return nunique
+        if ft.utils.is_python_2():
+            return pd.Series.nunique.__func__
         else:
             return pd.Series.nunique
 
@@ -244,7 +245,7 @@ class Median(AggregationPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda x: x.median()
+        return np.median
 
 
 class Skew(AggregationPrimitive):
@@ -261,7 +262,10 @@ class Skew(AggregationPrimitive):
     stack_on_self = False
 
     def get_function(self):
-        return 'skew'
+        if ft.utils.is_python_2():
+            return pd.Series.skew.__func__
+        else:
+            return pd.Series.skew
 
 
 class Std(AggregationPrimitive):

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from inspect import isclass
 
 import pandas as pd
@@ -8,10 +7,9 @@ from .base import AggregationPrimitive, PrimitiveBase, TransformPrimitive
 
 import featuretools
 
-IS_PY2 = (sys.version_info[0] == 2)
+from featuretools.utils import is_python_2
 
-
-if IS_PY2:
+if is_python_2():
     import imp
 else:
     import importlib.util
@@ -104,7 +102,7 @@ def check_valid_primitive_path(path):
 def load_primitive_from_file(filepath):
     """load primitive objects in a file"""
     module = os.path.basename(filepath)[:-3]
-    if IS_PY2:
+    if is_python_2():
         # for python 2.7
         module = imp.load_source(module, filepath)
     else:

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -6,7 +6,6 @@ import pandas as pd
 from .base import AggregationPrimitive, PrimitiveBase, TransformPrimitive
 
 import featuretools
-
 from featuretools.utils import is_python_2
 
 if is_python_2():

--- a/featuretools/utils/api.py
+++ b/featuretools/utils/api.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .cli_utils import get_installed_packages, get_sys_info
 from .entry_point import entry_point
-from .gen_utils import is_string, make_tqdm_iterator
+from .gen_utils import is_python_2, is_string, make_tqdm_iterator
 from .pickle_utils import load_features, save_features
 from .time_utils import make_temporal_cutoffs

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -78,3 +78,7 @@ def get_relationship_variable_id(path):
         child_link_name = '%s.%s' % (r.parent_entity.id,
                                      parent_link_name)
     return child_link_name
+
+
+def is_python_2():
+    return sys.version_info.major < 3


### PR DESCRIPTION
We were returning strings in some cases to improve performance. This breaks api with other primitives. We can simply return pandas objects instead add the string optimization into pandas backend. 