### PR TITLE
removed DaysSince primitive

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,13 +14,14 @@ Changelog
     * Changes
         * Remove unused variance_selection.py file (:pr:`613`)
         * Remove Timedelta data param (:pr:`619`)
+        * Remove DaysSince primitive (:pr:`628`)
     * Documentation Changes
         * Add installation instructions for add-on libraries (:pr:`617`)
     * Testing Changes
         * Miscellaneous changes (:pr:`595`, :pr:`612`)
 
     Thanks to the following people for contributing to this release:
-    :user:`CJStadler`, :user:`kmax12`, :user:`rwedge`, :user:`gsheni`
+    :user:`CJStadler`, :user:`kmax12`, :user:`rwedge`, :user:`gsheni`, :user:`kkleidal`
 
 **v0.9.0** June 19, 2019
     * Enhancements

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -381,30 +381,6 @@ class TimeSince(TransformPrimitive):
         return pd_time_since
 
 
-class DaysSince(TransformPrimitive):
-    """Calculates the number of days from a value to a specified datetime.
-
-    Examples:
-        >>> from datetime import datetime
-        >>> days_since = DaysSince()
-        >>> dates = [datetime(2019, 3, 2, 0),
-        ...          datetime(2019, 3, 10, 12),
-        ...          datetime(2019, 3, 1, 0)]
-        >>> cutoff_date = datetime(2019, 3, 1, 0, 0, 0, 0)
-        >>> days_since(array=dates, time=cutoff_date).tolist()
-        [-1, -10, 0]
-    """
-    name = "days_since"
-    input_types = [DatetimeTimeIndex]
-    return_type = Numeric
-    uses_calc_time = True
-
-    def get_function(self):
-        def pd_days_since(array, time):
-            return (time - pd.DatetimeIndex(array)).days
-        return pd_days_since
-
-
 class IsIn(TransformPrimitive):
     """Determines whether a value is present in a provided list.
 


### PR DESCRIPTION
### Pull Request Description

Fixes #605

According to #605 , DaysSince is made obsolete by TimeSince, since DaysSince is equivalent to TimeSince(unit="days"). This patch removes the obsolete DaysSince primitive

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
