### PR TITLE
Add error message when target entity does not exist

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -126,7 +126,8 @@ class EntitySet(object):
         """
         if entity_id in self.entity_dict:
             return self.entity_dict[entity_id]
-        raise KeyError('Entity %s does not exist in %s' % (entity_id, self.id))
+        name = self.id or "entity set"
+        raise KeyError('Entity %s does not exist in %s' % (entity_id, name))
 
     @property
     def entities(self):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -98,6 +98,12 @@ class DeepFeatureSynthesis(object):
                  drop_contains=None,
                  drop_exact=None,
                  where_stacking_limit=1):
+
+        if target_entity_id not in entityset.entity_dict:
+            es_name = entityset.id or 'entity set'
+            msg = 'Provided target entity %s does not exist in %s' % (target_entity_id, es_name)
+            raise KeyError(msg)
+
         # need to change max_depth and max_hlevel to None because DFs terminates when  <0
         if max_depth == -1:
             max_depth = None

--- a/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
+++ b/featuretools/tests/dfs_tests/test_deep_feature_synthesis.py
@@ -121,6 +121,25 @@ def test_only_makes_supplied_agg_feat(es):
     assert len(other_agg_features) == 0
 
 
+def test_error_for_missing_target_entity(es):
+    error_text = 'Provided target entity missing_entity does not exist in ecommerce'
+    with pytest.raises(KeyError, match=error_text):
+        DeepFeatureSynthesis(target_entity_id='missing_entity',
+                             entityset=es,
+                             agg_primitives=[Last],
+                             trans_primitives=[],
+                             ignore_entities=['log'])
+
+    es_without_id = ft.EntitySet()
+    error_text = 'Provided target entity missing_entity does not exist in entity set'
+    with pytest.raises(KeyError, match=error_text):
+        DeepFeatureSynthesis(target_entity_id='missing_entity',
+                             entityset=es_without_id,
+                             agg_primitives=[Last],
+                             trans_primitives=[],
+                             ignore_entities=['log'])
+
+
 def test_ignores_entities(es):
     error_text = 'ignore_entities must be a list'
     with pytest.raises(TypeError, match=error_text):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -3,7 +3,7 @@ import pytest
 
 from ..testing_utils import make_ecommerce_entityset
 
-from featuretools import Relationship, variable_types
+from featuretools import EntitySet, Relationship, variable_types
 
 
 @pytest.fixture
@@ -131,6 +131,11 @@ def test_raise_key_error_missing_entity(es):
     error_text = "Entity this entity doesn't exist does not exist in ecommerce"
     with pytest.raises(KeyError, match=error_text):
         es["this entity doesn't exist"]
+
+    es_without_id = EntitySet()
+    error_text = "Entity this entity doesn't exist does not exist in entity set"
+    with pytest.raises(KeyError, match=error_text):
+        es_without_id["this entity doesn't exist"]
 
 
 def test_add_parent_not_index_variable(es):


### PR DESCRIPTION
Also improve error message for EntitySets without an id when there is no
entity with the given name.

Resolves #466.