### PR TITLE
Fixed testing issue with residual directories causing FileExistsError for makedirs()

### DIFF
--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -21,12 +21,13 @@ else:
     from itertools import zip_longest
 
 
-def load_features(filepath):
-    """Loads the features from a filepath.
+def load_features(features):
+    """Loads the features from a filepath, an open file, or a JSON formatted string.
 
     Args:
-        filepath (str): The location of where features has been saved.
-            This must include the name of the file.
+        features (str or :class:`.FileObject): The location of where features has
+        been saved which this must include the name of the file, or a JSON formatted
+        string, or a readable file handle where the features have been saved.
 
     Returns:
         features (list[:class:`.FeatureBase`]): Feature definitions list.
@@ -46,10 +47,17 @@ def load_features(filepath):
 
             filepath = os.path.join('/Home/features/', 'list')
             ft.load_features(filepath)
+
+            f = open(filepath, 'r')
+            ft.load_features(f)
+
+            feature_str = f.read()
+            ft.load_features(feature_str)
+
     .. seealso::
         :func:`.save_features`
     """
-    return FeaturesDeserializer.load(filepath).to_list()
+    return FeaturesDeserializer.load(features).to_list()
 
 
 class FeaturesDeserializer(object):
@@ -71,11 +79,16 @@ class FeaturesDeserializer(object):
         self._primitives_deserializer = PrimitivesDeserializer()
 
     @classmethod
-    def load(cls, filepath):
-        with open(filepath, 'r') as f:
-            features_dict = json.load(f)
+    def load(cls, features):
+        if isinstance(features, str):
+            try:
+                f = open(features, 'r')
+                features_dict = json.load(f)
+            except OSError:
+                features_dict = json.loads(features)
+            return cls(features_dict)
+        return cls(json.load(features))
 
-        return cls(features_dict)
 
     def to_list(self):
         feature_names = self.features_dict['feature_list']

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -5,14 +5,17 @@ from featuretools.version import __version__ as ft_version
 SCHEMA_VERSION = "1.0.0"
 
 
-def save_features(features, filepath):
-    """Saves the features list as JSON to a specificed filepath.
+def save_features(features, file=None):
+    """Saves the features list as JSON to a specified filepath, writes to an open file, or
+    returns the serialized features as a JSON string. If no file provided, returns a string.
 
     Args:
         features (list[:class:`.FeatureBase`]): List of Feature definitions.
 
-        filepath (str): The location of where to save the features list. This
-            must include the name of the file.
+        file (str or :class:`.FileObject, optional): The location of where to save
+            the features list which must include the name of the file,
+            or a writeable file handle to write to.
+            Default: None
 
     Note:
         Features saved in one version of Featuretools are not guaranteed to work in another.
@@ -38,10 +41,15 @@ def save_features(features, filepath):
 
             filepath = os.path.join('/Home/features/', 'list')
             ft.save_features(features, filepath)
+
+            f = open(filepath, 'w')
+            ft.save_features(features, f)
+
+            features_str = ft.save_features(features)
     .. seealso::
         :func:`.load_features`
     """
-    FeaturesSerializer(features).save(filepath)
+    return FeaturesSerializer(features).save(file)
 
 
 class FeaturesSerializer(object):
@@ -61,10 +69,15 @@ class FeaturesSerializer(object):
             'feature_definitions': self._feature_definitions(),
         }
 
-    def save(self, filepath):
+    def save(self, file):
         features_dict = self.to_dict()
-        with open(filepath, "w") as f:
-            json.dump(features_dict, f)
+        if file is None:
+            return json.dumps(features_dict)
+        if isinstance(file, str):
+            f = open(file, "w")
+        else:
+            f = file
+        json.dump(features_dict, f)
 
     def _feature_definitions(self):
         if not self._features_dict:

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -79,6 +79,10 @@ def test_empty_dataframe(es):
 
 def test_to_csv(es):
     path = os.path.join(CACHE, 'es')
+    try:
+        shutil.rmtree(path)
+    except OSError:
+        pass
     os.makedirs(path)
     es.to_csv(path, encoding='utf-8', engine='python')
     new_es = deserialize.read_entityset(path)
@@ -122,3 +126,4 @@ def test_to_pickle_id_none():
     new_es = deserialize.read_entityset(path)
     assert es.__eq__(new_es, deep=True)
     shutil.rmtree(path)
+

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -126,4 +126,3 @@ def test_to_pickle_id_none():
     new_es = deserialize.read_entityset(path)
     assert es.__eq__(new_es, deep=True)
     shutil.rmtree(path)
-

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -77,7 +77,7 @@ def test_empty_dataframe(es):
         assert dataframe.empty
 
 
-def test_to_csv(es):
+def :
     path = os.path.join(CACHE, 'es')
     try:
         shutil.rmtree(path)

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -77,7 +77,7 @@ def test_empty_dataframe(es):
         assert dataframe.empty
 
 
-def :
+def test_to_csv(es):
     path = os.path.join(CACHE, 'es')
     try:
         shutil.rmtree(path)

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -1,3 +1,4 @@
+
 import os
 
 from pympler.asizeof import asizeof
@@ -13,17 +14,30 @@ def test_pickle_features(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
+    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
-    features_deserialized = ft.load_features(filepath)
-    for feat_1, feat_2 in zip(features_original, features_deserialized):
-        assert feat_1.unique_name() == feat_2.unique_name()
-        assert feat_1.entityset == feat_2.entityset
-
-    # file is smaller than entityset in memory
+    features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
-
     os.remove(filepath)
 
+    # ft.save_features(features, f)
+    f = open(filepath, "w")
+    ft.save_features(features_original, f)
+    f.close()
+    features_deserializedB = ft.load_features(open(filepath))
+    assert os.path.getsize(filepath) < asizeof(es)
+    os.remove(filepath)
+
+    # test for save_features(features)
+    features = ft.save_features(features_original)
+    features_deserializedC = ft.load_features(features)
+    assert asizeof(features) < asizeof(es)
+
+    features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
+    for features_deserialized in features_deserialized_options:
+        for feat_1, feat_2 in zip(features_original, features_deserialized):
+            assert feat_1.unique_name() == feat_2.unique_name()
+            assert feat_1.entityset == feat_2.entityset
 
 def test_pickle_features_with_custom_primitive(es):
     NewMax = make_agg_primitive(
@@ -40,13 +54,28 @@ def test_pickle_features_with_custom_primitive(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
+    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
-    features_deserialized = ft.load_features(filepath)
-    for feat_1, feat_2 in zip(features_original, features_deserialized):
-        assert feat_1.unique_name() == feat_2.unique_name()
-        assert feat_1.entityset == feat_2.entityset
-
-    # file is smaller than entityset in memory
+    features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
-
     os.remove(filepath)
+
+    # ft.save_features(features, f)
+    f = open(filepath, "w")
+    ft.save_features(features_original, f)
+    f.close()
+    features_deserializedB = ft.load_features(open(filepath))
+    assert os.path.getsize(filepath) < asizeof(es)
+    os.remove(filepath)
+
+    # test for save_features(features)
+    features = ft.save_features(features_original)
+    features_deserializedC = ft.load_features(features)
+    assert asizeof(features) < asizeof(es)
+
+    features_deserialized_options = [features_deserializedA, features_deserializedB, features_deserializedC]
+    for features_deserialized in features_deserialized_options:
+        for feat_1, feat_2 in zip(features_original, features_deserialized):
+            assert feat_1.unique_name() == feat_2.unique_name()
+            assert feat_1.entityset == feat_2.entityset
+

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -14,21 +14,18 @@ def test_pickle_features(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
-    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
     features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # ft.save_features(features, f)
-    f = open(filepath, "w")
-    ft.save_features(features_original, f)
-    f.close()
+    with open(filepath, "w") as f:
+        ft.save_features(features_original, f)
+        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # test for save_features(features)
     features = ft.save_features(features_original)
     features_deserializedC = ft.load_features(features)
     assert asizeof(features) < asizeof(es)
@@ -54,21 +51,18 @@ def test_pickle_features_with_custom_primitive(es):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(dir_path, 'test_feature')
 
-    # ft.save_features(features, '/path/to/save/to.txt')
     ft.save_features(features_original, filepath)
     features_deserializedA = ft.load_features(filepath)
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # ft.save_features(features, f)
-    f = open(filepath, "w")
-    ft.save_features(features_original, f)
-    f.close()
+    with open(filepath, "w") as f:
+        ft.save_features(features_original, f)
+        f.close()
     features_deserializedB = ft.load_features(open(filepath))
     assert os.path.getsize(filepath) < asizeof(es)
     os.remove(filepath)
 
-    # test for save_features(features)
     features = ft.save_features(features_original)
     features_deserializedC = ft.load_features(features)
     assert asizeof(features) < asizeof(es)
@@ -78,4 +72,3 @@ def test_pickle_features_with_custom_primitive(es):
         for feat_1, feat_2 in zip(features_original, features_deserialized):
             assert feat_1.unique_name() == feat_2.unique_name()
             assert feat_1.entityset == feat_2.entityset
-


### PR DESCRIPTION
Fix #565 
Resolved by adding shutil.rmtree(path) if the path already exists in entityset_tests/test_serialization.py test_to_csv(es) ~line 80. 

