### PR TITLE
Skip changelog CI check on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,3 +123,6 @@ workflows:
   changelog_updated:
     jobs:
       - "changelog_updated"
+          filters:
+            branches:
+              ignore: /^skip-changelog-ci-check-on-master?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,4 +125,4 @@ workflows:
       - changelog_updated:
           filters:
             branches:
-              ignore: /^skip-changelog-ci-check-on-master?/
+              ignore: /^master?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
       - "python-37"
   changelog_updated:
     jobs:
-      - "changelog_updated"
+      - changelog_updated:
           filters:
             branches:
               ignore: /^skip-changelog-ci-check-on-master?/

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ Changelog
         * Add Featuretools Enterprise to documentation (:pr:`563`)
         * Miscellaneous changes (:pr:`552`, :pr:`573`, :pr:`577`)
     * Testing Changes
-        * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`)
+        * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`, :pr:`584`)
 
     Thanks to the following people for contributing to this release:
     :user:`allisonportis`, :user:`CJStadler`, :user:`ctduffy`, :user:`gsheni`, :user:`kmax12`, :user:`rwedge`


### PR DESCRIPTION
### Pull Request Description
When we run CircleCI after merging into the master branch the changelog_updated check fails because there is no pull request number.  This PR filters out running the changelog_updated check on the master branch.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
