### PR TITLE
Specify tqdm >= 4.32.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 ---------
 **Future Release**
     * Enhancements
-        * Give more frequent progress bar updates and update chunk size behavior (:pr:`631`)
+        * Give more frequent progress bar updates and update chunk size behavior (:pr:`631`, :pr:`696`)
         * Added drop_first as param in encode_features (:pr:`647`)
         * Generate transform features of direct features (:pr:`623`)
         * Added serializing and deserializing from S3 and deserializing from URLs (:pr:`685`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.13.3
 pandas>=0.23.0
-tqdm>=4.19.2
+tqdm>=4.32.0
 toolz>=0.8.2
 pyyaml>=3.12
 cloudpickle>=0.4.0


### PR DESCRIPTION
815c46b uses `tqdm.reset` which was added in 4.32.0

Resolves #695