### PR TITLE
load and save functionality for open files and strings

### DIFF
--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -82,8 +82,8 @@ class FeaturesDeserializer(object):
     def load(cls, features):
         if isinstance(features, str):
             try:
-                f = open(features, 'r')
-                features_dict = json.load(f)
+                with open(features, 'r') as f:
+                    features_dict = json.load(f)
             except OSError:
                 features_dict = json.loads(features)
             return cls(features_dict)

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -84,7 +84,7 @@ class FeaturesDeserializer(object):
             try:
                 with open(features, 'r') as f:
                     features_dict = json.load(f)
-            except OSError, IOError:
+            except (OSError, IOError):
                 features_dict = json.loads(features)
             return cls(features_dict)
         return cls(json.load(features))

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -21,12 +21,13 @@ else:
     from itertools import zip_longest
 
 
-def load_features(filepath):
-    """Loads the features from a filepath.
+def load_features(features):
+    """Loads the features from a filepath, an open file, or a JSON formatted string.
 
     Args:
-        filepath (str): The location of where features has been saved.
-            This must include the name of the file.
+        features (str or :class:`.FileObject): The location of where features has
+        been saved which this must include the name of the file, or a JSON formatted
+        string, or a readable file handle where the features have been saved.
 
     Returns:
         features (list[:class:`.FeatureBase`]): Feature definitions list.
@@ -46,10 +47,17 @@ def load_features(filepath):
 
             filepath = os.path.join('/Home/features/', 'list')
             ft.load_features(filepath)
+
+            f = open(filepath, 'r')
+            ft.load_features(f)
+
+            feature_str = f.read()
+            ft.load_features(feature_str)
+
     .. seealso::
         :func:`.save_features`
     """
-    return FeaturesDeserializer.load(filepath).to_list()
+    return FeaturesDeserializer.load(features).to_list()
 
 
 class FeaturesDeserializer(object):
@@ -71,11 +79,16 @@ class FeaturesDeserializer(object):
         self._primitives_deserializer = PrimitivesDeserializer()
 
     @classmethod
-    def load(cls, filepath):
-        with open(filepath, 'r') as f:
-            features_dict = json.load(f)
+    def load(cls, features):
+        if isinstance(features, str):
+            try:
+                f = open(features, 'r')
+                features_dict = json.load(f)
+            except OSError:
+                features_dict = json.loads(features)
+            return cls(features_dict)
+        return cls(json.load(features))
 
-        return cls(features_dict)
 
     def to_list(self):
         feature_names = self.features_dict['feature_list']

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -89,7 +89,6 @@ class FeaturesDeserializer(object):
             return cls(features_dict)
         return cls(json.load(features))
 
-
     def to_list(self):
         feature_names = self.features_dict['feature_list']
         return [self._deserialize_feature(name) for name in feature_names]

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -25,7 +25,7 @@ def load_features(features):
     """Loads the features from a filepath, an open file, or a JSON formatted string.
 
     Args:
-        features (str or :class:`.FileObject): The location of where features has
+        features (str or :class:`.FileObject`): The location of where features has
         been saved which this must include the name of the file, or a JSON formatted
         string, or a readable file handle where the features have been saved.
 

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -82,10 +82,10 @@ class FeaturesDeserializer(object):
     def load(cls, features):
         if isinstance(features, str):
             try:
+                features_dict = json.loads(features)
+            except ValueError:
                 with open(features, 'r') as f:
                     features_dict = json.load(f)
-            except (OSError, IOError):
-                features_dict = json.loads(features)
             return cls(features_dict)
         return cls(json.load(features))
 

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -84,7 +84,7 @@ class FeaturesDeserializer(object):
             try:
                 with open(features, 'r') as f:
                     features_dict = json.load(f)
-            except OSError:
+            except OSError, IOError:
                 features_dict = json.loads(features)
             return cls(features_dict)
         return cls(json.load(features))

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -5,14 +5,17 @@ from featuretools.version import __version__ as ft_version
 SCHEMA_VERSION = "1.0.0"
 
 
-def save_features(features, filepath):
-    """Saves the features list as JSON to a specificed filepath.
+def save_features(features, file=None):
+    """Saves the features list as JSON to a specified filepath, writes to an open file, or
+    returns the serialized features as a JSON string. If no file provided, returns a string.
 
     Args:
         features (list[:class:`.FeatureBase`]): List of Feature definitions.
 
-        filepath (str): The location of where to save the features list. This
-            must include the name of the file.
+        file (str or :class:`.FileObject, optional): The location of where to save
+            the features list which must include the name of the file,
+            or a writeable file handle to write to.
+            Default: None
 
     Note:
         Features saved in one version of Featuretools are not guaranteed to work in another.
@@ -38,10 +41,15 @@ def save_features(features, filepath):
 
             filepath = os.path.join('/Home/features/', 'list')
             ft.save_features(features, filepath)
+
+            f = open(filepath, 'w')
+            ft.save_features(features, f)
+
+            features_str = ft.save_features(features)
     .. seealso::
         :func:`.load_features`
     """
-    FeaturesSerializer(features).save(filepath)
+    return FeaturesSerializer(features).save(file)
 
 
 class FeaturesSerializer(object):
@@ -61,10 +69,15 @@ class FeaturesSerializer(object):
             'feature_definitions': self._feature_definitions(),
         }
 
-    def save(self, filepath):
+    def save(self, file):
         features_dict = self.to_dict()
-        with open(filepath, "w") as f:
-            json.dump(features_dict, f)
+        if file is None:
+            return json.dumps(features_dict)
+        if isinstance(file, str):
+            f = open(file, "w")
+        else:
+            f = file
+        json.dump(features_dict, f)
 
     def _feature_definitions(self):
         if not self._features_dict:

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -12,7 +12,7 @@ def save_features(features, location=None):
     Args:
         features (list[:class:`.FeatureBase`]): List of Feature definitions.
 
-        location (str or :class:`.FileObject, optional): The location of where to save
+        location (str or :class:`.FileObject`, optional): The location of where to save
             the features list which must include the name of the file,
             or a writeable file handle to write to.
             Default: None

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -5,14 +5,14 @@ from featuretools.version import __version__ as ft_version
 SCHEMA_VERSION = "1.0.0"
 
 
-def save_features(features, file=None):
+def save_features(features, location=None):
     """Saves the features list as JSON to a specified filepath, writes to an open file, or
     returns the serialized features as a JSON string. If no file provided, returns a string.
 
     Args:
         features (list[:class:`.FeatureBase`]): List of Feature definitions.
 
-        file (str or :class:`.FileObject, optional): The location of where to save
+        location (str or :class:`.FileObject, optional): The location of where to save
             the features list which must include the name of the file,
             or a writeable file handle to write to.
             Default: None
@@ -49,7 +49,7 @@ def save_features(features, file=None):
     .. seealso::
         :func:`.load_features`
     """
-    return FeaturesSerializer(features).save(file)
+    return FeaturesSerializer(features).save(location)
 
 
 class FeaturesSerializer(object):
@@ -69,15 +69,15 @@ class FeaturesSerializer(object):
             'feature_definitions': self._feature_definitions(),
         }
 
-    def save(self, file):
+    def save(self, location):
         features_dict = self.to_dict()
-        if file is None:
+        if location is None:
             return json.dumps(features_dict)
-        if isinstance(file, str):
-            f = open(file, "w")
+        if isinstance(location, str):
+            with open(location, "w") as f:
+                json.dump(features_dict, f)
         else:
-            f = file
-        json.dump(features_dict, f)
+            json.dump(features_dict, location)
 
     def _feature_definitions(self):
         if not self._features_dict:

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -14,7 +14,8 @@ def save_features(features, location=None):
 
         location (str or :class:`.FileObject`, optional): The location of where to save
             the features list which must include the name of the file,
-            or a writeable file handle to write to.
+            or a writeable file handle to write to. If location is None, will return a JSON string
+            of the serialized features.
             Default: None
 
     Note:

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -8,32 +8,35 @@ from featuretools.primitives import make_agg_primitive
 from featuretools.variable_types import Numeric
 
 
-def test_pickle_features(es):
-    features_original = ft.dfs(target_entity='sessions', entityset=es, features_only=True)
-
+def pickle_features_test_helper(es_size, features_original):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
     ft.save_features(features_original, filepath)
     features_deserializedA = ft.load_features(filepath)
-    assert os.path.getsize(filepath) < asizeof(es)
+    assert os.path.getsize(filepath) < es_size
     os.remove(filepath)
 
     with open(filepath, "w") as f:
         ft.save_features(features_original, f)
     features_deserializedB = ft.load_features(open(filepath))
-    assert os.path.getsize(filepath) < asizeof(es)
+    assert os.path.getsize(filepath) < es_size
     os.remove(filepath)
 
     features = ft.save_features(features_original)
     features_deserializedC = ft.load_features(features)
-    assert asizeof(features) < asizeof(es)
+    assert asizeof(features) < es_size
 
     features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
     for features_deserialized in features_deserialized_options:
         for feat_1, feat_2 in zip(features_original, features_deserialized):
             assert feat_1.unique_name() == feat_2.unique_name()
             assert feat_1.entityset == feat_2.entityset
+
+
+def test_pickle_features(es):
+    features_original = ft.dfs(target_entity='sessions', entityset=es, features_only=True)
+    pickle_features_test_helper(asizeof(es), features_original)
 
 
 def test_pickle_features_with_custom_primitive(es):
@@ -48,26 +51,4 @@ def test_pickle_features_with_custom_primitive(es):
                                agg_primitives=["Last", "Mean", NewMax], features_only=True)
 
     assert any([isinstance(feat.primitive, NewMax) for feat in features_original])
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    filepath = os.path.join(dir_path, 'test_feature')
-
-    ft.save_features(features_original, filepath)
-    features_deserializedA = ft.load_features(filepath)
-    assert os.path.getsize(filepath) < asizeof(es)
-    os.remove(filepath)
-
-    with open(filepath, "w") as f:
-        ft.save_features(features_original, f)
-    features_deserializedB = ft.load_features(open(filepath))
-    assert os.path.getsize(filepath) < asizeof(es)
-    os.remove(filepath)
-
-    features = ft.save_features(features_original)
-    features_deserializedC = ft.load_features(features)
-    assert asizeof(features) < asizeof(es)
-
-    features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
-    for features_deserialized in features_deserialized_options:
-        for feat_1, feat_2 in zip(features_original, features_deserialized):
-            assert feat_1.unique_name() == feat_2.unique_name()
-            assert feat_1.entityset == feat_2.entityset
+    pickle_features_test_helper(asizeof(es), features_original)

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -39,6 +39,7 @@ def test_pickle_features(es):
             assert feat_1.unique_name() == feat_2.unique_name()
             assert feat_1.entityset == feat_2.entityset
 
+
 def test_pickle_features_with_custom_primitive(es):
     NewMax = make_agg_primitive(
         lambda x: max(x),
@@ -78,4 +79,3 @@ def test_pickle_features_with_custom_primitive(es):
         for feat_1, feat_2 in zip(features_original, features_deserialized):
             assert feat_1.unique_name() == feat_2.unique_name()
             assert feat_1.entityset == feat_2.entityset
-

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -1,4 +1,3 @@
-
 import os
 
 from pympler.asizeof import asizeof

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -14,21 +14,18 @@ def test_pickle_features(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
-    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
     features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # ft.save_features(features, f)
-    f = open(filepath, "w")
-    ft.save_features(features_original, f)
-    f.close()
+    with open(filepath, "w") as f:
+        ft.save_features(features_original, f)
+        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # test for save_features(features)
     features = ft.save_features(features_original)
     features_deserializedC = ft.load_features(features)
     assert asizeof(features) < asizeof(es)
@@ -55,21 +52,18 @@ def test_pickle_features_with_custom_primitive(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
-    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
     features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # ft.save_features(features, f)
-    f = open(filepath, "w")
-    ft.save_features(features_original, f)
-    f.close()
+    with open(filepath, "w") as f:
+        ft.save_features(features_original, f)
+        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # test for save_features(features)
     features = ft.save_features(features_original)
     features_deserializedC = ft.load_features(features)
     assert asizeof(features) < asizeof(es)

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -1,3 +1,4 @@
+
 import os
 
 from pympler.asizeof import asizeof
@@ -13,17 +14,30 @@ def test_pickle_features(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
+    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
-    features_deserialized = ft.load_features(filepath)
-    for feat_1, feat_2 in zip(features_original, features_deserialized):
-        assert feat_1.unique_name() == feat_2.unique_name()
-        assert feat_1.entityset == feat_2.entityset
-
-    # file is smaller than entityset in memory
+    features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
-
     os.remove(filepath)
 
+    # ft.save_features(features, f)
+    f = open(filepath, "w")
+    ft.save_features(features_original, f)
+    f.close()
+    features_deserializedB = ft.load_features(open(filepath))
+    assert os.path.getsize(filepath) < asizeof(es)
+    os.remove(filepath)
+
+    # test for save_features(features)
+    features = ft.save_features(features_original)
+    features_deserializedC = ft.load_features(features)
+    assert asizeof(features) < asizeof(es)
+
+    features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
+    for features_deserialized in features_deserialized_options:
+        for feat_1, feat_2 in zip(features_original, features_deserialized):
+            assert feat_1.unique_name() == feat_2.unique_name()
+            assert feat_1.entityset == feat_2.entityset
 
 def test_pickle_features_with_custom_primitive(es):
     NewMax = make_agg_primitive(
@@ -40,13 +54,28 @@ def test_pickle_features_with_custom_primitive(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
+    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
-    features_deserialized = ft.load_features(filepath)
-    for feat_1, feat_2 in zip(features_original, features_deserialized):
-        assert feat_1.unique_name() == feat_2.unique_name()
-        assert feat_1.entityset == feat_2.entityset
-
-    # file is smaller than entityset in memory
+    features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
-
     os.remove(filepath)
+
+    # ft.save_features(features, f)
+    f = open(filepath, "w")
+    ft.save_features(features_original, f)
+    f.close()
+    features_deserializedB = ft.load_features(open(filepath))
+    assert os.path.getsize(filepath) < asizeof(es)
+    os.remove(filepath)
+
+    # test for save_features(features)
+    features = ft.save_features(features_original)
+    features_deserializedC = ft.load_features(features)
+    assert asizeof(features) < asizeof(es)
+
+    features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
+    for features_deserialized in features_deserialized_options:
+        for feat_1, feat_2 in zip(features_original, features_deserialized):
+            assert feat_1.unique_name() == feat_2.unique_name()
+            assert feat_1.entityset == feat_2.entityset
+

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -21,7 +21,6 @@ def test_pickle_features(es):
 
     with open(filepath, "w") as f:
         ft.save_features(features_original, f)
-        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
@@ -59,7 +58,6 @@ def test_pickle_features_with_custom_primitive(es):
 
     with open(filepath, "w") as f:
         ft.save_features(features_original, f)
-        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)


### PR DESCRIPTION
fixes #73 

Updated /featuretools/feature_base save and load to fulfill:

Returns the serialized features as a string
ft.save_features(features) 

Saves the serialized features as a file
ft.save_features(features, '/path/to/save/to.txt')

Save the features to open file f
ft.save_features(features, f)


Loads features from string:
ft.load_features(feature_str)

Loads features from file path:
ft.load_features('/path/to/features')

Loads features from open file f: 
ft.load_features(f)