### PR TITLE
Remove max_hlevel from DFS

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,7 @@ Changelog
         * Refactor get_pandas_data_slice to take single entity (:pr:`547`)
         * Updates TimeSincePrevious and Diff Primitives (:pr:`561`)
         * Remove unecessary time_last variable (:pr:`546`)
+        * Remove max_hlevel from DeepFeatureSynthesis (:pr:`608`)
     * Documentation Changes
         * Add Featuretools Enterprise to documentation (:pr:`563`)
         * Miscellaneous changes (:pr:`552`, :pr:`573`, :pr:`577`, :pr:`599`)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -637,13 +637,10 @@ class DeepFeatureSynthesis(object):
             if (variable_type == variable_types.PandasTypes._all or
                     f.variable_type == variable_type or
                     any(issubclass(f.variable_type, vt) for vt in variable_type)):
-                if max_depth is None or self._get_depth(f) <= max_depth:
+                if max_depth is None or f.get_depth(stop_at=self.seed_features) <= max_depth:
                     selected_features.append(f)
 
         return selected_features
-
-    def _get_depth(self, f):
-        return f.get_depth(stop_at=self.seed_features)
 
     def _feature_in_relationship_path(self, relationship_path, feature):
         # must be identity feature to be in the relationship path

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -53,9 +53,6 @@ class DeepFeatureSynthesis(object):
             max_depth (int, optional) : maximum allowed depth of features.
                 Default: 2. If -1, no limit.
 
-            max_hlevel (int, optional) :  #TODO how to document.
-                Default: 2. If -1, no limit.
-
             max_features (int, optional) : Cap the number of generated features to
                 this number. If -1, no limit.
 
@@ -90,7 +87,6 @@ class DeepFeatureSynthesis(object):
                  where_primitives=None,
                  groupby_trans_primitives=None,
                  max_depth=2,
-                 max_hlevel=2,
                  max_features=-1,
                  allowed_paths=None,
                  ignore_entities=None,
@@ -105,14 +101,10 @@ class DeepFeatureSynthesis(object):
             msg = 'Provided target entity %s does not exist in %s' % (target_entity_id, es_name)
             raise KeyError(msg)
 
-        # need to change max_depth and max_hlevel to None because DFs terminates when  <0
+        # need to change max_depth to None because DFs terminates when  <0
         if max_depth == -1:
             max_depth = None
         self.max_depth = max_depth
-
-        if max_hlevel == -1:
-            max_hlevel = None
-        self.max_hlevel = max_hlevel
 
         self.max_features = max_features
 
@@ -401,9 +393,6 @@ class DeepFeatureSynthesis(object):
         Raises:
             Exception: Attempted to add a single feature multiple times
         """
-        if (self.max_hlevel is not None and
-                self._max_hlevel(new_feature) > self.max_hlevel):
-            return
         entity_id = new_feature.entity.id
         name = new_feature.unique_name()
 
@@ -648,9 +637,7 @@ class DeepFeatureSynthesis(object):
             if (variable_type == variable_types.PandasTypes._all or
                     f.variable_type == variable_type or
                     any(issubclass(f.variable_type, vt) for vt in variable_type)):
-                if ((max_depth is None or self._get_depth(f) <= max_depth) and
-                        (self.max_hlevel is None or
-                         self._max_hlevel(f) <= self.max_hlevel)):
+                if max_depth is None or self._get_depth(f) <= max_depth:
                     selected_features.append(f)
 
         return selected_features
@@ -673,24 +660,6 @@ class DeepFeatureSynthesis(object):
                 return True
 
         return False
-
-    def _max_hlevel(self, f):
-        # for each base_feat along each path in f,
-        # if base_feat is a direct_feature of an agg_primitive
-        # determine aggfeat's hlevel
-        # return max hlevel
-        deps = [f] + f.get_dependencies(deep=True)
-        hlevel = 0
-        for d in deps:
-            if isinstance(d, DirectFeature) and \
-                    isinstance(d.base_features[0], AggregationFeature):
-
-                assert d.parent_entity.id == d.base_features[0].entity.id
-                path, new_hlevel = self.es.find_path(self.target_entity_id,
-                                                     d.parent_entity.id,
-                                                     include_num_forward=True)
-                hlevel = max(hlevel, new_hlevel)
-        return hlevel
 
 
 def check_stacking(primitive, inputs):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -203,39 +203,6 @@ def test_find_backward_paths_multiple_relationships(games_es):
     assert r2.parent_variable.id == 'id'
 
 
-def test_find_path(es):
-    path, forward = es.find_path('products', 'customers',
-                                 include_num_forward=True)
-
-    assert len(path) == 3
-    assert forward == 2
-    assert path[0].child_entity.id == 'log'
-    assert path[0].parent_entity.id == 'products'
-    assert path[1].child_entity.id == 'log'
-    assert path[1].parent_entity.id == 'sessions'
-    assert path[2].child_entity.id == 'sessions'
-    assert path[2].parent_entity.id == 'customers'
-
-
-def test_find_path_same_entity(es):
-    path, forward = es.find_path('products', 'products',
-                                 include_num_forward=True)
-    assert len(path) == 0
-    assert forward == 0
-
-    # also test include_num_forward==False
-    path = es.find_path('products', 'products',
-                        include_num_forward=False)
-    assert len(path) == 0
-
-
-def test_find_path_no_path_found(es):
-    es.relationships = []
-    error_text = "No path from products to customers. Check that all entities are connected by relationships"
-    with pytest.raises(ValueError, match=error_text):
-        es.find_path('products', 'customers')
-
-
 def test_has_unique_path(diamond_es):
     assert diamond_es.has_unique_forward_path('customers', 'regions')
     assert not diamond_es.has_unique_forward_path('transactions', 'regions')

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -575,39 +575,6 @@ def test_dfeats_where(es):
         features, 'COUNT(log WHERE products.department = electronics)'))
 
 
-def test_max_hlevel(es):
-    kwargs = dict(
-        target_entity_id='log',
-        entityset=es,
-        agg_primitives=[Count, Last],
-        trans_primitives=[Hour],
-        max_depth=-1,
-    )
-
-    dfs_h_n1 = DeepFeatureSynthesis(max_hlevel=-1, **kwargs)
-    dfs_h_0 = DeepFeatureSynthesis(max_hlevel=0, **kwargs)
-    dfs_h_1 = DeepFeatureSynthesis(max_hlevel=1, **kwargs)
-    feats_n1 = dfs_h_n1.build_features()
-    feats_n1 = [f.get_name() for f in feats_n1]
-    feats_0 = dfs_h_0.build_features()
-    feats_0 = [f.get_name() for f in feats_0]
-    feats_1 = dfs_h_1.build_features()
-    feats_1 = [f.get_name() for f in feats_1]
-
-    customer_log = ft.Feature(es['log']['value'], parent_entity=es['customers'], primitive=Last)
-    session_log = ft.Feature(es['log']['value'], parent_entity=es['sessions'], primitive=Last)
-    log_customer_log = ft.Feature(ft.Feature(customer_log, es["sessions"]), es['log'])
-    log_session_log = ft.Feature(session_log, es['log'])
-    assert log_customer_log.get_name() in feats_n1
-    assert log_session_log.get_name() in feats_n1
-
-    assert log_customer_log.get_name() not in feats_1
-    assert log_session_log.get_name() in feats_1
-
-    assert log_customer_log.get_name() not in feats_0
-    assert log_session_log.get_name() not in feats_0
-
-
 def test_commutative(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='log',
                                    entityset=es,


### PR DESCRIPTION
This was not exposed in the `dfs` method so it always used the default
value of 2, it was undocumented, and it was unclear if it provided any
value.

Also remove `EntitySet.find_path` as it is no longer used.

The base branch should be changed to `master` after #600 is merged.

