### PR TITLE
Add relationship_path to agg and direct features

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -256,8 +256,8 @@ EntitySet query methods
     :toctree: generated/
 
     EntitySet.__getitem__
-    EntitySet.find_backward_path
-    EntitySet.find_forward_path
+    EntitySet.find_backward_paths
+    EntitySet.find_forward_paths
     EntitySet.get_forward_entities
     EntitySet.get_backward_entities
 

--- a/featuretools/computational_backends/feature_tree.py
+++ b/featuretools/computational_backends/feature_tree.py
@@ -198,8 +198,9 @@ class FeatureTree(object):
             # like an identity feature.
             if f.entity.id in self.top_level_features.keys() and \
                     f.entity.id != entity_id and not \
-                    self.entityset.find_backward_path(start_entity_id=entity_id,
-                                                      goal_entity_id=f.entity.id):
+                    next(self.entityset.find_backward_paths(start_entity_id=entity_id,
+                                                            goal_entity_id=f.entity.id),
+                         None):
                 continue
 
             # otherwise, add this feature to the output dict

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -168,8 +168,9 @@ class PandasBackend(ComputationalBackend):
                 # descendent entity frames will have to be re-calculated.
                 # TODO: this check might not be necessary, depending on our
                 # constraints
-                if not self.entityset.find_backward_path(start_entity_id=filter_eid,
-                                                         goal_entity_id=eid):
+                paths = self.entityset.find_backward_paths(start_entity_id=filter_eid,
+                                                           goal_entity_id=eid)
+                if not next(paths, None):
                     entity_frames[eid] = eframes_by_filter[eid][eid]
                     # TODO: look this over again
                     # precalculated features will only be placed in entity_frames,
@@ -382,7 +383,8 @@ class PandasBackend(ComputationalBackend):
 
         assert entity_id in entity_frames and parent_entity_id in entity_frames
 
-        path = self.entityset.find_forward_path(entity_id, parent_entity_id)
+        paths = self.entityset.find_forward_paths(entity_id, parent_entity_id)
+        path = next(paths)
         assert len(path) == 1, \
             "Error calculating DirectFeatures, len(path) > 1"
 
@@ -447,8 +449,9 @@ class PandasBackend(ComputationalBackend):
             for f in features:
                 frame[f.get_name()] = np.nan
         else:
-            relationship_path = self.entityset.find_backward_path(entity.id,
-                                                                  child_entity.id)
+            relationship_paths = self.entityset.find_backward_paths(entity.id,
+                                                                    child_entity.id)
+            relationship_path = next(relationship_paths)
 
             groupby_var = get_relationship_variable_id(relationship_path)
 

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -49,23 +49,6 @@ def description_to_entity(description, entityset, path=None):
         variable_types=variable_types)
 
 
-def description_to_relationship(description, entityset):
-    '''Deserialize parent and child variables from relationship description.
-
-    Args:
-        description (dict) : Description of :class:`.Relationship`.
-        entityset (EntitySet) : Instance of :class:`.EntitySet` containing parent and child variables.
-
-    Returns:
-        item (tuple(Variable, Variable)) : Tuple containing parent and child variables.
-    '''
-    entity, variable = description['parent']
-    parent = entityset[entity][variable]
-    entity, variable = description['child']
-    child = entityset[entity][variable]
-    return Relationship(parent, child)
-
-
 def description_to_entityset(description, **kwargs):
     '''Deserialize entityset from data description.
 
@@ -90,7 +73,7 @@ def description_to_entityset(description, **kwargs):
             last_time_index.append(entity['id'])
 
     for relationship in description['relationships']:
-        relationship = description_to_relationship(relationship, entityset)
+        relationship = Relationship.from_dictionary(relationship, entityset)
         entityset.add_relationship(relationship)
 
     if len(last_time_index):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -565,6 +565,19 @@ class EntitySet(object):
                 prev_entity = r.parent_variable.entity.id
         return rels
 
+    def has_unique_forward_path(self, start_entity_id, end_entity_id):
+        """
+        Is the forward path from start to end unique?
+
+        This will raise if there is no such path.
+        """
+        paths = self.find_forward_paths(start_entity_id, end_entity_id)
+
+        next(paths)
+        second_path = next(paths, None)
+
+        return not second_path
+
     ###########################################################################
     #  Entity creation methods  ##############################################
     ###########################################################################

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -463,10 +463,11 @@ class EntitySet(object):
         yield start_entity_id, []
 
         for relationship in self.get_forward_relationships(start_entity_id):
-            next = relationship.parent_entity.id
+            next_entity = relationship.parent_entity.id
             # Copy seen entities for each next node to allow multiple paths (but
             # not cycles).
-            for sub_entity_id, sub_path in self._forward_entity_paths(next, seen_entities.copy()):
+            descendants = self._forward_entity_paths(next_entity, seen_entities.copy())
+            for sub_entity_id, sub_path in descendants:
                 yield sub_entity_id, [relationship] + sub_path
 
     def get_forward_entities(self, entity_id, deep=False):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -370,8 +370,8 @@ class EntitySet(object):
                 returns a tuple of (relationship_list, forward_distance).
 
         See Also:
-            :func:`EntitySet.find_forward_path`
-            :func:`EntitySet.find_backward_path`
+            :func:`EntitySet.find_forward_paths`
+            :func:`EntitySet.find_backward_paths`
         """
         if start_entity_id == goal_entity_id:
             if include_num_forward:

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -74,6 +74,7 @@ class Relationship(object):
         """Instance of variable in child entity"""
         return self.child_entity[self._child_variable_id]
 
+    @property
     def parent_name(self):
         """The name of the parent, relative to the child."""
         if self._is_unique():
@@ -81,6 +82,7 @@ class Relationship(object):
         else:
             return '%s[%s]' % (self._parent_entity_id, self._child_variable_id)
 
+    @property
     def child_name(self):
         """The name of the child, relative to the parent."""
         if self._is_unique():

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -88,7 +88,7 @@ class Relationship(object):
         else:
             return '%s[%s]' % (self._child_entity_id, self._child_variable_id)
 
-    def get_arguments(self):
+    def to_dictionary(self):
         return {
             'parent_entity_id': self._parent_entity_id,
             'child_entity_id': self._child_entity_id,

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -26,6 +26,14 @@ class Relationship(object):
                 parent_variable.id != parent_variable.entity.index):
             raise AttributeError("Parent variable '%s' is not the index of entity %s" % (parent_variable, parent_variable.entity))
 
+    @classmethod
+    def from_dictionary(cls, arguments, es):
+        parent_entity = es[arguments['parent_entity_id']]
+        child_entity = es[arguments['child_entity_id']]
+        parent_variable = parent_entity[arguments['parent_variable_id']]
+        child_variable = child_entity[arguments['child_variable_id']]
+        return cls(parent_variable, child_variable)
+
     def __repr__(self):
         ret = u"<Relationship: %s.%s -> %s.%s>" % \
             (self._child_entity_id, self._child_variable_id,
@@ -65,3 +73,35 @@ class Relationship(object):
     def child_variable(self):
         """Instance of variable in child entity"""
         return self.child_entity[self._child_variable_id]
+
+    def parent_name(self):
+        """The name of the parent, relative to the child."""
+        if self._is_unique():
+            return self._parent_entity_id
+        else:
+            return '%s[%s]' % (self._parent_entity_id, self._child_variable_id)
+
+    def child_name(self):
+        """The name of the child, relative to the parent."""
+        if self._is_unique():
+            return self._child_entity_id
+        else:
+            return '%s[%s]' % (self._child_entity_id, self._child_variable_id)
+
+    def get_arguments(self):
+        return {
+            'parent_entity_id': self._parent_entity_id,
+            'child_entity_id': self._child_entity_id,
+            'parent_variable_id': self._parent_variable_id,
+            'child_variable_id': self._child_variable_id,
+        }
+
+    def _is_unique(self):
+        """Is there any other relationship with same parent and child entities?"""
+        es = self.child_entity.entityset
+        relationships = es.get_forward_relationships(self._child_entity_id)
+        n = len([r for r in relationships if r.parent_entity == self.parent_entity])
+
+        assert n > 0, 'This relationship is missing from the entityset'
+
+        return n == 1

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -42,21 +42,6 @@ def entity_to_description(entity):
     return description
 
 
-def relationship_to_description(relationship):
-    '''Serialize entityset relationship to data description.
-
-    Args:
-        relationship (Relationship) : Instance of :class:`.Relationship`.
-
-    Returns:
-        description (dict) : Description of :class:`.Relationship`.
-    '''
-    return {
-        'parent': [relationship.parent_entity.id, relationship.parent_variable.id],
-        'child': [relationship.child_entity.id, relationship.child_variable.id],
-    }
-
-
 def entityset_to_description(entityset):
     '''Serialize entityset to data description.
 
@@ -67,7 +52,7 @@ def entityset_to_description(entityset):
         description (dict) : Description of :class:`.EntitySet`.
     '''
     entities = {entity.id: entity_to_description(entity) for entity in entityset.entities}
-    relationships = [relationship_to_description(relationship) for relationship in entityset.relationships]
+    relationships = [relationship.to_dictionary() for relationship in entityset.relationships]
     data_description = {
         'id': entityset.id,
         'entities': entities,

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -427,7 +427,8 @@ class DirectFeature(FeatureBase):
 
     def copy(self):
         """Return copy of feature"""
-        return DirectFeature(self.base_features[0], self.entity)
+        return DirectFeature(self.base_features[0], self.entity,
+                             relationship_path=self.relationship_path)
 
     @property
     def variable_type(self):
@@ -542,8 +543,12 @@ class AggregationFeature(FeatureBase):
                    use_previous=use_previous, where=where)
 
     def copy(self):
-        return AggregationFeature(self.base_features, parent_entity=self.parent_entity,
-                                  primitive=self.primitive, use_previous=self.use_previous, where=self.where)
+        return AggregationFeature(self.base_features,
+                                  parent_entity=self.parent_entity,
+                                  relationship_path=self.relationship_path,
+                                  primitive=self.primitive,
+                                  use_previous=self.use_previous,
+                                  where=self.where)
 
     def _where_str(self):
         if self.where is not None:

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -736,7 +736,9 @@ def _find_unique_forward_path(start_entity, end_entity):
     # Entity ids from which we know there is a path to the end entity.
     in_path = set()
 
-    for entity, entity_path in _depth_first_search(start_entity, es, []):
+    # Pass visited_multiple so that we stop recursing once we've visited a node
+    # multiple times.
+    for entity, entity_path in _depth_first_search(start_entity, es, visited_multiple, []):
         # Skip the start_entity.
         if not entity_path:
             continue
@@ -748,8 +750,8 @@ def _find_unique_forward_path(start_entity, end_entity):
 
         if entity.id in visited:
             visited_multiple.add(entity.id)
-
-        visited.add(entity.id)
+        else:
+            visited.add(entity.id)
 
         if entity == end_entity:
             # Mark each entity in path as in_path
@@ -767,12 +769,15 @@ def _find_unique_forward_path(start_entity, end_entity):
     return path
 
 
-def _depth_first_search(start_entity, es, path):
+def _depth_first_search(start_entity, es, done_entities, path):
     """Generator which yields all entities connected through forward relationships."""
+    if start_entity.id in done_entities:
+        return
+
     yield start_entity, path
 
     for relationship in es.get_forward_relationships(start_entity.id):
         next = relationship.parent_entity
         new_path = path + [relationship]
-        for entity, entity_path in _depth_first_search(next, es, new_path):
+        for entity, entity_path in _depth_first_search(next, es, done_entities, new_path):
             yield entity, entity_path

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -460,9 +460,8 @@ class AggregationFeature(FeatureBase):
     # each time point during calculation
     use_previous = None
 
-    def __init__(self, base_features, primitive,
-                 relationship_path=None, parent_entity=None,
-                 use_previous=None, where=None):
+    def __init__(self, base_features, parent_entity, primitive,
+                 relationship_path=None, use_previous=None, where=None):
         if hasattr(base_features, '__iter__'):
             base_features = [_check_feature(bf) for bf in base_features]
             msg = "all base features must share the same entity"
@@ -525,6 +524,8 @@ class AggregationFeature(FeatureBase):
         base_features = [dependencies[name] for name in arguments['base_features']]
         relationship_path = [Relationship.from_dictionary(r, entityset)
                              for r in arguments['relationship_path']]
+        parent_entity = relationship_path[0].parent_entity
+
         primitive = primitives_deserializer.deserialize_primitive(arguments['primitive'])
 
         use_previous_data = arguments['use_previous']
@@ -533,7 +534,7 @@ class AggregationFeature(FeatureBase):
         where_name = arguments['where']
         where = where_name and dependencies[where_name]
 
-        return cls(base_features, primitive, relationship_path=relationship_path,
+        return cls(base_features, parent_entity, primitive, relationship_path=relationship_path,
                    use_previous=use_previous, where=where)
 
     def copy(self):

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -444,7 +444,7 @@ class DirectFeature(FeatureBase):
     def get_arguments(self):
         return {
             'base_feature': self.base_features[0].unique_name(),
-            'relationship_path': [r.get_arguments() for r in self.relationship_path]
+            'relationship_path': [r.to_dictionary() for r in self.relationship_path]
         }
 
 
@@ -568,7 +568,7 @@ class AggregationFeature(FeatureBase):
     def get_arguments(self):
         return {
             'base_features': [feat.unique_name() for feat in self.base_features],
-            'relationship_path': [r.get_arguments() for r in self.relationship_path],
+            'relationship_path': [r.to_dictionary() for r in self.relationship_path],
             'primitive': serialize_primitive(self.primitive),
             'where': self.where and self.where.unique_name(),
             'use_previous': self.use_previous and self.use_previous.get_arguments(),

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -396,8 +396,7 @@ class DirectFeature(FeatureBase):
 
             path_is_unique = child_entity.entityset \
                 .has_unique_forward_path(child_entity.id, self.parent_entity.id)
-
-        if not relationship_path:
+        else:
             relationship_path = _find_path(child_entity.id,
                                            self.parent_entity.id,
                                            child_entity.entityset)
@@ -514,7 +513,6 @@ class AggregationFeature(FeatureBase):
 
             path_is_unique = parent_entity.entityset \
                 .has_unique_forward_path(self.child_entity.id, parent_entity.id)
-
         else:
             relationship_path = _find_path(parent_entity.id,
                                            self.child_entity.id,

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -24,7 +24,7 @@ from featuretools.variable_types import (
 
 
 class FeatureBase(object):
-    def __init__(self, entity, base_features, primitive):
+    def __init__(self, entity, base_features, relationship_path, primitive):
         """Base class for all features
 
         Args:
@@ -44,6 +44,8 @@ class FeatureBase(object):
         if not isinstance(primitive, PrimitiveBase):
             primitive = primitive()
         self.primitive = primitive
+
+        self.relationship_path = relationship_path
 
         self._name = None
 
@@ -330,7 +332,7 @@ class IdentityFeature(FeatureBase):
         entity_id = variable.entity_id
         self.variable = variable.entityset.metadata[entity_id][variable.id]
         self.return_type = type(variable)
-        super(IdentityFeature, self).__init__(variable.entity, [], primitive=PrimitiveBase)
+        super(IdentityFeature, self).__init__(variable.entity, [], [], primitive=PrimitiveBase)
 
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
@@ -396,8 +398,8 @@ class DirectFeature(FeatureBase):
                                            backward=False)
             self._is_unique_path = True
 
-        self.relationship_path = relationship_path
-        super(DirectFeature, self).__init__(child_entity, [base_feature], primitive=PrimitiveBase)
+        super(DirectFeature, self).__init__(child_entity, [base_feature], relationship_path,
+                                            primitive=PrimitiveBase)
 
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
@@ -491,8 +493,6 @@ class AggregationFeature(FeatureBase):
                                            backward=True)
             self._is_unique_path = True
 
-        self.relationship_path = relationship_path
-
         self.parent_entity = parent_entity.entityset.metadata[parent_entity.id]
 
         if where is not None:
@@ -516,6 +516,7 @@ class AggregationFeature(FeatureBase):
 
         super(AggregationFeature, self).__init__(parent_entity,
                                                  base_features,
+                                                 relationship_path,
                                                  primitive=primitive)
 
     @classmethod
@@ -589,7 +590,9 @@ class TransformFeature(FeatureBase):
         assert all(bf.number_output_features == 1 for bf in base_features)
 
         super(TransformFeature, self).__init__(base_features[0].entity,
-                                               base_features, primitive=primitive)
+                                               base_features,
+                                               [],
+                                               primitive=primitive)
 
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -332,7 +332,10 @@ class IdentityFeature(FeatureBase):
         entity_id = variable.entity_id
         self.variable = variable.entityset.metadata[entity_id][variable.id]
         self.return_type = type(variable)
-        super(IdentityFeature, self).__init__(variable.entity, [], [], primitive=PrimitiveBase)
+        super(IdentityFeature, self).__init__(entity=variable.entity,
+                                              base_features=[],
+                                              relationship_path=[],
+                                              primitive=PrimitiveBase)
 
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
@@ -398,7 +401,9 @@ class DirectFeature(FeatureBase):
                                            backward=False)
             self._is_unique_path = True
 
-        super(DirectFeature, self).__init__(child_entity, [base_feature], relationship_path,
+        super(DirectFeature, self).__init__(entity=child_entity,
+                                            base_features=[base_feature],
+                                            relationship_path=relationship_path,
                                             primitive=PrimitiveBase)
 
     @classmethod
@@ -514,9 +519,9 @@ class AggregationFeature(FeatureBase):
                                             "on entities with a time index")
             assert _check_time_against_column(self.use_previous, time_col)
 
-        super(AggregationFeature, self).__init__(parent_entity,
-                                                 base_features,
-                                                 relationship_path,
+        super(AggregationFeature, self).__init__(entity=parent_entity,
+                                                 base_features=base_features,
+                                                 relationship_path=relationship_path,
                                                  primitive=primitive)
 
     @classmethod
@@ -589,9 +594,9 @@ class TransformFeature(FeatureBase):
         # R TODO handle stacking on sub-features
         assert all(bf.number_output_features == 1 for bf in base_features)
 
-        super(TransformFeature, self).__init__(base_features[0].entity,
-                                               base_features,
-                                               [],
+        super(TransformFeature, self).__init__(entity=base_features[0].entity,
+                                               base_features=base_features,
+                                               relationship_path=[],
                                                primitive=primitive)
 
     @classmethod
@@ -625,7 +630,7 @@ class GroupByTransformFeature(TransformFeature):
         else:
             base_features = [base_features, groupby]
 
-        super(GroupByTransformFeature, self).__init__(base_features,
+        super(GroupByTransformFeature, self).__init__(base_features=base_features,
                                                       primitive=primitive)
 
     @classmethod

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -437,7 +437,7 @@ class DirectFeature(FeatureBase):
         if self._is_unique_path:
             relationship_path_name = self.parent_entity.id
         else:
-            relationship_names = [r.parent_name() for r in self.relationship_path]
+            relationship_names = [r.parent_name for r in self.relationship_path]
             relationship_path_name = '.'.join(relationship_names)
         return u"%s.%s" % (relationship_path_name,
                            self.base_features[0].get_name())
@@ -562,7 +562,7 @@ class AggregationFeature(FeatureBase):
         if self._is_unique_path:
             relationship_path_name = self.child_entity.id
         else:
-            relationship_names = [r.child_name() for r in self.relationship_path]
+            relationship_names = [r.child_name for r in self.relationship_path]
             relationship_path_name = '.'.join(relationship_names)
         return self.primitive.generate_name(base_feature_names=[bf.get_name() for bf in self.base_features],
                                             relationship_path_name=relationship_path_name,

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -106,11 +106,20 @@ class FeaturesDeserializer(object):
 
     def _check_schema_version(self):
         current = SCHEMA_VERSION.split('.')
-        saved = self.features_dict['schema_version'].split('.')
+        version_string = self.features_dict['schema_version']
+        saved = version_string.split('.')
+
+        # Check if saved has older major version.
+        if current[0] > saved[0]:
+            raise RuntimeError('Unable to load features. The schema version '
+                               'of the saved features (%s) is no longer '
+                               'supported by this version of featuretools.'
+                               % version_string)
+
         error_text = ('Unable to load features. The schema version of the saved '
                       'features (%s) is greater than the latest supported (%s). '
                       'You may need to upgrade featuretools.'
-                      % (self.features_dict['schema_version'], SCHEMA_VERSION))
+                      % (version_string, SCHEMA_VERSION))
 
         for c_num, s_num in zip_longest(current, saved, fillvalue=0):
             if c_num > s_num:

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -2,7 +2,7 @@ import json
 
 from featuretools.version import __version__ as ft_version
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "2.0.0"
 
 
 def save_features(features, filepath):

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -14,12 +14,12 @@ class AggregationPrimitive(PrimitiveBase):
     stack_on_self = True  # whether or not it can be in input_types of self
     allow_where = True  # whether DFS can apply where clause to this primitive
 
-    def generate_name(self, base_feature_names, child_entity_id,
+    def generate_name(self, base_feature_names, relationship_path_name,
                       parent_entity_id, where_str, use_prev_str):
         base_features_str = ", ".join(base_feature_names)
         return u"%s(%s.%s%s%s%s)" % (
             self.name.upper(),
-            child_entity_id,
+            relationship_path_name,
             base_features_str,
             where_str,
             use_prev_str,

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -41,9 +41,9 @@ class Count(AggregationPrimitive):
         else:
             return pd.Series.count
 
-    def generate_name(self, base_feature_names, child_entity_id,
+    def generate_name(self, base_feature_names, relationship_path_name,
                       parent_entity_id, where_str, use_prev_str):
-        return u"COUNT(%s%s%s)" % (child_entity_id,
+        return u"COUNT(%s%s%s)" % (relationship_path_name,
                                    where_str, use_prev_str)
 
 
@@ -100,14 +100,14 @@ class Mean(AggregationPrimitive):
             return np.mean(series.values)
         return mean
 
-    def generate_name(self, base_feature_names, child_entity_id,
+    def generate_name(self, base_feature_names, relationship_path_name,
                       parent_entity_id, where_str, use_prev_str):
         skipna = ""
         if not self.skipna:
             skipna = ", skipna=False"
         base_features_str = ", ".join(base_feature_names)
         return u"%s(%s.%s%s%s%s)" % (self.name.upper(),
-                                     child_entity_id,
+                                     relationship_path_name,
                                      base_features_str,
                                      where_str,
                                      use_prev_str,

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -100,19 +100,6 @@ class Mean(AggregationPrimitive):
             return np.mean(series.values)
         return mean
 
-    def generate_name(self, base_feature_names, relationship_path_name,
-                      parent_entity_id, where_str, use_prev_str):
-        skipna = ""
-        if not self.skipna:
-            skipna = ", skipna=False"
-        base_features_str = ", ".join(base_feature_names)
-        return u"%s(%s.%s%s%s%s)" % (self.name.upper(),
-                                     relationship_path_name,
-                                     base_features_str,
-                                     where_str,
-                                     use_prev_str,
-                                     skipna)
-
 
 class Mode(AggregationPrimitive):
     """Determines the most commonly repeated value.

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -579,8 +579,9 @@ class DeepFeatureSynthesis(object):
                                               variable_type=set(input_types))
 
             # remove features in relationship path
-            relationship_path = self.es.find_backward_path(parent_entity.id,
-                                                           child_entity.id)
+            relationship_paths = self.es.find_backward_paths(parent_entity.id,
+                                                             child_entity.id)
+            relationship_path = next(relationship_paths)
 
             features = [f for f in features if not self._feature_in_relationship_path(
                 relationship_path, f)]

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -537,11 +537,11 @@ def test_handles_primitive_function_name_uniqueness(es):
 
             return my_function
 
-        def generate_name(self, base_feature_names, child_entity_id,
+        def generate_name(self, base_feature_names, relationship_path_name,
                           parent_entity_id, where_str, use_prev_str):
             base_features_str = ", ".join(base_feature_names)
             return u"%s(%s.%s%s%s, n=%s)" % (self.name.upper(),
-                                             child_entity_id,
+                                             relationship_path_name,
                                              base_features_str,
                                              where_str, use_prev_str, self.n)
 

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -537,14 +537,6 @@ def test_handles_primitive_function_name_uniqueness(es):
 
             return my_function
 
-        def generate_name(self, base_feature_names, relationship_path_name,
-                          parent_entity_id, where_str, use_prev_str):
-            base_features_str = ", ".join(base_feature_names)
-            return u"%s(%s.%s%s%s, n=%s)" % (self.name.upper(),
-                                             relationship_path_name,
-                                             base_features_str,
-                                             where_str, use_prev_str, self.n)
-
     # works as expected
     f1 = ft.Feature(es["log"]["value"],
                     parent_entity=es["customers"],

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -1,5 +1,7 @@
+import pandas as pd
 import pytest
 
+import featuretools as ft
 from featuretools.tests.testing_utils import make_ecommerce_entityset
 
 
@@ -11,3 +13,42 @@ def es():
 @pytest.fixture
 def int_es():
     return make_ecommerce_entityset(with_integer_time_index=True)
+
+
+@pytest.fixture
+def diamond_es():
+    regions_df = pd.DataFrame({
+        'id': range(3),
+        'name': ['Northeast', 'Midwest', 'South'],
+    })
+    stores_df = pd.DataFrame({
+        'id': range(5),
+        'region_id': [0, 1, 2, 2, 1],
+    })
+    customers_df = pd.DataFrame({
+        'id': range(5),
+        'region_id': [1, 0, 0, 1, 1],
+        'name': ['A', 'B', 'C', 'D', 'E'],
+    })
+    transactions_df = pd.DataFrame({
+        'id': range(8),
+        'store_id': [4, 4, 2, 3, 4, 0, 1, 1],
+        'customer_id': [3, 0, 2, 4, 3, 3, 2, 3],
+        'amount': [100, 40, 45, 83, 13, 94, 27, 81],
+    })
+
+    entities = {
+        'regions': (regions_df, 'id'),
+        'stores': (stores_df, 'id'),
+        'customers': (customers_df, 'id'),
+        'transactions': (transactions_df, 'id'),
+    }
+    relationships = [
+        ('regions', 'id', 'stores', 'region_id'),
+        ('regions', 'id', 'customers', 'region_id'),
+        ('stores', 'id', 'transactions', 'store_id'),
+        ('customers', 'id', 'transactions', 'customer_id'),
+    ]
+    return ft.EntitySet(id='ecommerce_diamond',
+                        entities=entities,
+                        relationships=relationships)

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -56,11 +56,16 @@ def diamond_es():
 
 @pytest.fixture
 def home_games_es():
-    teams = pd.DataFrame({'id': range(3)})
+    teams = pd.DataFrame({
+        'id': range(3),
+        'name': ['Breakers', 'Spirit', 'Thorns']
+    })
     games = pd.DataFrame({
         'id': range(5),
         'home_team_id': [2, 2, 1, 0, 1],
         'away_team_id': [1, 0, 2, 1, 0],
+        'home_team_score': [3, 0, 1, 0, 4],
+        'away_team_score': [2, 1, 2, 0, 0]
     })
     entities = {'teams': (teams, 'id'), 'games': (games, 'id')}
     relationships = [('teams', 'id', 'games', 'home_team_id')]

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -52,3 +52,24 @@ def diamond_es():
     return ft.EntitySet(id='ecommerce_diamond',
                         entities=entities,
                         relationships=relationships)
+
+
+@pytest.fixture
+def home_games_es():
+    teams = pd.DataFrame({'id': range(3)})
+    games = pd.DataFrame({
+        'id': range(5),
+        'home_team_id': [2, 2, 1, 0, 1],
+        'away_team_id': [1, 0, 2, 1, 0],
+    })
+    entities = {'teams': (teams, 'id'), 'games': (games, 'id')}
+    relationships = [('teams', 'id', 'games', 'home_team_id')]
+    return ft.EntitySet(entities=entities,
+                        relationships=relationships)
+
+
+@pytest.fixture
+def games_es(home_games_es):
+    away_team = ft.Relationship(home_games_es['teams']['id'],
+                                home_games_es['games']['away_team_id'])
+    return home_games_es.add_relationship(away_team)

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -82,7 +82,7 @@ def test_find_forward_paths(es):
     assert path[1].parent_entity.id == 'customers'
 
 
-def test_find_forward_paths_multiple(diamond_es):
+def test_find_forward_paths_multiple_paths(diamond_es):
     paths = list(diamond_es.find_forward_paths('transactions', 'regions'))
     assert len(paths) == 2
 
@@ -99,6 +99,27 @@ def test_find_forward_paths_multiple(diamond_es):
     assert r1.parent_entity.id == 'customers'
     assert r2.child_entity.id == 'customers'
     assert r2.parent_entity.id == 'regions'
+
+
+def test_find_forward_paths_multiple_relationships(games_es):
+    paths = list(games_es.find_forward_paths('games', 'teams'))
+    assert len(paths) == 2
+
+    path1, path2 = paths
+    assert len(path1) == 1
+    assert len(path2) == 1
+    r1 = path1[0]
+    r2 = path2[0]
+
+    assert r1.child_entity.id == 'games'
+    assert r2.child_entity.id == 'games'
+    assert r1.parent_entity.id == 'teams'
+    assert r2.parent_entity.id == 'teams'
+
+    assert r1.child_variable.id == 'home_team_id'
+    assert r2.child_variable.id == 'away_team_id'
+    assert r1.parent_variable.id == 'id'
+    assert r2.parent_variable.id == 'id'
 
 
 def test_find_forward_paths_ignores_loops():
@@ -125,7 +146,7 @@ def test_find_backward_paths(es):
     assert path[1].parent_entity.id == 'sessions'
 
 
-def test_find_backward_paths_multiple(diamond_es):
+def test_find_backward_paths_multiple_paths(diamond_es):
     paths = list(diamond_es.find_backward_paths('regions', 'transactions'))
     assert len(paths) == 2
 
@@ -142,6 +163,27 @@ def test_find_backward_paths_multiple(diamond_es):
     assert r1.parent_entity.id == 'regions'
     assert r2.child_entity.id == 'transactions'
     assert r2.parent_entity.id == 'customers'
+
+
+def test_find_backward_paths_multiple_relationships(games_es):
+    paths = list(games_es.find_backward_paths('teams', 'games'))
+    assert len(paths) == 2
+
+    path1, path2 = paths
+    assert len(path1) == 1
+    assert len(path2) == 1
+    r1 = path1[0]
+    r2 = path2[0]
+
+    assert r1.child_entity.id == 'games'
+    assert r2.child_entity.id == 'games'
+    assert r1.parent_entity.id == 'teams'
+    assert r2.parent_entity.id == 'teams'
+
+    assert r1.child_variable.id == 'home_team_id'
+    assert r2.child_variable.id == 'away_team_id'
+    assert r1.parent_variable.id == 'id'
+    assert r2.parent_variable.id == 'id'
 
 
 def test_find_path(es):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -67,8 +67,11 @@ def test_get_backward_relationships(es):
     assert relationships[0].child_entity.id == 'sessions'
 
 
-def test_find_forward_path(es):
-    path = es.find_forward_path('log', 'customers')
+def test_find_forward_paths(es):
+    paths = list(es.find_forward_paths('log', 'customers'))
+    assert len(paths) == 1
+
+    path = paths[0]
 
     assert len(path) == 2
     assert path[0].child_entity.id == 'log'
@@ -77,14 +80,55 @@ def test_find_forward_path(es):
     assert path[1].parent_entity.id == 'customers'
 
 
-def test_find_backward_path(es):
-    path = es.find_backward_path('customers', 'log')
+def test_find_forward_paths_multiple(diamond_es):
+    paths = list(diamond_es.find_forward_paths('transactions', 'regions'))
+    assert len(paths) == 2
+
+    path1, path2 = paths
+
+    r1, r2 = path1
+    assert r1.child_entity.id == 'transactions'
+    assert r1.parent_entity.id == 'stores'
+    assert r2.child_entity.id == 'stores'
+    assert r2.parent_entity.id == 'regions'
+
+    r1, r2 = path2
+    assert r1.child_entity.id == 'transactions'
+    assert r1.parent_entity.id == 'customers'
+    assert r2.child_entity.id == 'customers'
+    assert r2.parent_entity.id == 'regions'
+
+
+def test_find_backward_paths(es):
+    paths = list(es.find_backward_paths('customers', 'log'))
+    assert len(paths) == 1
+
+    path = paths[0]
 
     assert len(path) == 2
     assert path[0].child_entity.id == 'sessions'
     assert path[0].parent_entity.id == 'customers'
     assert path[1].child_entity.id == 'log'
     assert path[1].parent_entity.id == 'sessions'
+
+
+def test_find_backward_paths_multiple(diamond_es):
+    paths = list(diamond_es.find_backward_paths('regions', 'transactions'))
+    assert len(paths) == 2
+
+    path1, path2 = paths
+
+    r1, r2 = path1
+    assert r1.child_entity.id == 'stores'
+    assert r1.parent_entity.id == 'regions'
+    assert r2.child_entity.id == 'transactions'
+    assert r2.parent_entity.id == 'stores'
+
+    r1, r2 = path2
+    assert r1.child_entity.id == 'customers'
+    assert r1.parent_entity.id == 'regions'
+    assert r2.child_entity.id == 'transactions'
+    assert r2.parent_entity.id == 'customers'
 
 
 def test_find_path(es):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
 import pandas as pd
-import featuretools as ft
+import pytest
 
+import featuretools as ft
 from featuretools import EntitySet, Relationship, variable_types
 
 

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
+import pandas as pd
+import featuretools as ft
 
 from featuretools import EntitySet, Relationship, variable_types
 
@@ -97,6 +99,17 @@ def test_find_forward_paths_multiple(diamond_es):
     assert r1.parent_entity.id == 'customers'
     assert r2.child_entity.id == 'customers'
     assert r2.parent_entity.id == 'regions'
+
+
+def test_find_forward_paths_ignores_loops():
+    employee_df = pd.DataFrame({'id': [0], 'manager_id': [0]})
+    entities = {'employees': (employee_df, 'id')}
+    relationships = [('employees', 'id', 'employees', 'manager_id')]
+    es = ft.EntitySet(entities=entities, relationships=relationships)
+
+    paths = list(es.find_forward_paths('employees', 'employees'))
+    assert len(paths) == 1
+    assert paths[0] == []
 
 
 def test_find_backward_paths(es):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -177,6 +177,11 @@ def test_find_path_no_path_found(es):
         es.find_path('products', 'customers')
 
 
+def test_has_unique_path(diamond_es):
+    assert diamond_es.has_unique_forward_path('customers', 'regions')
+    assert not diamond_es.has_unique_forward_path('transactions', 'regions')
+
+
 def test_raise_key_error_missing_entity(es):
     error_text = "Entity this entity doesn't exist does not exist in ecommerce"
     with pytest.raises(KeyError, match=error_text):

--- a/featuretools/tests/entityset_tests/test_relationship.py
+++ b/featuretools/tests/entityset_tests/test_relationship.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import pytest
+
+import featuretools as ft
+
+
+@pytest.fixture
+def home_games_es():
+    teams = pd.DataFrame({'id': range(3)})
+    games = pd.DataFrame({
+        'id': range(5),
+        'home_team_id': [2, 2, 1, 0, 1],
+        'away_team_id': [1, 0, 2, 1, 0],
+    })
+    entities = {'teams': (teams, 'id'), 'games': (games, 'id')}
+    relationships = [('teams', 'id', 'games', 'home_team_id')]
+    return ft.EntitySet(entities=entities,
+                        relationships=relationships)
+
+
+@pytest.fixture
+def games_es(home_games_es):
+    away_team = ft.Relationship(home_games_es['teams']['id'],
+                                home_games_es['games']['away_team_id'])
+    return home_games_es.add_relationship(away_team)
+
+
+def test_names_when_multiple_relationships_between_entities(games_es):
+    relationship = ft.Relationship(games_es['teams']['id'],
+                                   games_es['games']['home_team_id'])
+    assert relationship.child_name() == 'games[home_team_id]'
+    assert relationship.parent_name() == 'teams[home_team_id]'
+
+
+def test_names_when_no_other_relationship_between_entities(home_games_es):
+    relationship = ft.Relationship(home_games_es['teams']['id'],
+                                   home_games_es['games']['home_team_id'])
+    assert relationship.child_name() == 'games'
+    assert relationship.parent_name() == 'teams'
+
+
+def test_serialization(es):
+    relationship = ft.Relationship(es['sessions']['id'], es['log']['session_id'])
+
+    dictionary = {
+        'parent_entity_id': 'sessions',
+        'parent_variable_id': 'id',
+        'child_entity_id': 'log',
+        'child_variable_id': 'session_id',
+    }
+    assert relationship.get_arguments() == dictionary
+    assert ft.Relationship.from_dictionary(dictionary, es) == relationship

--- a/featuretools/tests/entityset_tests/test_relationship.py
+++ b/featuretools/tests/entityset_tests/test_relationship.py
@@ -1,28 +1,4 @@
-import pandas as pd
-import pytest
-
 import featuretools as ft
-
-
-@pytest.fixture
-def home_games_es():
-    teams = pd.DataFrame({'id': range(3)})
-    games = pd.DataFrame({
-        'id': range(5),
-        'home_team_id': [2, 2, 1, 0, 1],
-        'away_team_id': [1, 0, 2, 1, 0],
-    })
-    entities = {'teams': (teams, 'id'), 'games': (games, 'id')}
-    relationships = [('teams', 'id', 'games', 'home_team_id')]
-    return ft.EntitySet(entities=entities,
-                        relationships=relationships)
-
-
-@pytest.fixture
-def games_es(home_games_es):
-    away_team = ft.Relationship(home_games_es['teams']['id'],
-                                home_games_es['games']['away_team_id'])
-    return home_games_es.add_relationship(away_team)
 
 
 def test_names_when_multiple_relationships_between_entities(games_es):

--- a/featuretools/tests/entityset_tests/test_relationship.py
+++ b/featuretools/tests/entityset_tests/test_relationship.py
@@ -48,5 +48,5 @@ def test_serialization(es):
         'child_entity_id': 'log',
         'child_variable_id': 'session_id',
     }
-    assert relationship.get_arguments() == dictionary
+    assert relationship.to_dictionary() == dictionary
     assert ft.Relationship.from_dictionary(dictionary, es) == relationship

--- a/featuretools/tests/entityset_tests/test_relationship.py
+++ b/featuretools/tests/entityset_tests/test_relationship.py
@@ -28,15 +28,15 @@ def games_es(home_games_es):
 def test_names_when_multiple_relationships_between_entities(games_es):
     relationship = ft.Relationship(games_es['teams']['id'],
                                    games_es['games']['home_team_id'])
-    assert relationship.child_name() == 'games[home_team_id]'
-    assert relationship.parent_name() == 'teams[home_team_id]'
+    assert relationship.child_name == 'games[home_team_id]'
+    assert relationship.parent_name == 'teams[home_team_id]'
 
 
 def test_names_when_no_other_relationship_between_entities(home_games_es):
     relationship = ft.Relationship(home_games_es['teams']['id'],
                                    home_games_es['games']['home_team_id'])
-    assert relationship.child_name() == 'games'
-    assert relationship.parent_name() == 'teams'
+    assert relationship.child_name == 'games'
+    assert relationship.parent_name == 'teams'
 
 
 def test_serialization(es):

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -46,13 +46,6 @@ def test_entity_descriptions(es):
         assert entity.__eq__(_entity, deep=True)
 
 
-def test_relationship_descriptions(es):
-    for relationship in es.relationships:
-        description = serialize.relationship_to_description(relationship)
-        _relationship = deserialize.description_to_relationship(description, es)
-        assert relationship.__eq__(_relationship)
-
-
 def test_entityset_description(es):
     description = serialize.entityset_to_description(es)
     _es = deserialize.description_to_entityset(description)

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -316,6 +316,20 @@ def test_name_with_multiple_possible_paths(diamond_es):
     assert feat.get_name() == "MEAN(customers.transactions.amount)"
 
 
+def test_copy(games_es):
+    home_games = next(r for r in games_es.relationships
+                      if r.child_variable.id == 'home_team_id')
+    feat = ft.AggregationFeature(games_es['games']['home_team_score'],
+                                 games_es['teams'],
+                                 relationship_path=[home_games],
+                                 primitive=ft.primitives.Mean)
+    copied = feat.copy()
+    assert copied.entity == feat.entity
+    assert copied.base_features == feat.base_features
+    assert copied.relationship_path == feat.relationship_path
+    assert copied.primitive == feat.primitive
+
+
 def test_serialization(es):
     primitives_deserializer = PrimitivesDeserializer()
     value = ft.IdentityFeature(es['log']['value'])

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -99,9 +99,9 @@ def test_count_null_and_make_agg_primitive(es):
 
         return values.count()
 
-    def count_generate_name(self, base_feature_names, child_entity_id,
+    def count_generate_name(self, base_feature_names, relationship_path_name,
                             parent_entity_id, where_str, use_prev_str):
-        return u"COUNT(%s%s%s)" % (child_entity_id,
+        return u"COUNT(%s%s%s)" % (relationship_path_name,
                                    where_str,
                                    use_prev_str)
 
@@ -237,15 +237,91 @@ def test_init_and_name(es):
                 ft.calculate_feature_matrix([instance], entityset=es).head(5)
 
 
+def test_invalid_init_args(diamond_es):
+    error_text = 'parent_entity or relationship_path must be provided'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean)
+
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_store = next(r for r in transaction_relationships
+                                if r.parent_entity.id == 'stores')
+    error_text = 'parent_entity must match first relationship in path'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                              parent_entity=diamond_es['customers'],
+                              relationship_path=[transaction_to_store])
+
+    store_to_region = diamond_es.get_forward_relationships('stores')[0]
+    error_text = 'Base feature must be defined on the entity at the end of relationship_path'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                              parent_entity=diamond_es['regions'],
+                              relationship_path=[store_to_region])
+
+
+def test_init_with_multiple_possible_paths(diamond_es):
+    error_text = "There are multiple possible paths to the base entity. " \
+                 "You must specify a relationship path."
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                              parent_entity=diamond_es['regions'])
+
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_customer = next(r for r in transaction_relationships
+                                   if r.parent_entity.id == 'customers')
+    customer_to_region = diamond_es.get_forward_relationships('customers')[0]
+    # Does not raise if path specified.
+    ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                          parent_entity=diamond_es['regions'],
+                          relationship_path=[customer_to_region, transaction_to_customer])
+
+
+def test_init_with_single_possible_path(diamond_es):
+    # This uses diamond_es to test that there being a cycle somewhere in the
+    # graph doesn't cause an error.
+    feat = ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                                 parent_entity=diamond_es['customers'])
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_customer = next(r for r in transaction_relationships
+                                   if r.parent_entity.id == 'customers')
+    assert feat.relationship_path == [transaction_to_customer]
+
+
+def test_init_with_no_path(diamond_es):
+    error_text = 'No path from "transactions" to "customers" found.'
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.AggregationFeature(diamond_es['customers']['name'], ft.primitives.Count,
+                              parent_entity=diamond_es['transactions'])
+
+    error_text = 'No path from "transactions" to "transactions" found.'
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                              parent_entity=diamond_es['transactions'])
+
+
+def test_name_with_multiple_possible_paths(diamond_es):
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_customer = next(r for r in transaction_relationships
+                                   if r.parent_entity.id == 'customers')
+    customer_to_region = diamond_es.get_forward_relationships('customers')[0]
+    # Does not raise if path specified.
+    feat = ft.AggregationFeature(diamond_es['transactions']['amount'], ft.primitives.Mean,
+                                 parent_entity=diamond_es['regions'],
+                                 relationship_path=[customer_to_region, transaction_to_customer])
+
+    assert feat.get_name() == "MEAN(customers.transactions.amount)"
+
+
 def test_serialization(es):
     primitives_deserializer = PrimitivesDeserializer()
     value = ft.IdentityFeature(es['log']['value'])
     primitive = ft.primitives.Max()
-    max1 = ft.AggregationFeature(value, es['sessions'], primitive)
+    max1 = ft.AggregationFeature(value, primitive, parent_entity=es['customers'])
 
+    path = es.find_backward_path('customers', 'log')
     dictionary = {
         'base_features': [value.unique_name()],
-        'parent_entity_id': 'sessions',
+        'relationship_path': [r.get_arguments() for r in path],
         'primitive': serialize_primitive(primitive),
         'where': None,
         'use_previous': None,
@@ -259,12 +335,12 @@ def test_serialization(es):
 
     is_purchased = ft.IdentityFeature(es['log']['purchased'])
     use_previous = ft.Timedelta(3, 'd')
-    max2 = ft.AggregationFeature(value, es['sessions'], primitive,
+    max2 = ft.AggregationFeature(value, primitive, parent_entity=es['customers'],
                                  where=is_purchased, use_previous=use_previous)
 
     dictionary = {
         'base_features': [value.unique_name()],
-        'parent_entity_id': 'sessions',
+        'relationship_path': [r.get_arguments() for r in path],
         'primitive': serialize_primitive(primitive),
         'where': is_purchased.unique_name(),
         'use_previous': use_previous.get_arguments(),

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -318,7 +318,7 @@ def test_serialization(es):
     primitive = ft.primitives.Max()
     max1 = ft.AggregationFeature(value, primitive, parent_entity=es['customers'])
 
-    path = es.find_backward_path('customers', 'log')
+    path = next(es.find_backward_paths('customers', 'log'))
     dictionary = {
         'base_features': [value.unique_name()],
         'relationship_path': [r.to_dictionary() for r in path],

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -321,7 +321,7 @@ def test_serialization(es):
     path = es.find_backward_path('customers', 'log')
     dictionary = {
         'base_features': [value.unique_name()],
-        'relationship_path': [r.get_arguments() for r in path],
+        'relationship_path': [r.to_dictionary() for r in path],
         'primitive': serialize_primitive(primitive),
         'where': None,
         'use_previous': None,
@@ -340,7 +340,7 @@ def test_serialization(es):
 
     dictionary = {
         'base_features': [value.unique_name()],
-        'relationship_path': [r.get_arguments() for r in path],
+        'relationship_path': [r.to_dictionary() for r in path],
         'primitive': serialize_primitive(primitive),
         'where': is_purchased.unique_name(),
         'use_previous': use_previous.get_arguments(),

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -55,6 +55,17 @@ def test_direct_rename(es):
     assert feat.entity == copy_feat.entity
 
 
+def test_direct_copy(games_es):
+    home_team = next(r for r in games_es.relationships
+                     if r.child_variable.id == 'home_team_id')
+    feat = DirectFeature(games_es['teams']['name'], games_es['games'],
+                         relationship_path=[home_team])
+    copied = feat.copy()
+    assert copied.entity == feat.entity
+    assert copied.base_features == feat.base_features
+    assert copied.relationship_path == feat.relationship_path
+
+
 def test_direct_of_multi_output_transform_feat(es):
     class TestTime(TransformPrimitive):
         name = "test_time"

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -233,7 +233,7 @@ def test_serialization(es):
                            if r.parent_entity.id == 'products')
     dictionary = {
         'base_feature': value.unique_name(),
-        'relationship_path': [log_to_products.get_arguments()],
+        'relationship_path': [log_to_products.to_dictionary()],
     }
 
     assert dictionary == direct.get_arguments()

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -183,24 +183,6 @@ def test_direct_with_multiple_possible_paths(diamond_es):
     assert feat.get_name() == 'customers.regions.name'
 
 
-def test_direct_with_loop():
-    # This tests the case where we first find that there are multiple paths to a
-    # node, and then that there is a path from that node to the end node.
-    employee_df = pd.DataFrame({'id': [0], 'manager_id': [0], 'company_id': [0]})
-    company_df = pd.DataFrame({'id': [0], 'name': ['A']})
-    entities = {'employees': (employee_df, 'id'), 'companies': (company_df, 'id')}
-    relationships = [
-        ('employees', 'id', 'employees', 'manager_id'),
-        ('companies', 'id', 'employees', 'company_id')
-    ]
-    es = ft.EntitySet(entities=entities, relationships=relationships)
-
-    error_text = "There are multiple possible paths to the base entity. " \
-                 "You must specify a relationship path."
-    with pytest.raises(RuntimeError, match=error_text):
-        ft.DirectFeature(es['companies']['name'], child_entity=es['employees'])
-
-
 def test_direct_with_single_possible_path(diamond_es):
     # This uses diamond_es to test that there being a cycle somewhere in the
     # graph doesn't cause an error.

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 import featuretools as ft
 from featuretools.computational_backends import PandasBackend
@@ -146,13 +147,75 @@ def test_direct_features_of_multi_output_agg_primitives(es):
                         value == row[j])
 
 
+def test_direct_with_invalid_init_args(diamond_es):
+    error_text = 'child_entity or relationship_path must be provided'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.DirectFeature(diamond_es['regions']['name'])
+
+    customer_to_region = diamond_es.get_forward_relationships('customers')[0]
+    error_text = 'child_entity must match the first relationship'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.DirectFeature(diamond_es['regions']['name'], diamond_es['stores'],
+                         relationship_path=[customer_to_region])
+
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_store = next(r for r in transaction_relationships
+                                if r.parent_entity.id == 'stores')
+    error_text = 'Base feature must be defined on the entity at the end of relationship_path'
+    with pytest.raises(AssertionError, match=error_text):
+        ft.DirectFeature(diamond_es['regions']['name'], diamond_es['transactions'],
+                         relationship_path=[transaction_to_store])
+
+
+def test_direct_with_multiple_possible_paths(diamond_es):
+    error_text = "There are multiple possible paths to the base entity. " \
+                 "You must specify a relationship path."
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.DirectFeature(diamond_es['regions']['name'], diamond_es['transactions'])
+
+    transaction_relationships = diamond_es.get_forward_relationships('transactions')
+    transaction_to_customer = next(r for r in transaction_relationships
+                                   if r.parent_entity.id == 'customers')
+    customer_to_region = diamond_es.get_forward_relationships('customers')[0]
+    # Does not raise if path specified.
+    feat = ft.DirectFeature(diamond_es['regions']['name'], diamond_es['transactions'],
+                            relationship_path=[transaction_to_customer, customer_to_region])
+    assert feat.get_name() == 'customers.regions.name'
+
+
+def test_direct_with_single_possible_path(diamond_es):
+    # This uses diamond_es to test that there being a cycle somewhere in the
+    # graph doesn't cause an error.
+    feat = ft.DirectFeature(diamond_es['customers']['name'], diamond_es['transactions'])
+    relationships = diamond_es.get_forward_relationships('transactions')
+    relationship = next(r for r in relationships if r.parent_entity.id == 'customers')
+    assert feat.relationship_path == [relationship]
+
+
+def test_get_name_skips_relationships_when_single_possible_path(es):
+    feat = ft.DirectFeature(es['customers']['age'], es['log'])
+    assert feat.get_name() == 'customers.age'
+
+
+def test_direct_with_no_path(diamond_es):
+    error_text = 'No path from "regions" to "customers" found.'
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.DirectFeature(diamond_es['customers']['name'], diamond_es['regions'])
+
+    error_text = 'No path from "customers" to "customers" found.'
+    with pytest.raises(RuntimeError, match=error_text):
+        ft.DirectFeature(diamond_es['customers']['name'], diamond_es['customers'])
+
+
 def test_serialization(es):
-    value = ft.IdentityFeature(es['log']['value'])
+    value = ft.IdentityFeature(es['products']['rating'])
     direct = ft.DirectFeature(value, es['log'])
 
+    log_to_products = next(r for r in es.get_forward_relationships('log')
+                           if r.parent_entity.id == 'products')
     dictionary = {
         'base_feature': value.unique_name(),
-        'child_entity_id': 'log',
+        'relationship_path': [log_to_products.get_arguments()],
     }
 
     assert dictionary == direct.get_arguments()

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -148,10 +148,6 @@ def test_direct_features_of_multi_output_agg_primitives(es):
 
 
 def test_direct_with_invalid_init_args(diamond_es):
-    error_text = 'child_entity or relationship_path must be provided'
-    with pytest.raises(AssertionError, match=error_text):
-        ft.DirectFeature(diamond_es['regions']['name'])
-
     customer_to_region = diamond_es.get_forward_relationships('customers')[0]
     error_text = 'child_entity must match the first relationship'
     with pytest.raises(AssertionError, match=error_text):

--- a/featuretools/tests/primitive_tests/test_features_deserializer.py
+++ b/featuretools/tests/primitive_tests/test_features_deserializer.py
@@ -26,8 +26,7 @@ def test_single_feature(es):
 
 def test_base_features_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
-                                     parent_entity=es['sessions'])
+    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
     dictionary = {
         'ft_version': ft.__version__,
         'schema_version': SCHEMA_VERSION,
@@ -48,8 +47,7 @@ def test_base_features_not_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
     value_x2 = ft.TransformFeature(value,
                                    ft.primitives.MultiplyNumericScalar(value=2))
-    max_feat = ft.AggregationFeature(value_x2, ft.primitives.Max,
-                                     parent_entity=es['sessions'])
+    max_feat = ft.AggregationFeature(value_x2, es['sessions'], ft.primitives.Max)
     dictionary = {
         'ft_version': ft.__version__,
         'schema_version': SCHEMA_VERSION,
@@ -132,8 +130,7 @@ def test_unknown_feature_type(es):
 
 def test_unknown_primitive_type(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
-                                     parent_entity=es['sessions'])
+    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
     max_dict = max_feat.to_dictionary()
     max_dict['arguments']['primitive']['type'] = 'FakePrimitive'
     dictionary = {
@@ -158,8 +155,7 @@ def test_unknown_primitive_type(es):
 
 def test_unknown_primitive_module(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
-                                     parent_entity=es['sessions'])
+    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
     max_dict = max_feat.to_dictionary()
     max_dict['arguments']['primitive']['module'] = 'fake.module'
     dictionary = {

--- a/featuretools/tests/primitive_tests/test_features_deserializer.py
+++ b/featuretools/tests/primitive_tests/test_features_deserializer.py
@@ -26,7 +26,8 @@ def test_single_feature(es):
 
 def test_base_features_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
+    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
+                                     parent_entity=es['sessions'])
     dictionary = {
         'ft_version': ft.__version__,
         'schema_version': SCHEMA_VERSION,
@@ -47,7 +48,8 @@ def test_base_features_not_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
     value_x2 = ft.TransformFeature(value,
                                    ft.primitives.MultiplyNumericScalar(value=2))
-    max_feat = ft.AggregationFeature(value_x2, es['sessions'], ft.primitives.Max)
+    max_feat = ft.AggregationFeature(value_x2, ft.primitives.Max,
+                                     parent_entity=es['sessions'])
     dictionary = {
         'ft_version': ft.__version__,
         'schema_version': SCHEMA_VERSION,
@@ -121,7 +123,8 @@ def test_unknown_feature_type(es):
 
 def test_unknown_primitive_type(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
+    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
+                                     parent_entity=es['sessions'])
     max_dict = max_feat.to_dictionary()
     max_dict['arguments']['primitive']['type'] = 'FakePrimitive'
     dictionary = {
@@ -146,7 +149,8 @@ def test_unknown_primitive_type(es):
 
 def test_unknown_primitive_module(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feat = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
+    max_feat = ft.AggregationFeature(value, ft.primitives.Max,
+                                     parent_entity=es['sessions'])
     max_dict = max_feat.to_dictionary()
     max_dict['arguments']['primitive']['module'] = 'fake.module'
     dictionary = {

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -2,7 +2,7 @@ import featuretools as ft
 from featuretools.entityset.deserialize import description_to_entityset
 from featuretools.feature_base.features_serializer import FeaturesSerializer
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "2.0.0"
 
 
 def test_single_feature(es):

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -24,7 +24,8 @@ def test_single_feature(es):
 
 def test_base_features_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feature = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
+    max_feature = ft.AggregationFeature(value, ft.primitives.Max,
+                                        parent_entity=es['sessions'])
     features = [max_feature, value]
     serializer = FeaturesSerializer(features)
 
@@ -46,7 +47,8 @@ def test_base_features_not_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
     value_x2 = ft.TransformFeature(value,
                                    ft.primitives.MultiplyNumericScalar(value=2))
-    max_feature = ft.AggregationFeature(value_x2, es['sessions'], ft.primitives.Max)
+    max_feature = ft.AggregationFeature(value_x2, ft.primitives.Max,
+                                        parent_entity=es['sessions'])
     features = [max_feature]
     serializer = FeaturesSerializer(features)
 
@@ -68,7 +70,8 @@ def test_base_features_not_in_list(es):
 def test_where_feature_dependency(es):
     value = ft.IdentityFeature(es['log']['value'])
     is_purchased = ft.IdentityFeature(es['log']['purchased'])
-    max_feature = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max,
+    max_feature = ft.AggregationFeature(value, ft.primitives.Max,
+                                        parent_entity=es['sessions'],
                                         where=is_purchased)
     features = [max_feature]
     serializer = FeaturesSerializer(features)

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -24,8 +24,7 @@ def test_single_feature(es):
 
 def test_base_features_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
-    max_feature = ft.AggregationFeature(value, ft.primitives.Max,
-                                        parent_entity=es['sessions'])
+    max_feature = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max)
     features = [max_feature, value]
     serializer = FeaturesSerializer(features)
 
@@ -47,8 +46,7 @@ def test_base_features_not_in_list(es):
     value = ft.IdentityFeature(es['log']['value'])
     value_x2 = ft.TransformFeature(value,
                                    ft.primitives.MultiplyNumericScalar(value=2))
-    max_feature = ft.AggregationFeature(value_x2, ft.primitives.Max,
-                                        parent_entity=es['sessions'])
+    max_feature = ft.AggregationFeature(value_x2, es['sessions'], ft.primitives.Max)
     features = [max_feature]
     serializer = FeaturesSerializer(features)
 
@@ -70,8 +68,7 @@ def test_base_features_not_in_list(es):
 def test_where_feature_dependency(es):
     value = ft.IdentityFeature(es['log']['value'])
     is_purchased = ft.IdentityFeature(es['log']['purchased'])
-    max_feature = ft.AggregationFeature(value, ft.primitives.Max,
-                                        parent_entity=es['sessions'],
+    max_feature = ft.AggregationFeature(value, es['sessions'], ft.primitives.Max,
                                         where=is_purchased)
     features = [max_feature]
     serializer = FeaturesSerializer(features)

--- a/featuretools/tests/primitive_tests/test_identity_features.py
+++ b/featuretools/tests/primitive_tests/test_identity_features.py
@@ -2,6 +2,11 @@ import featuretools as ft
 from featuretools.primitives.utils import PrimitivesDeserializer
 
 
+def test_relationship_path(es):
+    value = ft.IdentityFeature(es['log']['value'])
+    assert value.relationship_path == []
+
+
 def test_serialization(es):
     value = ft.IdentityFeature(es['log']['value'])
 

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -87,6 +87,12 @@ def test_init_and_name(es):
             ft.calculate_feature_matrix([instance], entityset=es).head(5)
 
 
+def test_relationship_path(es):
+    f = ft.TransformFeature(es['log']['datetime'], Hour)
+
+    assert f.relationship_path == []
+
+
 def test_serialization(es):
     value = ft.IdentityFeature(es['log']['value'])
     primitive = ft.primitives.MultiplyNumericScalar(value=2)


### PR DESCRIPTION
This adds an optional constructor parameter, and stores the `relationship_path` on the feature. If no `relationship_path` is passed to the constructor we search for a path between the target entity and base entity. If none or more than one is found we raise an error.  When there are more than one possible paths between entities the feature name will include the full path.

Also add `parent_name` and `child_name` to `Relationship`.

This does not update any other logic to use the paths, as this will be added in later commits.

See #543 for context.