### PR TITLE
Change time since return type to numeric

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,6 +17,7 @@ Changelog
         * Improved error message for index/time_index being the same column in normalize_entity and entity_from_dataframe (:pr:`583`)
         * Removed all mentions of allow_where (:pr:`587`, :pr:`588`)
         * Removed unused variable in normalize entity (:pr:`589`)
+        * Change time since return type to numeric (:pr:`606`)
     * Changes
         * Refactor get_pandas_data_slice to take single entity (:pr:`547`)
         * Updates TimeSincePrevious and Diff Primitives (:pr:`561`)

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -17,7 +17,6 @@ from featuretools.variable_types import (
     Numeric,
     Ordinal,
     Text,
-    Timedelta,
     Variable
 )
 
@@ -369,7 +368,7 @@ class TimeSince(TransformPrimitive):
     """
     name = 'time_since'
     input_types = [[DatetimeTimeIndex], [Datetime]]
-    return_type = Timedelta
+    return_type = Numeric
     uses_calc_time = True
 
     def __init__(self, unit="seconds"):


### PR DESCRIPTION
Currently, the primitive annotation says Timedelta. It should be numeric.