### PR TITLE
Better test function for error checking normalize_entity

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Changelog
         * Add Featuretools Enterprise to documentation (:pr:`563`)
         * Miscellaneous changes (:pr:`552`, :pr:`573`, :pr:`577`)
     * Testing Changes
-        * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`, :pr:`584`)
+        * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`, :pr:`584`, :pr:`590`)
 
     Thanks to the following people for contributing to this release:
     :user:`alexjwang`, :user:`allisonportis`, :user:`CJStadler`, :user:`ctduffy`, :user:`gsheni`, :user:`kmax12`, :user:`rwedge`

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -814,6 +814,7 @@ def test_normalize_entity(es):
 
 
 def test_normalize_entity_new_time_index_error_check(es):
+    es_copy = copy.deepcopy(es)
     error_text = "'make_time_index' must be a variable in the base entity"
     with pytest.raises(ValueError, match=error_text):
         es.normalize_entity(base_entity_id='customers',
@@ -831,8 +832,16 @@ def test_normalize_entity_new_time_index_error_check(es):
     es.normalize_entity(base_entity_id='customers',
                         new_entity_id='cancellations',
                         index='cancel_reason',
+                        make_time_index='cancel_date',
                         additional_variables=['cancel_date'],
-                        make_time_index='cancel_date')
+                        copy_variables=[])
+    es = es_copy
+    es.normalize_entity(base_entity_id='customers',
+                        new_entity_id='cancellations',
+                        index='cancel_reason',
+                        make_time_index='cancel_date',
+                        additional_variables=[],
+                        copy_variables=['cancel_date'])
 
 
 def test_normalize_time_index_from_none(es):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -819,7 +819,7 @@ def test_normalize_entity_new_time_index_error_check(es):
         es.normalize_entity(base_entity_id='customers',
                             new_entity_id='cancellations',
                             index='cancel_reason',
-                            make_time_index="non-extistent")
+                            make_time_index="non-existent")
 
     error_text = "'make_time_index' must specified in 'additional_variables' or 'copy_variables'"
     with pytest.raises(ValueError, match=error_text):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -801,16 +801,6 @@ def test_normalize_entity(es):
         es.normalize_entity('sessions', 'device_types', 'device_type',
                             copy_variables='log')
 
-    error_text = "'make_time_index' must be a variable in the base entity"
-    with pytest.raises(ValueError, match=error_text):
-        es.normalize_entity('sessions', 'device_types', 'device_type',
-                            make_time_index="nonextistent")
-
-    error_text = "'make_time_index' must specified in 'additional_variables' or 'copy_variables'"
-    with pytest.raises(ValueError, match=error_text):
-        es.normalize_entity('sessions', 'device_types', 'device_type',
-                            make_time_index='ip')
-
     es.normalize_entity('sessions', 'device_types', 'device_type',
                         additional_variables=['device_name'],
                         make_time_index=False)
@@ -821,6 +811,28 @@ def test_normalize_entity(es):
     assert 'device_name' in es['device_types'].df.columns
     assert 'device_name' not in es['sessions'].df.columns
     assert 'device_type' in es['device_types'].df.columns
+
+
+def test_normalize_entity_new_time_index_error_check(es):
+    error_text = "'make_time_index' must be a variable in the base entity"
+    with pytest.raises(ValueError, match=error_text):
+        es.normalize_entity(base_entity_id='customers',
+                            new_entity_id='cancellations',
+                            index='cancel_reason',
+                            make_time_index="non-extistent")
+
+    error_text = "'make_time_index' must specified in 'additional_variables' or 'copy_variables'"
+    with pytest.raises(ValueError, match=error_text):
+        es.normalize_entity(base_entity_id='customers',
+                            new_entity_id='cancellations',
+                            index='cancel_reason',
+                            make_time_index='cancel_date')
+
+    es.normalize_entity(base_entity_id='customers',
+                        new_entity_id='cancellations',
+                        index='cancel_reason',
+                        additional_variables=['cancel_date'],
+                        make_time_index='cancel_date')
 
 
 def test_normalize_time_index_from_none(es):


### PR DESCRIPTION
- Added a more clear test for normalize_entity and make_time_index
  - We have an error check for `make_time_index` to make sure that the column is in `copy_variables` or `additional_variables`
  - I rewrote the test cases to more clearly check this, and it uses another entity (customers instead of sessions)