### PR TITLE
Remove unnecessary sorting from normalize_entity

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -729,12 +729,17 @@ class EntitySet(object):
             make_time_index = True
 
         if isinstance(make_time_index, str):
+            # Set the new time index to make_time_index.
             base_time_index = make_time_index
             new_entity_time_index = make_time_index
+            already_sorted = (new_entity_time_index == base_entity.time_index)
         elif make_time_index:
+            # Create a new time index based on the base entity time index.
             base_time_index = base_entity.time_index
             if new_entity_time_index is None:
                 new_entity_time_index = "first_%s_time" % (base_entity.id)
+
+            already_sorted = True
 
             assert base_entity.time_index is not None, \
                 "Base entity doesn't have time_index defined"
@@ -745,6 +750,7 @@ class EntitySet(object):
             transfer_types[new_entity_time_index] = type(base_entity[base_entity.time_index])
         else:
             new_entity_time_index = None
+            already_sorted = False
 
         selected_variables = [index] +\
             [v for v in additional_variables] +\
@@ -786,7 +792,7 @@ class EntitySet(object):
             new_entity_id,
             new_entity_df,
             index,
-            already_sorted=(new_entity_time_index == base_entity.time_index),
+            already_sorted=already_sorted,
             time_index=new_entity_time_index,
             secondary_time_index=make_secondary_time_index,
             variable_types=transfer_types)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -730,7 +730,7 @@ class EntitySet(object):
 
         if isinstance(make_time_index, str):
             base_time_index = make_time_index
-            new_entity_time_index = base_entity[make_time_index].id
+            new_entity_time_index = make_time_index
         elif make_time_index:
             base_time_index = base_entity.time_index
             if new_entity_time_index is None:
@@ -743,10 +743,6 @@ class EntitySet(object):
                 copy_variables.append(base_time_index)
 
             transfer_types[new_entity_time_index] = type(base_entity[base_entity.time_index])
-
-            new_entity_df.sort_values([base_time_index, base_entity.index],
-                                      kind="mergesort",
-                                      inplace=True)
         else:
             new_entity_time_index = None
 
@@ -790,6 +786,7 @@ class EntitySet(object):
             new_entity_id,
             new_entity_df,
             index,
+            already_sorted=(new_entity_time_index == base_entity.time_index),
             time_index=new_entity_time_index,
             secondary_time_index=make_secondary_time_index,
             variable_types=transfer_types)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -838,6 +838,7 @@ def test_normalize_time_index_from_none(entityset):
     entityset['customers'].time_index = None
     entityset.normalize_entity('customers', 'birthdays', 'date_of_birth', make_time_index='date_of_birth')
     assert entityset['birthdays'].time_index == 'date_of_birth'
+    assert entityset['birthdays'].df['date_of_birth'].is_monotonic_increasing
 
 
 def test_raise_error_if_dupicate_additional_variables_passed(entityset):
@@ -898,13 +899,15 @@ def test_make_time_index_keeps_original_sorting():
 
 
 def test_normalize_entity_new_time_index(entityset):
+    new_time_index = 'value_time'
     entityset.normalize_entity('log', 'values', 'value',
                                make_time_index=True,
-                               new_entity_time_index="value_time")
+                               new_entity_time_index=new_time_index)
 
-    assert entityset['values'].time_index == 'value_time'
-    assert 'value_time' in entityset['values'].df.columns
+    assert entityset['values'].time_index == new_time_index
+    assert new_time_index in entityset['values'].df.columns
     assert len(entityset['values'].df.columns) == 2
+    assert entityset['values'].df[new_time_index].is_monotonic_increasing
 
 
 def test_secondary_time_index(entityset):


### PR DESCRIPTION
We can assume the base entity dataframe is sorted by time index, so if
we are using the same time index for the new entity then there is no
need to sort.