### PR TITLE
Update api_reference.rst

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -167,7 +167,7 @@ Text Transform Primitives
 Location Transform Primitives
 *****************************
 .. autosummary::
-   :toctree generated/
+   :toctree: generated/
 
    Latitude
    Longitude


### PR DESCRIPTION
- missing colon resulted in class Names that were not clickable. 