### PR TITLE
Remove build_ext code from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=open('requirements.txt').readlines(),
     setup_requires=open('setup-requirements.txt').readlines(),
     python_requires='>=2.7, <4',
-    cmdclass={'build_ext': build_ext},
     test_suite='featuretools/tests',
     tests_require=open('test-requirements.txt').readlines(),
     keywords='feature engineering data science machine learning',

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,10 @@
 from os import path
 
 from setuptools import find_packages, setup
-from setuptools.command.build_ext import build_ext as _build_ext
 
 dirname = path.abspath(path.dirname(__file__))
 with open(path.join(dirname, 'README.md')) as f:
     long_description = f.read()
-
-
-# Bootstrap numpy install
-class build_ext(_build_ext):
-
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
 
 setup(
     name='featuretools',


### PR DESCRIPTION
To my knowledge featuretools doesn't build any extension modules currently, this code must is left over from early development