### PR TITLE
Filter entity df through forward relationship in CFM

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
     * Fixes
         * Select columns of dataframe using a list (:pr:`615`)
         * Change type of features calculated on Index features to Categorical (:pr:`602`)
+        * Filter dataframes through forward relationships (:pr:`625`)
     * Changes
         * Remove unused variance_selection.py file (:pr:`613`)
         * Remove Timedelta data param (:pr:`619`)

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -205,22 +205,22 @@ class FeatureSetCalculator(object):
 
         # Step 3: Recurse on children.
 
+        # Pass filtered values, even if we are using a full df.
+        if need_full_entity:
+            filtered_df = df[df[filter_variable].isin(filter_values)]
+        else:
+            filtered_df = df
+
         for edge, sub_trie in feature_trie.children():
             is_forward, relationship = edge
             if is_forward:
                 sub_entity = relationship.parent_entity.id
                 sub_filter_variable = relationship.parent_variable.id
-                sub_filter_values = df[relationship.child_variable.id]
+                sub_filter_values = filtered_df[relationship.child_variable.id]
                 parent_data = None
             else:
                 sub_entity = relationship.child_entity.id
                 sub_filter_variable = relationship.child_variable.id
-
-                # Pass filtered values, even if we are using a full df.
-                if need_full_entity:
-                    filtered_df = df[df[filter_variable].isin(filter_values)]
-                else:
-                    filtered_df = df
                 sub_filter_values = filtered_df[relationship.parent_variable.id]
 
                 parent_data = (relationship,


### PR DESCRIPTION
If the current entity node uses the full entity df we were filtering the
parent using the values from the full df instead of the filtered df.
This resulted in calculating features on the full df unnecessarily.

This bug seems so obvious I'm wondering whether it was just missed
in #598 , or if there is a legitimate reason not to do this through
forward paths which I am now forgetting.