### PR TITLE
Don't delete the whole destination folder while saving entityset

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Changelog
         * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`723`)
         * Fixed CumCount and other group-by transform primitives that take ID as input (:pr:`733`)
 	* Updated training_window error assertion to only check against observations (:pr:`728`)
+        * Don't delete the whole destination folder while saving entityset (:pr:`717`)
     * Changes
         * Raise warning and not error on schema version mismatch (:pr:`718`)
     * Documentation Changes

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-import shutil
 import tarfile
 
 import boto3
@@ -145,9 +144,7 @@ def write_data_description(entityset, path, profile_name=None, **kwargs):
         raise ValueError("Writing to URLs is not supported")
     else:
         path = os.path.abspath(path)
-        if os.path.exists(path):
-            shutil.rmtree(path)
-        os.makedirs(os.path.join(path, 'data'))
+        os.makedirs(os.path.join(path, 'data'), exist_ok=True)
         dump_data_description(entityset, path, **kwargs)
 
 

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -1,4 +1,5 @@
 import datetime
+import errno
 import json
 import os
 import tarfile
@@ -144,7 +145,12 @@ def write_data_description(entityset, path, profile_name=None, **kwargs):
         raise ValueError("Writing to URLs is not supported")
     else:
         path = os.path.abspath(path)
-        os.makedirs(os.path.join(path, 'data'), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(path, 'data'))
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
         dump_data_description(entityset, path, **kwargs)
 
 

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -1,4 +1,5 @@
 import errno
+import json
 import os
 import shutil
 
@@ -268,11 +269,15 @@ def test_serialize_url_csv(es):
         es.to_csv(URL, encoding='utf-8', engine='python')
 
 
-def test_serialize_data_description(es, tmpdir):
+def test_serialize_subdirs_not_removed(es, tmpdir):
     write_path = tmpdir.mkdir("test")
     test_dir = write_path.mkdir("test_dir")
+    with open(write_path.join('data_description.json'), 'w') as f:
+        json.dump('__SAMPLE_TEXT__', f)
     serialize.write_data_description(es, path=str(write_path), index='1', sep='\t', encoding='utf-8', compression=None)
     assert os.path.exists(str(test_dir))
+    with open(write_path.join('data_description.json'), 'r') as f:
+        assert '__SAMPLE_TEXT__' not in json.load(f)
 
 
 def test_deserialize_url_csv(es):

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -268,6 +268,13 @@ def test_serialize_url_csv(es):
         es.to_csv(URL, encoding='utf-8', engine='python')
 
 
+def test_serialize_data_description(es, tmpdir):
+    write_path = tmpdir.mkdir("test")
+    test_dir = write_path.mkdir("test_dir")
+    serialize.write_data_description(es, path=str(write_path), index='1', sep='\t', encoding='utf-8', compression=None)
+    assert os.path.exists(test_dir)
+
+
 def test_deserialize_url_csv(es):
     new_es = deserialize.read_entityset(URL)
     assert es.__eq__(new_es, deep=True)

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -272,7 +272,7 @@ def test_serialize_data_description(es, tmpdir):
     write_path = tmpdir.mkdir("test")
     test_dir = write_path.mkdir("test_dir")
     serialize.write_data_description(es, path=str(write_path), index='1', sep='\t', encoding='utf-8', compression=None)
-    assert os.path.exists(test_dir)
+    assert os.path.exists(str(test_dir))
 
 
 def test_deserialize_url_csv(es):

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -272,11 +272,11 @@ def test_serialize_url_csv(es):
 def test_serialize_subdirs_not_removed(es, tmpdir):
     write_path = tmpdir.mkdir("test")
     test_dir = write_path.mkdir("test_dir")
-    with open(write_path.join('data_description.json'), 'w') as f:
+    with open(str(write_path.join('data_description.json')), 'w') as f:
         json.dump('__SAMPLE_TEXT__', f)
     serialize.write_data_description(es, path=str(write_path), index='1', sep='\t', encoding='utf-8', compression=None)
     assert os.path.exists(str(test_dir))
-    with open(write_path.join('data_description.json'), 'r') as f:
+    with open(str(write_path.join('data_description.json')), 'r') as f:
         assert '__SAMPLE_TEXT__' not in json.load(f)
 
 


### PR DESCRIPTION
### Pull Request Description
Fixes #706  as the title suggests. The new functionality is to replace the conflicting files only and not the whole path.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
