### PR TITLE
Replace n_unique with num_unique in docs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Changelog
         * Remove unecessary time_last variable (:pr:`546`)
     * Documentation Changes
         * Add Featuretools Enterprise to documentation (:pr:`563`)
-        * Miscellaneous changes (:pr:`552`, :pr:`573`, :pr:`577`)
+        * Miscellaneous changes (:pr:`552`, :pr:`573`, :pr:`577`, :pr:`599`)
     * Testing Changes
         * Miscellaneous changes (:pr:`559`, :pr:`569`, :pr:`570`, :pr:`574`, :pr:`584`, :pr:`590`)
 

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -69,7 +69,7 @@ def dfs(entities=None,
         agg_primitives (list[str or AggregationPrimitive], optional): List of Aggregation
             Feature types to apply.
 
-                Default: ["sum", "std", "max", "skew", "min", "mean", "count", "percent_true", "n_unique", "mode"]
+                Default: ["sum", "std", "max", "skew", "min", "mean", "count", "percent_true", "num_unique", "mode"]
 
         trans_primitives (list[str or TransformPrimitive], optional):
             List of Transform Feature functions to apply.

--- a/featuretools/wrappers/sklearn.py
+++ b/featuretools/wrappers/sklearn.py
@@ -54,7 +54,7 @@ class DFSTransformer(TransformerMixin):
                 of Aggregation Feature types to apply.
 
                     Default: ["sum", "std", "max", "skew", "min", "mean",
-                              "count", "percent_true", "n_unique", "mode"]
+                              "count", "percent_true", "num_unique", "mode"]
 
             trans_primitives (list[str or TransformPrimitive], optional):
                 List of Transform Feature functions to apply.


### PR DESCRIPTION
The name of the primitive was changed in #510, so `n_unique` is no longer valid.