### PR TITLE
Store full entity dfs in separate trie

### DIFF
--- a/featuretools/computational_backends/feature_set.py
+++ b/featuretools/computational_backends/feature_set.py
@@ -62,12 +62,11 @@ class FeatureSet(object):
         for dep_feat in f.get_dependencies():
             self._add_feature_to_trie(sub_trie, dep_feat, f.relationship_path)
 
-    def group_features(self, feature_names):
+    def group_features(self, features):
         """
         Topologically sort the given features, then group by path,
         feature type, use_previous, and where.
         """
-        features = [self.features_by_name[name] for name in feature_names]
         depths = self._get_feature_depths(features)
 
         def key_func(f):

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -117,11 +117,13 @@ class _FeaturesCalculator(object):
         feature_trie = self.feature_set.feature_trie
 
         df_trie = Trie(path_constructor=RelationshipPath)
+        large_df_trie = Trie(path_constructor=RelationshipPath)
 
         target_entity = self.entityset[self.target_eid]
         self._calculate_features_for_entity(entity_id=self.target_eid,
                                             feature_trie=feature_trie,
                                             df_trie=df_trie,
+                                            large_df_trie=large_df_trie,
                                             precalculated_trie=self.precalculated_features,
                                             filter_variable=target_entity.index,
                                             filter_values=instance_ids)
@@ -148,6 +150,7 @@ class _FeaturesCalculator(object):
         return df[column_list]
 
     def _calculate_features_for_entity(self, entity_id, feature_trie, df_trie,
+                                       large_df_trie,
                                        precalculated_trie,
                                        filter_variable, filter_values,
                                        parent_data=None):
@@ -163,6 +166,9 @@ class _FeaturesCalculator(object):
 
             df_trie (Trie): a parallel trie for storing dataframes. The
                 dataframe with features calculated will be placed in the root.
+
+            large_df_trie (Trie): a trie storing dataframes will all entity
+                rows, for features that are uses_full_entity.
 
             precalculated_trie (Trie): a parallel trie containing dataframes
                 with precalculated features. The dataframe for this entity will
@@ -200,16 +206,27 @@ class _FeaturesCalculator(object):
         # conditions.
 
         features = [self.feature_set.features_by_name[fname] for fname in feature_trie.value]
-        need_all_rows = any(self.feature_set.uses_full_entity(f) for f in features)
-        if need_all_rows:
+        entity = self.entityset[entity_id]
+        columns = _necessary_columns(entity, features)
+
+        # Group features by uses_full_entity
+        full_entity_features = []
+        not_full_entity_features = []
+        for f in features:
+            if self.feature_set.uses_full_entity(f, check_dependents=True):
+                full_entity_features.append(f)
+            else:
+                not_full_entity_features.append(f)
+
+        # If there are features that use the full entity then don't filter by
+        # filter_values.
+        if full_entity_features:
             query_variable = None
             query_values = None
         else:
             query_variable = filter_variable
             query_values = filter_values
 
-        entity = self.entityset[entity_id]
-        columns = _necessary_columns(entity, features)
         df = entity.query_by_values(query_values,
                                     variable_id=query_variable,
                                     columns=columns,
@@ -224,8 +241,6 @@ class _FeaturesCalculator(object):
                 parent_data
 
             if ancestor_relationship_variables:
-                assert parent_df is not None
-
                 df, new_ancestor_relationship_variables = self._add_ancestor_relationship_variables(
                     df, parent_df, ancestor_relationship_variables, parent_relationship)
 
@@ -245,15 +260,26 @@ class _FeaturesCalculator(object):
             else:
                 sub_entity = relationship.child_entity.id
                 sub_filter_variable = relationship.child_variable.id
-                sub_filter_values = df[relationship.parent_variable.id]
-                parent_data = (relationship, new_ancestor_relationship_variables, df)
+
+                # Pass filtered values, even if we are using a full df.
+                if full_entity_features:
+                    filtered_df = df[df[filter_variable].isin(filter_values)]
+                else:
+                    filtered_df = df
+                sub_filter_values = filtered_df[relationship.parent_variable.id]
+
+                parent_data = (relationship,
+                               new_ancestor_relationship_variables,
+                               df)
 
             sub_df_trie = df_trie.get_node([edge])
+            sub_large_df_trie = large_df_trie.get_node([edge])
             sub_precalc_trie = precalculated_trie.get_node([edge])
             self._calculate_features_for_entity(
                 entity_id=sub_entity,
                 feature_trie=sub_trie,
                 df_trie=sub_df_trie,
+                large_df_trie=sub_large_df_trie,
                 precalculated_trie=sub_precalc_trie,
                 filter_variable=sub_filter_variable,
                 filter_values=sub_filter_values,
@@ -278,23 +304,38 @@ class _FeaturesCalculator(object):
         if self.ignored:
             feature_names -= self.ignored
 
+        # First, calculate any features that require the full entity. These can
+        # be calculated first because all of their dependents are included in
+        # full_entity_features (See FeatureSet.uses_full_entity).
+        if full_entity_features:
+            df = self._calculate_features(df, large_df_trie, full_entity_features)
+
+            # Store large df.
+            large_df_trie.value = df
+
+            # Filter df so that features that don't require the full entity are
+            # only calculated on the necessary instances.
+            df = df[df[filter_variable].isin(filter_values)]
+
+        # Calculate all features that don't require the full entity.
+        df = self._calculate_features(df, df_trie, not_full_entity_features)
+
+        # Step 5: Store the dataframe for this entity at the root of df_trie, so
+        # that it can be accessed by the caller.
+        df_trie.value = df
+
+    def _calculate_features(self, df, df_trie, features):
         # Group the features so that each group can be calculated together.
         # The groups must also be in topological order (if A is a transform of B
         # then B must be in a group before A).
-        feature_groups = self.feature_set.group_features(feature_names)
+        feature_groups = self.feature_set.group_features(features)
 
         for group in feature_groups:
             representative_feature = group[0]
             handler = self._feature_type_handler(representative_feature)
             df = handler(group, df, df_trie)
 
-        # If we used all rows, filter the df to those that we actually need.
-        if need_all_rows:
-            df = df[df[filter_variable].isin(filter_values)]
-
-        # Step 5: Store the dataframe for this entity at the root of df_trie, so
-        # that it can be accessed by the caller.
-        df_trie.value = df
+        return df
 
     def _add_ancestor_relationship_variables(self, child_df, parent_df,
                                              ancestor_relationship_variables,

--- a/featuretools/computational_backends/pandas_backend.py
+++ b/featuretools/computational_backends/pandas_backend.py
@@ -153,7 +153,6 @@ class _FeaturesCalculator(object):
                                        full_entity_df_trie,
                                        precalculated_trie,
                                        filter_variable, filter_values,
-                                       ancestor_uses_full_entity=False,
                                        parent_data=None):
         """
         Generate dataframes with features calculated for this node of the trie,
@@ -266,7 +265,6 @@ class _FeaturesCalculator(object):
                 precalculated_trie=sub_precalc_trie,
                 filter_variable=sub_filter_variable,
                 filter_values=sub_filter_values,
-                ancestor_uses_full_entity=need_full_entity,
                 parent_data=parent_data)
 
         # Step 4: Calculate the features for this entity.

--- a/featuretools/tests/computational_backend/test_feature_set.py
+++ b/featuretools/tests/computational_backend/test_feature_set.py
@@ -3,7 +3,7 @@ from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.tests.testing_utils import backward_path
 
 
-def test_feature_trie(diamond_es):
+def test_feature_trie_without_needs_full_entity(diamond_es):
     es = diamond_es
     country_name = ft.IdentityFeature(es['countries']['name'])
     direct_name = ft.DirectFeature(country_name, es['regions'])
@@ -33,10 +33,74 @@ def test_feature_trie(diamond_es):
     feature_set = FeatureSet(es, features)
     trie = feature_set.feature_trie
 
-    assert trie.value == {f.unique_name() for f in features}
-    assert trie.get_node(direct_name.relationship_path).value == {country_name.unique_name()}
-    assert trie.get_node(regions_to_customers).value == {negation.unique_name(), customers_mean.unique_name()}
+    assert trie.value == \
+        (False, set(), {f.unique_name() for f in features})
+    assert trie.get_node(direct_name.relationship_path).value == \
+        (False, set(), {country_name.unique_name()})
+    assert trie.get_node(regions_to_customers).value == \
+        (False, set(), {negation.unique_name(), customers_mean.unique_name()})
     regions_to_stores = backward_path(es, ['regions', 'stores'])
-    assert trie.get_node(regions_to_stores).value == set()
-    assert trie.get_node(path_through_customers).value == {amount.unique_name()}
-    assert trie.get_node(path_through_stores).value == {amount.unique_name()}
+    assert trie.get_node(regions_to_stores).value == (False, set(), set())
+    assert trie.get_node(path_through_customers).value == \
+        (False, set(), {amount.unique_name()})
+    assert trie.get_node(path_through_stores).value == \
+        (False, set(), {amount.unique_name()})
+
+
+def test_feature_trie_with_needs_full_entity(diamond_es):
+    es = diamond_es
+    amount = ft.IdentityFeature(es['transactions']['amount'])
+
+    path_through_customers = backward_path(es, ['regions', 'customers', 'transactions'])
+    agg = ft.AggregationFeature(amount, es['regions'],
+                                primitive=ft.primitives.Mean,
+                                relationship_path=path_through_customers)
+    trans_of_agg = ft.TransformFeature(agg, ft.primitives.CumSum)
+
+    path_through_stores = backward_path(es, ['regions', 'stores', 'transactions'])
+    trans = ft.TransformFeature(amount, ft.primitives.CumSum)
+    agg_of_trans = ft.AggregationFeature(trans, es['regions'],
+                                         primitive=ft.primitives.Mean,
+                                         relationship_path=path_through_stores)
+
+    features = [agg, trans_of_agg, agg_of_trans]
+    feature_set = FeatureSet(es, features)
+    trie = feature_set.feature_trie
+
+    assert trie.value == \
+        (True, {agg.unique_name(), trans_of_agg.unique_name()}, {agg_of_trans.unique_name()})
+    assert trie.get_node(path_through_customers).value == \
+        (True, {amount.unique_name()}, set())
+    assert trie.get_node(path_through_customers[:1]).value == (True, set(), set())
+    assert trie.get_node(path_through_stores).value == \
+        (True, {amount.unique_name(), trans.unique_name()}, set())
+    assert trie.get_node(path_through_stores[:1]).value == (False, set(), set())
+
+
+def test_feature_trie_with_needs_full_entity_direct(es):
+    value = ft.IdentityFeature(es['log']['value'],)
+    agg = ft.AggregationFeature(value, es['sessions'],
+                                primitive=ft.primitives.Mean)
+    agg_of_agg = ft.AggregationFeature(agg, es['customers'],
+                                       primitive=ft.primitives.Sum)
+    direct = ft.DirectFeature(agg_of_agg, es['sessions'])
+    trans = ft.TransformFeature(direct, ft.primitives.CumSum)
+
+    features = [trans, agg]
+    feature_set = FeatureSet(es, features)
+    trie = feature_set.feature_trie
+
+    assert trie.value == \
+        (True, {direct.unique_name(), trans.unique_name()}, {agg.unique_name()})
+
+    assert trie.get_node(agg.relationship_path).value == \
+        (False, set(), {value.unique_name()})
+
+    parent_node = trie.get_node(direct.relationship_path)
+    assert parent_node.value == (True, {agg_of_agg.unique_name()}, set())
+
+    child_through_parent_node = parent_node.get_node(agg_of_agg.relationship_path)
+    assert child_through_parent_node.value == (True, {agg.unique_name()}, set())
+
+    assert child_through_parent_node.get_node(agg.relationship_path).value == \
+        (True, {value.unique_name()}, set())

--- a/featuretools/tests/computational_backend/test_pandas_backend.py
+++ b/featuretools/tests/computational_backend/test_pandas_backend.py
@@ -15,6 +15,7 @@ from featuretools.feature_base import DirectFeature, IdentityFeature
 from featuretools.primitives import (  # NMostCommon,
     And,
     Count,
+    CumSum,
     EqualScalar,
     GreaterThanEqualToScalar,
     GreaterThanScalar,
@@ -70,6 +71,18 @@ def test_make_agg_feat_of_identity_variable(es, backend):
                                                time_last=None)
     v = df[agg_feat.get_name()][0]
     assert (v == 50)
+
+
+def test_full_entity_trans_of_agg(es, backend):
+    agg_feat = ft.Feature(es['log']['value'], parent_entity=es['customers'],
+                          primitive=Sum)
+    trans_feat = ft.Feature(agg_feat, primitive=CumSum)
+
+    pandas_backend = backend([trans_feat])
+    df = pandas_backend.calculate_all_features(instance_ids=[1], time_last=None)
+
+    v = df[trans_feat.get_name()][1]
+    assert v == 82
 
 
 def test_make_agg_feat_of_identity_index_variable(es, backend):


### PR DESCRIPTION
@kmax12 and @rwedge this resolved the performance issues in a benchmark I wrote, but we should definitely run it against the EntitySets tests as well. I put this in a separate PR to make it easier to see the changes, but it should probably be merged into #572. This makes the logic a bit more complicated, so let me know if anything needs to be clarified.

If there is an aggregation of a `uses_full_entity` feature the aggregation
should not be calculated on the full entity. Previously because we only
had one set of dfs this was not possible.

Now, we always store the "filtered" df in `df_trie`, and if necessary also
store a full df in `large_df_trie`.

If any features at a given node require a full df we first calculate
them. Then we extract the filtered df from the result and use this to
calculate any remaining features. Because `FeatureSet.uses_full_entity` is
`True` for features which have a dependent `uses_full_entity` feature the
large df does not need to contain any of the `not_full_entity_features`.