### PR TITLE
Update sklearn version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ dask>=1.1.0
 distributed>=1.24.2
 psutil>=5.4.8
 click>=7.0.0
-scikit-learn>=0.20.0
+scikit-learn>=0.20.0,<0.21; python_version < '3'
+scikit-learn>=0.20.0; python_version >= '3'
 funcsigs>=1.0.2; python_version < '3'


### PR DESCRIPTION
sklearn 0.21 doesn't support python 27 so we must adjust our version requirement