### PR TITLE
Normalize entity same index as base entity

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,7 +11,7 @@ Changelog
         * Set index after adding ancestor relationship variables (:pr:`668`)
         * Fix user-supplied variable_types modification in Entity init (:pr:`675`)
         * Don't calculate dependencies of unnecessary features (:pr:`667`)
-        * Fix normalize entity's new entity having same index as base entity (:pr:`681`)
+        * Prevent normalize entity's new entity having same index as base entity (:pr:`681`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Changelog
         * Set index after adding ancestor relationship variables (:pr:`668`)
         * Fix user-supplied variable_types modification in Entity init (:pr:`675`)
         * Don't calculate dependencies of unnecessary features (:pr:`667`)
+        * Normalize entity same index as base entity #681 (:pr:`681`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,7 +11,7 @@ Changelog
         * Set index after adding ancestor relationship variables (:pr:`668`)
         * Fix user-supplied variable_types modification in Entity init (:pr:`675`)
         * Don't calculate dependencies of unnecessary features (:pr:`667`)
-        * Normalize entity same index as base entity #681 (:pr:`681`)
+        * Fix normalize entity's new entity having same index as base entity (:pr:`681`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -557,6 +557,8 @@ class EntitySet(object):
                 raise ValueError("'make_time_index' must be a variable in the base entity")
             elif make_time_index not in additional_variables + copy_variables:
                 raise ValueError("'make_time_index' must specified in 'additional_variables' or 'copy_variables'")
+        if index == base_entity.index:
+            raise ValueError("'index' must be different from the index column of the base entity")
 
         transfer_types = {}
         transfer_types[index] = type(base_entity[index])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -789,6 +789,22 @@ def test_normalize_entity_new_time_index(es):
     assert len(es['values'].df.columns) == 2
     assert es['values'].df[new_time_index].is_monotonic_increasing
 
+def test_normalize_entity_same_index(es):
+    transactions_df = pd.DataFrame({"id": [1, 2, 3],
+                                    "transaction_time": pd.date_range(start="10:00", periods=3, freq="10s"),
+                                    "first_entity_time": [1, 2, 3]})
+    es = ft.EntitySet("example")
+    es.entity_from_dataframe(entity_id="entity",
+                             index="id",
+                             time_index="transaction_time",
+                             dataframe=transactions_df)
+
+    error_text = "'index' must be different from the index column of the base entity"
+    with pytest.raises(ValueError, match=error_text):
+        es.normalize_entity(base_entity_id="entity",
+                            new_entity_id="new_entity",
+                            index="id",
+                            make_time_index=True)
 
 def test_secondary_time_index(es):
     es.normalize_entity('log', 'values', 'value',

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -789,6 +789,7 @@ def test_normalize_entity_new_time_index(es):
     assert len(es['values'].df.columns) == 2
     assert es['values'].df[new_time_index].is_monotonic_increasing
 
+
 def test_normalize_entity_same_index(es):
     transactions_df = pd.DataFrame({"id": [1, 2, 3],
                                     "transaction_time": pd.date_range(start="10:00", periods=3, freq="10s"),
@@ -805,6 +806,7 @@ def test_normalize_entity_same_index(es):
                             new_entity_id="new_entity",
                             index="id",
                             make_time_index=True)
+
 
 def test_secondary_time_index(es):
     es.normalize_entity('log', 'values', 'value',


### PR DESCRIPTION
This request addresses #670 .

Adds a check and raises an exception if the index of the base entity is equal to the index argument. This request adds an accompanying test case.

As stated in #670, Feature tools does not handle one-to-one relationships in entitysets. Therefore, this check must be made to stop creating a one-to-one relationship with the same index.
