### PR TITLE
Raise an error when DatetimeTimeIndex is a variable but time_index is empty

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Changelog
         * Improve how files are copied and written (:pr:`721`)
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
-        * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`497`)
+        * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`723`)
     * Changes
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,6 @@ Changelog
         * Improve how files are copied and written (:pr:`721`)
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
-        * Added error message when DatetimeTimeIndex is not set as time_index (:pr:`497`)
     * Changes
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
         * Improve how files are copied and written (:pr:`721`)
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
+        * Added error message when DatetimeTimeIndex is not set as time_index (:pr:`497`)
     * Changes
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`christopherbunn`
+    :user:`jeff-hernandez`, :user:`christopherbunn`, :user:`kmax12`
 
 
 **v0.10.1 Aug 25, 2019**
@@ -24,7 +24,7 @@ Changelog
         * Fixed FAQ cell output (:pr:`710`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`kmax12`, :user:`rwedge`
+    :user:`gsheni`, :user:`rwedge`
 
 
 **v0.10.0 Aug 19, 2019**

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,13 +7,14 @@ Changelog
         * Improve how files are copied and written (:pr:`721`)
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
+        * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`497`)
     * Changes
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`
+    :user:`jeff-hernandez`, :user:`christopherbunn`
 
 
 **v0.10.1 Aug 25, 2019**

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -486,7 +486,8 @@ class EntitySet(object):
             raise ValueError("time_index and index cannot be the same value, %s" % (time_index))
 
         if vtypes.DatetimeTimeIndex in variable_types.values() and time_index is None:
-            raise ValueError("'DatetimeTimeIndex' must be set using time_index parameter")
+            var_name = variable_types.keys()[variable_types.values().index(vtypes.DatetimeTimeIndex)]
+            raise ValueError("Variable %s must be set using time_index parameter" % (var_name))
 
         entity = Entity(
             entity_id,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -485,9 +485,10 @@ class EntitySet(object):
         if time_index is not None and time_index == index:
             raise ValueError("time_index and index cannot be the same value, %s" % (time_index))
 
-        if vtypes.DatetimeTimeIndex in variable_types.values() and time_index is None:
-            var_name = variable_types.keys()[variable_types.values().index(vtypes.DatetimeTimeIndex)]
-            raise ValueError("Variable %s must be set using time_index parameter" % (var_name))
+        if time_index is None:
+            for variable, variable_type in variable_types.items():
+                if variable_type == vtypes.DatetimeTimeIndex:
+                    raise ValueError("Variable %s must be set using time_index parameter" % (variable))
 
         entity = Entity(
             entity_id,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -488,7 +488,7 @@ class EntitySet(object):
         if time_index is None:
             for variable, variable_type in variable_types.items():
                 if variable_type == vtypes.DatetimeTimeIndex:
-                    raise ValueError("Variable %s must be set using time_index parameter" % (variable))
+                    raise ValueError("DatetimeTimeIndex variable %s must be set using time_index parameter" % (variable))
 
         entity = Entity(
             entity_id,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -485,6 +485,9 @@ class EntitySet(object):
         if time_index is not None and time_index == index:
             raise ValueError("time_index and index cannot be the same value, %s" % (time_index))
 
+        if vtypes.DatetimeTimeIndex in variable_types.values() and time_index is None:
+            raise ValueError("'DatetimeTimeIndex' must be set using time_index parameter")
+
         entity = Entity(
             entity_id,
             dataframe,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -951,7 +951,7 @@ def test_use_time_index():
     df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
                        "transaction_time": pd.date_range(start="10:00", periods=6, freq="10s")})
     es = ft.EntitySet()
-    error_text = "'DatetimeTimeIndex' must be set using time_index parameter"
+    error_text = "Variable transaction_time must be set using time_index parameter"
     with pytest.raises(ValueError, match=error_text):
         es.entity_from_dataframe(entity_id="entity",
                                  index="id",

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -951,7 +951,7 @@ def test_use_time_index():
     df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
                        "transaction_time": pd.date_range(start="10:00", periods=6, freq="10s")})
     es = ft.EntitySet()
-    error_text = "Variable transaction_time must be set using time_index parameter"
+    error_text = "DatetimeTimeIndex variable transaction_time must be set using time_index parameter"
     with pytest.raises(ValueError, match=error_text):
         es.entity_from_dataframe(entity_id="entity",
                                  index="id",

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -945,3 +945,20 @@ def test_same_index_values():
                             new_entity_id="new_entity",
                             index="first_entity_time",
                             make_time_index=True)
+
+
+def test_use_time_index():
+    df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                       "transaction_time": pd.date_range(start="10:00", periods=6, freq="10s")})
+    es = ft.EntitySet()
+    error_text = "'DatetimeTimeIndex' must be set using time_index parameter"
+    with pytest.raises(ValueError, match=error_text):
+        es.entity_from_dataframe(entity_id="entity",
+                                 index="id",
+                                 variable_types={"transaction_time": variable_types.DatetimeTimeIndex},
+                                 dataframe=df)
+
+    es.entity_from_dataframe(entity_id="entity",
+                             index="id",
+                             time_index="transaction_time",
+                             dataframe=df)


### PR DESCRIPTION
Added a ValueError message when a DatetimeTimeIndex is set as a variable but is not specified as a time_index

fixes #497 