### PR TITLE
Remove Timedelta data param

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
         * Change type of features calculated on Index features to Categorical (:pr:`602`)
     * Changes
         * Remove unused variance_selection.py file (:pr:`613`)
+        * Remove Timedelta data param (:pr:`619`)
     * Documentation Changes
     * Testing Changes
 

--- a/featuretools/exceptions.py
+++ b/featuretools/exceptions.py
@@ -1,9 +1,3 @@
-class NotEnoughData(Exception):
-
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
-
-
 class UnknownFeature(Exception):
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Constructing a Timedelta with data via `__call__` was removed in #572 ,
so this is no longer used.

Resolves #592 
