### PR TITLE
Fix relationship path deserialization

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
     * Fixes
         * Fix performance regression in DFS (:pr:`637`)
+        * Fix deserialization of feature relationship path (:pr:`665`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes
@@ -18,7 +19,7 @@ Changelog
         * Miscellaneous changes ()
 
     Thanks to the following people for contributing to this release:
-    :user:`ayushpatidar`, :user:`jeff-hernandez`, :user:`gsheni`
+    :user:`ayushpatidar`, :user:`jeff-hernandez`, :user:`gsheni`, :user:`CJStadler`
 
 
 **v0.9.1 July 3, 2019**

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -562,7 +562,7 @@ class AggregationFeature(FeatureBase):
         relationship_path = [Relationship.from_dictionary(r, entityset)
                              for r in arguments['relationship_path']]
         parent_entity = relationship_path[0].parent_entity
-        relationship_path = [(False, r) for r in relationship_path]
+        relationship_path = RelationshipPath([(False, r) for r in relationship_path])
 
         primitive = primitives_deserializer.deserialize_primitive(arguments['primitive'])
 

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -349,10 +349,11 @@ def test_serialization(es):
     }
 
     assert dictionary == max1.get_arguments()
-    assert max1 == \
-        ft.AggregationFeature.from_dictionary(dictionary, es,
-                                              {value.unique_name(): value},
-                                              primitives_deserializer)
+    deserialized = ft.AggregationFeature.from_dictionary(dictionary,
+                                                         es,
+                                                         {value.unique_name(): value},
+                                                         primitives_deserializer)
+    _assert_agg_feats_equal(max1, deserialized)
 
     is_purchased = ft.IdentityFeature(es['log']['purchased'])
     use_previous = ft.Timedelta(3, 'd')
@@ -373,9 +374,11 @@ def test_serialization(es):
         value.unique_name(): value,
         is_purchased.unique_name(): is_purchased
     }
-    assert max2 == \
-        ft.AggregationFeature.from_dictionary(dictionary, es, dependencies,
-                                              primitives_deserializer)
+    deserialized = ft.AggregationFeature.from_dictionary(dictionary,
+                                                         es,
+                                                         dependencies,
+                                                         primitives_deserializer)
+    _assert_agg_feats_equal(max2, deserialized)
 
 
 def test_time_since_last(es):
@@ -605,3 +608,12 @@ def test_make_three_most_common(es):
         else:
             for i1, i2 in zip(true_results.iloc[i], df.iloc[i]):
                 assert (pd.isnull(i1) and pd.isnull(i2)) or (i1 == i2)
+
+
+def _assert_agg_feats_equal(f1, f2):
+    assert f1.unique_name() == f2.unique_name()
+    assert f1.child_entity.id == f2.child_entity.id
+    assert f1.parent_entity.id == f2.parent_entity.id
+    assert f1.relationship_path == f2.relationship_path
+    assert f1.primitive == f2.primitive
+    assert f1.use_previous == f2.use_previous

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -615,5 +615,4 @@ def _assert_agg_feats_equal(f1, f2):
     assert f1.child_entity.id == f2.child_entity.id
     assert f1.parent_entity.id == f2.parent_entity.id
     assert f1.relationship_path == f2.relationship_path
-    assert f1.primitive == f2.primitive
     assert f1.use_previous == f2.use_previous


### PR DESCRIPTION
We were deserializing the `AggregationFeatures.relationship_path` as a `list` instead of a `RelationshipPath`.

Fixes #657