### PR TITLE
Fixed testing issue with residual directories causing FileExistsError for makedirs()

### DIFF
--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -1,5 +1,5 @@
-import os
 import errno
+import os
 import shutil
 
 import pandas as pd
@@ -8,7 +8,6 @@ import pytest
 from featuretools.demo import load_mock_customer
 from featuretools.entityset import EntitySet, deserialize, serialize
 from featuretools.tests import integration_data
-
 
 CACHE = os.path.join(os.path.dirname(integration_data.__file__), '.cache')
 

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -59,12 +59,19 @@ def test_entityset_description(es):
     assert es.metadata.__eq__(_es, deep=True)
 
 
-def test_invalid_formats(es):
+@pytest.fixture
+def path_management():
     path = os.path.join(CACHE, 'es')
+    os.makedirs(path)
+    yield path
+    shutil.rmtree(path)
+
+
+def test_invalid_formats(es, path_management):
     error_text = 'must be one of the following formats: {}'
     error_text = error_text.format(', '.join(serialize.FORMATS))
     with pytest.raises(ValueError, match=error_text):
-        serialize.write_entity_data(es.entities[0], path=path, format='')
+        serialize.write_entity_data(es.entities[0], path=path_management, format='')
     with pytest.raises(ValueError, match=error_text):
         entity = {'loading_info': {'location': 'data', 'type': ''}}
         deserialize.read_entity_data(entity, path='.')
@@ -77,48 +84,33 @@ def test_empty_dataframe(es):
         assert dataframe.empty
 
 
-def test_to_csv(es):
-    path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
-    es.to_csv(path, encoding='utf-8', engine='python')
-    new_es = deserialize.read_entityset(path)
+def test_to_csv(es, path_management):
+    es.to_csv(path_management, encoding='utf-8', engine='python')
+    new_es = deserialize.read_entityset(path_management)
     assert es.__eq__(new_es, deep=True)
-    shutil.rmtree(path)
 
 
-def test_to_pickle(es):
-    path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
-    es.to_pickle(path)
-    new_es = deserialize.read_entityset(path)
+def test_to_pickle(es, path_management):
+    es.to_pickle(path_management)
+    new_es = deserialize.read_entityset(path_management)
     assert es.__eq__(new_es, deep=True)
-    shutil.rmtree(path)
 
 
-def test_to_parquet(es):
-    path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
-    es.to_parquet(path)
-    new_es = deserialize.read_entityset(path)
+def test_to_parquet(es, path_management):
+    es.to_parquet(path_management)
+    new_es = deserialize.read_entityset(path_management)
     assert es.__eq__(new_es, deep=True)
-    shutil.rmtree(path)
 
 
-def test_to_parquet_with_lti():
+def test_to_parquet_with_lti(path_management):
     es = load_mock_customer(return_entityset=True, random_seed=0)
-    path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
-    es.to_parquet(path)
-    new_es = deserialize.read_entityset(path)
+    es.to_parquet(path_management)
+    new_es = deserialize.read_entityset(path_management)
     assert es.__eq__(new_es, deep=True)
-    shutil.rmtree(path)
 
 
-def test_to_pickle_id_none():
-    path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
+def test_to_pickle_id_none(path_management):
     es = EntitySet()
-    es.to_pickle(path)
-    new_es = deserialize.read_entityset(path)
+    es.to_pickle(path_management)
+    new_es = deserialize.read_entityset(path_management)
     assert es.__eq__(new_es, deep=True)
-    shutil.rmtree(path)

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -59,7 +59,7 @@ def path_management():
     try:
         os.makedirs(path)
     except OSError as e:
-        if e.errno != errno.EEXIST:
+        if e.errno != errno.EEXIST:  # EEXIST corresponds to FileExistsError
             raise e
     yield path
     shutil.rmtree(path)

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -1,4 +1,5 @@
 import os
+import errno
 import shutil
 
 import pandas as pd
@@ -7,6 +8,7 @@ import pytest
 from featuretools.demo import load_mock_customer
 from featuretools.entityset import EntitySet, deserialize, serialize
 from featuretools.tests import integration_data
+
 
 CACHE = os.path.join(os.path.dirname(integration_data.__file__), '.cache')
 
@@ -64,8 +66,9 @@ def path_management():
     path = os.path.join(CACHE, 'es')
     try:
         os.makedirs(path)
-    except (OSError, IOError):
-        pass
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise e
     yield path
     shutil.rmtree(path)
 

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -62,7 +62,10 @@ def test_entityset_description(es):
 @pytest.fixture
 def path_management():
     path = os.path.join(CACHE, 'es')
-    os.makedirs(path)
+    try:
+        os.makedirs(path)
+    except (OSError, IOError):
+        pass
     yield path
     shutil.rmtree(path)
 


### PR DESCRIPTION
Fix #565
Resolved by adding fixture that creates the path and makes the directory, yields the path, and removes the path folder in the finalization code.