### PR TITLE
removed all mentions of allow_where

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
         * Support custom variable types (:pr:`571`)
     * Fixes
         * Normalize_entity specifies error when 'make_time_index' is an invalid string (:pr:`550`)
+        * Removed all mentions of allow_where (:pr:`587`)
     * Changes
         * Refactor get_pandas_data_slice to take single entity (:pr:`547`)
         * Updates TimeSincePrevious and Diff Primitives (:pr:`561`)
@@ -21,7 +22,7 @@ Changelog
         * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`, :pr:`584`)
 
     Thanks to the following people for contributing to this release:
-    :user:`allisonportis`, :user:`CJStadler`, :user:`ctduffy`, :user:`gsheni`, :user:`kmax12`, :user:`rwedge`
+    :user:`alexjwang`, :user:`allisonportis`, :user:`CJStadler`, :user:`ctduffy`, :user:`gsheni`, :user:`kmax12`, :user:`rwedge`
 
 **v0.8.0** May 17, 2019
     * Rename NUnique to NumUnique (:pr:`510`)

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -12,7 +12,6 @@ class AggregationPrimitive(PrimitiveBase):
     base_of = None  # whitelist of primitives this prim can be input for
     base_of_exclude = None  # primitives this primitive can't be input for
     stack_on_self = True  # whether or not it can be in input_types of self
-    allow_where = True  # whether DFS can apply where clause to this primitive
 
     def generate_name(self, base_feature_names, relationship_path_name,
                       parent_entity_id, where_str, use_prev_str):

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -22,8 +22,6 @@ class PrimitiveBase(object):
     #: (bool): True if feature needs to know what the current calculation time
     # is (provided to computational backend as "time_last")
     uses_calc_time = False
-    #: (bool): If True, allow where clauses in DFS
-    allow_where = False
     #: (int): Maximum number of features in the largest chain proceeding
     # downward from this feature's base features.
     max_stack_depth = None

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -597,10 +597,6 @@ class DeepFeatureSynthesis(object):
                                            primitive=agg_prim)
                 self._handle_new_feature(new_f, all_features)
 
-                # Obey allow where
-                if not agg_prim.allow_where:
-                    continue
-
                 # limit the stacking of where features
                 # count up the the number of where features
                 # in this feature and its dependencies

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -537,7 +537,8 @@ def test_stacking_where_primitives(es):
 
 
 def test_no_allow_where(es):
-    Count.allow_where = False
+    with pytest.raises(AttributeError):
+        Count.allow_where
 
 
 def test_where_different_base_feats(es):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -536,6 +536,10 @@ def test_stacking_where_primitives(es):
     assert len(stacked_where_limit_2_feats) > 0
 
 
+def test_no_allow_where(es):
+    Count.allow_where = False
+
+
 def test_where_different_base_feats(es):
     es = copy.deepcopy(es)
     es['sessions']['device_type'].interesting_values = [0]

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -536,32 +536,6 @@ def test_stacking_where_primitives(es):
     assert len(stacked_where_limit_2_feats) > 0
 
 
-def test_allow_where(es):
-    es = copy.deepcopy(es)
-    es['sessions']['device_type'].interesting_values = [0]
-    Count.allow_where = False
-    kwargs = dict(
-        target_entity_id='customers',
-        entityset=es,
-        agg_primitives=[Count, Last],
-        max_depth=3,
-    )
-    dfs_constrained = DeepFeatureSynthesis(where_primitives=[Count, Last],
-                                           **kwargs)
-    features = dfs_constrained.build_features()
-
-    # change it back after building features
-    Count.allow_where = True
-
-    where_feats = [f for f in features
-                   if isinstance(f, AggregationFeature) and f.where is not None]
-
-    assert len([f for f in where_feats
-                if isinstance(f.primitive, Last)]) > 0
-    assert len([f for f in where_feats
-                if isinstance(f.primitive, Count)]) == 0
-
-
 def test_where_different_base_feats(es):
     es = copy.deepcopy(es)
     es['sessions']['device_type'].interesting_values = [0]


### PR DESCRIPTION
Fixes #474 

Removed:
allow_where variable in aggregation_primitive_base.py
allow_where variable in primitive_base.py
test_allow_where() entire function in test_deep_feature_synthesis.py