### PR TITLE
Cache feature names

### DIFF
--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -24,8 +24,6 @@ from featuretools.variable_types import (
 
 
 class FeatureBase(object):
-    _name = None
-
     def __init__(self, entity, base_features, primitive):
         """Base class for all features
 
@@ -46,6 +44,8 @@ class FeatureBase(object):
         if not isinstance(primitive, PrimitiveBase):
             primitive = primitive()
         self.primitive = primitive
+
+        self._name = None
 
         assert self._check_input_types(), ("Provided inputs don't match input "
                                            "type requirements")

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -64,9 +64,9 @@ class FeatureBase(object):
         raise NotImplementedError("Must define copy on FeatureBase subclass")
 
     def get_name(self):
-        if self._name is not None:
-            return self._name
-        return self.generate_name()
+        if not self._name:
+            self._name = self.generate_name()
+        return self._name
 
     def get_feature_names(self):
         n = self.number_output_features


### PR DESCRIPTION
Computing the name of a feature can be expensive because primitives use
reflection to generate their names, and when features are stacked the
number of calls to `get_name()` grows. This commit caches the name when it
is computed the first time. Is it reasonable to assume that features are
immutable, or are there places where we should invalidate the cache?

With `max_depth=2` this sped up `ft.dfs` (just building the features) by
about 3x, and the improvement is greater for higher values of `max_depth`.