### PR TITLE
Stop isort from changing __init__.py files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ filterwarnings =
 exclude = docs/*
 ignore = E501,W504 # line too long error, line break after binary operator
 [isort]
+skip=__init__.py
 forced_separate=featuretools
 # vertical hanging indent
 multi_line_output=3


### PR DESCRIPTION
- Stop isort from changing __init__.py files to prevent circular imports