### PR TITLE
Do not calculate dependencies of precalculated features 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
     * Fixes
         * Fix performance regression in DFS (:pr:`637`)
         * Fix deserialization of feature relationship path (:pr:`665`)
+        * Don't calculate dependencies of unnecessary features (:pr:`667`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -189,12 +189,11 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     # Get features to approximate
     if approximate is not None:
-        approximate_feature_trie, all_approx_feature_set = gather_approximate_features(feature_set)
+        approximate_feature_trie = gather_approximate_features(feature_set)
         # Make a new FeatureSet that ignores approximated features
         feature_set = FeatureSet(features, ignored_feature_trie=approximate_feature_trie)
     else:
         approximate_feature_trie = None
-        all_approx_feature_set = None
 
     # Check if there are any non-approximated aggregation features
     no_unapproximated_aggs = True
@@ -205,7 +204,11 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
             no_unapproximated_aggs = False
             break
 
-        deps = feature.get_dependencies(deep=True, ignored=all_approx_feature_set)
+        if approximate_feature_trie:
+            all_approx_features = {f for _, feats in approximate_feature_trie for f in feats}
+        else:
+            all_approx_features = set()
+        deps = feature.get_dependencies(deep=True, ignored=all_approx_features)
         for dependency in deps:
             if isinstance(dependency, AggregationFeature):
                 no_unapproximated_aggs = False

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -29,7 +29,7 @@ class FeatureSetCalculator(object):
     """
 
     def __init__(self, entityset, feature_set, time_last=None,
-                 training_window=None, precalculated_features=None, ignored=None):
+                 training_window=None, precalculated_features=None):
         """
         Args:
             feature_set (FeatureSet): The features to calculate values for.
@@ -43,12 +43,10 @@ class FeatureSetCalculator(object):
             precalculated_features (Trie[RelationshipPath -> pd.DataFrame]):
                 Maps RelationshipPaths to dataframes of precalculated_features
 
-            ignored (set[str], optional): Unique names of precalculated features.
         """
         self.entityset = entityset
         self.feature_set = feature_set
         self.training_window = training_window
-        self.ignored = ignored
 
         if time_last is None:
             time_last = datetime.now()
@@ -169,14 +167,10 @@ class FeatureSetCalculator(object):
                 ancestor_relationship_variables is the names of variables which
                 link the parent entity to its ancestors.
         """
-
         # Step 1: Get a dataframe for the given entity, filtered by the given
         # conditions.
 
         need_full_entity, full_entity_features, not_full_entity_features = feature_trie.value
-        if self.ignored:
-            full_entity_features -= self.ignored
-            not_full_entity_features -= self.ignored
 
         all_features = full_entity_features | not_full_entity_features
         entity = self.entityset[entity_id]

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -66,12 +66,18 @@ def datetime_round(dt, freq, round_up=False):
 
 
 def gather_approximate_features(feature_set):
-    # A trie where the edges are RelationshipPaths and the nodes contain sets of
-    # feature names.
-    approximate_feature_trie = Trie(default=set, path_constructor=RelationshipPath)
+    """
+    Find features which can be approximated. Returned as a trie where the values
+    are sets of feature names.
 
-    # A set of all approximated feature names.
-    approximate_feature_set = set()
+    Args:
+        feature_set (FeatureSet): Features to search the dependencies of for
+            features to approximate.
+
+    Returns:
+        Trie[RelationshipPath, set[str]]
+    """
+    approximate_feature_trie = Trie(default=set, path_constructor=RelationshipPath)
 
     for feature in feature_set.target_features:
         if feature_set.uses_full_entity(feature, check_dependents=True):
@@ -88,9 +94,8 @@ def gather_approximate_features(feature_set):
             if isinstance(base_feature, AggregationFeature):
                 node_feature_set = approximate_feature_trie.get_node(path).value
                 node_feature_set.add(base_feature.unique_name())
-                approximate_feature_set.add(base_feature.unique_name())
 
-    return approximate_feature_trie, approximate_feature_set
+    return approximate_feature_trie
 
 
 def gen_empty_approx_features_df(approx_features):

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -66,11 +66,11 @@ def datetime_round(dt, freq, round_up=False):
 
 
 def gather_approximate_features(feature_set):
-    # A trie where the edges are RelationshipPaths and the nodes contain lists
-    # of features.
-    approximate_feature_trie = Trie(default=list, path_constructor=RelationshipPath)
+    # A trie where the edges are RelationshipPaths and the nodes contain sets of
+    # feature names.
+    approximate_feature_trie = Trie(default=set, path_constructor=RelationshipPath)
 
-    # A set of feature names.
+    # A set of all approximated feature names.
     approximate_feature_set = set()
 
     for feature in feature_set.target_features:
@@ -86,8 +86,8 @@ def gather_approximate_features(feature_set):
                 base_feature = base_feature.base_features[0]
 
             if isinstance(base_feature, AggregationFeature):
-                feature_list = approximate_feature_trie.get_node(path).value
-                feature_list.append(base_feature)
+                node_feature_set = approximate_feature_trie.get_node(path).value
+                node_feature_set.add(base_feature.unique_name())
                 approximate_feature_set.add(base_feature.unique_name())
 
     return approximate_feature_trie, approximate_feature_set

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -165,7 +165,7 @@ class RelationshipPath(object):
         if self._relationships_with_direction:
             path = '%s.%s' % (next(self.entities()), self.name)
         else:
-            path = 'empty'
+            path = '[]'
         return '<RelationshipPath %s>' % path
 
 

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -161,6 +161,13 @@ class RelationshipPath(object):
         return isinstance(other, RelationshipPath) and \
             self._relationships_with_direction == other._relationships_with_direction
 
+    def __repr__(self):
+        if self._relationships_with_direction:
+            path = '%s.%s' % (next(self.entities()), self.name)
+        else:
+            path = 'empty'
+        return '<RelationshipPath %s>' % path
+
 
 def _direction_name(is_forward, relationship):
     if is_forward:

--- a/featuretools/tests/computational_backend/test_feature_set.py
+++ b/featuretools/tests/computational_backend/test_feature_set.py
@@ -108,7 +108,7 @@ def test_feature_trie_with_needs_full_entity_direct(es):
         (True, {value.unique_name()}, set())
 
 
-def test_feature_trie_with_ignored_features(es):
+def test_feature_trie_ignores_approximate_features(es):
     value = ft.IdentityFeature(es['log']['value'],)
     agg = ft.AggregationFeature(value, es['sessions'],
                                 primitive=ft.primitives.Mean)
@@ -117,9 +117,9 @@ def test_feature_trie_with_ignored_features(es):
     direct = ft.DirectFeature(agg_of_agg, es['sessions'])
     features = [direct, agg]
 
-    ignored_features = Trie(default=list, path_constructor=RelationshipPath)
-    ignored_features.get_node(direct.relationship_path).value = [agg_of_agg]
-    feature_set = FeatureSet(features, ignored_feature_trie=ignored_features)
+    approximate_feature_trie = Trie(default=list, path_constructor=RelationshipPath)
+    approximate_feature_trie.get_node(direct.relationship_path).value = [agg_of_agg]
+    feature_set = FeatureSet(features, approximate_feature_trie=approximate_feature_trie)
     trie = feature_set.feature_trie
 
     # Since agg_of_agg is ignored it and its dependencies should not be in the

--- a/featuretools/tests/computational_backend/test_feature_set.py
+++ b/featuretools/tests/computational_backend/test_feature_set.py
@@ -1,6 +1,8 @@
 import featuretools as ft
 from featuretools.computational_backends.feature_set import FeatureSet
+from featuretools.entityset.relationship import RelationshipPath
 from featuretools.tests.testing_utils import backward_path
+from featuretools.utils import Trie
 
 
 def test_feature_trie_without_needs_full_entity(diamond_es):
@@ -104,3 +106,28 @@ def test_feature_trie_with_needs_full_entity_direct(es):
 
     assert child_through_parent_node.get_node(agg.relationship_path).value == \
         (True, {value.unique_name()}, set())
+
+
+def test_feature_trie_with_ignored_features(es):
+    value = ft.IdentityFeature(es['log']['value'],)
+    agg = ft.AggregationFeature(value, es['sessions'],
+                                primitive=ft.primitives.Mean)
+    agg_of_agg = ft.AggregationFeature(agg, es['customers'],
+                                       primitive=ft.primitives.Sum)
+    direct = ft.DirectFeature(agg_of_agg, es['sessions'])
+    features = [direct, agg]
+
+    ignored_features = Trie(default=list, path_constructor=RelationshipPath)
+    ignored_features.get_node(direct.relationship_path).value = [agg_of_agg]
+    feature_set = FeatureSet(features, ignored_feature_trie=ignored_features)
+    trie = feature_set.feature_trie
+
+    # Since agg_of_agg is ignored it and its dependencies should not be in the
+    # trie.
+    sub_trie = trie.get_node(direct.relationship_path)
+    for _path, (_, _, features) in sub_trie:
+        assert not features
+
+    assert trie.value == (False, set(), {direct.unique_name(), agg.unique_name()})
+    assert trie.get_node(agg.relationship_path).value == \
+        (False, set(), {value.unique_name()})

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -4,9 +4,8 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
-from numpy.testing import assert_array_equal
-
 import pytest
+from numpy.testing import assert_array_equal
 
 import featuretools as ft
 from featuretools import Timedelta

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -793,7 +793,7 @@ def test_precalculated_features(es):
     # Set up a FeatureSet which knows which features are precalculated.
     precalculated_feature_trie = Trie(default=set, path_constructor=RelationshipPath)
     precalculated_feature_trie.get_node(direct.relationship_path).value.add(agg2.unique_name())
-    feature_set = FeatureSet([direct], ignored_feature_trie=precalculated_feature_trie)
+    feature_set = FeatureSet([direct], approximate_feature_trie=precalculated_feature_trie)
 
     # Fake precalculated data.
     values = [0, 1, 2]


### PR DESCRIPTION
Currently if there is a precalculated feature "A(B)" (and no other feature depends on B) we will still re-calculate B even though the resulting feature vector will never be used.

This commit solves this by making FeatureSet aware of which features will be precalculated, so that it can exclude them and their dependencies from the feature trie.

Script showing this:
<details>

```py
import pandas as pd
import featuretools as ft

from datetime import datetime
from featuretools.tests.testing_utils import make_ecommerce_entityset

es = make_ecommerce_entityset()


class Hello(ft.primitives.AggregationPrimitive):
    name = "hello"
    input_types = [ft.variable_types.Numeric]
    return_type = ft.variable_types.Numeric

    def get_function(self):
        def hello(s):
            print('Hello')
            return 0
        return hello

class World(ft.primitives.AggregationPrimitive):
    name = "world"
    input_types = [ft.variable_types.Numeric]
    return_type = ft.variable_types.Numeric

    def get_function(self):
        def hello(s):
            print('World')
            return 0
        return hello

agg_feat = ft.Feature(es['log']['value'], parent_entity=es['sessions'], primitive=Hello)
agg_feat2 = ft.Feature(agg_feat, parent_entity=es['customers'], primitive=World)
dfeat = ft.DirectFeature(agg_feat2, es['sessions'])
cutoff_time = pd.DataFrame({
    'time': [datetime(2013, 4, 9, 10, 31, 19), datetime(2013, 4, 9, 11, 0, 0)],
    'instance_id': [0, 2]
})
feature_matrix = ft.calculate_feature_matrix([dfeat],
                                             es,
                                             cutoff_time_in_index=False,
                                             approximate=ft.Timedelta(12, 's'),
                                             cutoff_time=cutoff_time,
                                             chunk_size='cutoff time')
```

On master this outputs

```
Hello
Hello
Hello
World
Hello
Hello
Hello
Hello
Hello
Hello
World
Hello
Hello
Hello
```

The 3 `Hello`s after each `World` are generating feature vectors which are never used (this is only obvious for the last 3 though).

On this branch we instead get

```
Hello
Hello
Hello
World
Hello
Hello
Hello
World
```

</details>