### PR TITLE
Select columns from dataframe using a list

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
+    :user:`CJStadler`
 
 **v0.9.0** June 19, 2019
     * Enhancements

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 **Future Release**
     * Enhancements
     * Fixes
-      * Change type of features calculated on Index features to Categorical (:pr:`602`)
+        * Select columns of dataframe using a list (:pr:`615`)
+        * Change type of features calculated on Index features to Categorical (:pr:`602`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -617,11 +617,11 @@ class FeatureSetCalculator(object):
                          if isinstance(v, (variable_types.Index,
                                            variable_types.Id,
                                            variable_types.TimeIndex))}
-        features = [self.feature_set.features_by_name[name]
-                    for name in feature_names]
+        features = (self.feature_set.features_by_name[name]
+                    for name in feature_names)
         feature_columns = {f.variable.id for f in features
                            if isinstance(f, IdentityFeature)}
-        return index_columns | feature_columns
+        return list(index_columns | feature_columns)
 
 
 def _can_agg(feature):


### PR DESCRIPTION
Previously the columns were in a set, but this does not work on pandas 0.23.

Fixes #614
