### PR TITLE
Remove pytest options for code that has been phased out

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ description-file = README.md
 [aliases]
 test=pytest
 [tool:pytest]
-addopts = -m "not requires_training_data and not requires_credentials" --ignore "featuretools/tests/primitive_tests/primitives_to_install/featuretools_pip_tester/" --doctest-modules
+addopts = --doctest-modules
 python_files = featuretools/tests/*
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
The `requires_training_data` and `require_credentials` markers are no longer used.  The `featuretools_pip_tester` folder is no longer in our codebase.