### PR TITLE
Updated training window error assertion for relative units

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
         * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`723`)
+	* Updated training_window error assertion to only check against observations (:pr:`728`) 
     * Changes
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pandas.api.types as pdtypes
 
 from featuretools import variable_types as vtypes
-from featuretools.entityset.timedelta import Timedelta
 from featuretools.utils import is_string
 from featuretools.utils.entity_utils import (
     col_is_datetime,
@@ -240,10 +239,9 @@ class Entity(object):
         instance_vals = self._vals_to_series(instance_vals, variable_id)
 
         training_window = _check_timedelta(training_window)
+
         if training_window is not None:
-            assert (isinstance(training_window, Timedelta) and
-                    training_window.is_absolute()),\
-                "training window must be an absolute Timedelta"
+            assert training_window.unit != "o", "Training window cannot be in observations"
 
         if instance_vals is None:
             df = self.df.copy()

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -509,6 +509,7 @@ class Entity(object):
             if time_last is not None and not df.empty:
                 df = df[df[self.time_index] <= time_last]
                 if training_window is not None:
+                    training_window = _check_timedelta(training_window)
                     mask = df[self.time_index] >= time_last - training_window
                     if self.last_time_index is not None:
                         lti_slice = self.last_time_index.reindex(df.index)

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -118,8 +118,9 @@ def dfs(entities=None,
 
         training_window (Timedelta or str, optional):
             Window defining how much time before the cutoff time data
-            can be used when calculating features. If ``None`` , all data before cutoff time is used.
-            Defaults to ``None``.
+            can be used when calculating features. If ``None`` , all data
+            before cutoff time is used. Defaults to ``None``. Month and year
+            units are not relative when Pandas Timedeltas are used.
 
         approximate (Timedelta): Bucket size to group instances with similar
             cutoff times by for features with costly calculations. For example,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -120,7 +120,8 @@ def dfs(entities=None,
             Window defining how much time before the cutoff time data
             can be used when calculating features. If ``None`` , all data
             before cutoff time is used. Defaults to ``None``. Month and year
-            units are not relative when Pandas Timedeltas are used.
+            units are not relative when Pandas Timedeltas are used. Relative
+            units should be passed as a Featuretools Timedelta or a string.
 
         approximate (Timedelta): Bucket size to group instances with similar
             cutoff times by for features with costly calculations. For example,

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -292,7 +292,7 @@ def test_training_window(es):
 
     es.add_last_time_indexes()
 
-    error_text = 'training window must be an absolute Timedelta'
+    error_text = 'Training window cannot be in observations'
     with pytest.raises(AssertionError, match=error_text):
         feature_matrix = calculate_feature_matrix([property_feature],
                                                   es,

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -148,8 +148,8 @@ def test_accepts_pandas_training_window():
     transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5],
                                     "card_id": [1, 1, 5, 1, 5],
                                     "transaction_time": pd.to_datetime([
-                                        '2012-1-1 04:00', '2014-2-1 05:00',
-                                        '2014-3-1 06:00', '2014-4-1 08:00',
+                                        '2011-1-1 04:00', '2012-2-28 05:00',
+                                        '2012-2-29 06:00', '2012-3-1 08:00',
                                         '2014-4-1 10:00']),
                                     "fraud": [True, False, False, False, True]})
 
@@ -171,12 +171,20 @@ def test_accepts_pandas_training_window():
 
     feature_matrix_2, features_2 = dfs(entityset=es,
                                        target_entity="transactions",
-                                       cutoff_time=pd.Timestamp("2014-4-1 04:00"))
+                                       cutoff_time=pd.Timestamp("2012-4-1 04:00"))
 
     feature_matrix_3, features_3 = dfs(entityset=es,
                                        target_entity="transactions",
-                                       cutoff_time=pd.Timestamp("2014-4-1 04:00"),
+                                       cutoff_time=pd.Timestamp("2012-4-1 04:00"),
                                        training_window=pd.Timedelta(3, "M"))
+
+    # Test case for leap years
+    feature_matrix_4, features_4 = dfs(entityset=es,
+                                       target_entity="transactions",
+                                       cutoff_time=pd.Timestamp("2013-2-28 04:00"),
+                                       training_window=pd.Timedelta(1, "Y"))
+
     assert feature_matrix.index.all([1, 2, 3, 4, 5])
-    assert feature_matrix_2.index.all([1, 2, 3])
-    assert feature_matrix_3.index.all([2, 3])
+    assert feature_matrix_2.index.all([1, 2, 3, 4])
+    assert feature_matrix_3.index.all([2, 3, 4])
+    assert feature_matrix_4.index.all([2, 3])

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -34,7 +34,7 @@ def datetime_es():
     transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5],
                                     "card_id": [1, 1, 5, 1, 5],
                                     "transaction_time": pd.to_datetime([
-                                        '2011-1-1 04:00', '2012-2-28 05:00',
+                                        '2011-2-28 04:00', '2012-2-28 05:00',
                                         '2012-2-29 06:00', '2012-3-1 08:00',
                                         '2014-4-1 10:00']),
                                     "fraud": [True, False, False, False, True]})
@@ -190,20 +190,20 @@ def test_accepts_relative_training_window(datetime_es):
     # Test case for leap years
     feature_matrix_5, features_5 = dfs(entityset=datetime_es,
                                        target_entity="transactions",
-                                       cutoff_time=pd.Timestamp("2013-2-28 04:00"),
+                                       cutoff_time=pd.Timestamp("2012-2-29 04:00"),
                                        training_window=Timedelta("1 year"))
 
-    assert feature_matrix.index.all([1, 2, 3, 4, 5])
-    assert feature_matrix_2.index.all([1, 2, 3, 4])
-    assert feature_matrix_3.index.all([2, 3, 4])
-    assert feature_matrix_4.index.all([2, 3, 4])
-    assert feature_matrix_4.index.all([2, 3])
+    assert (feature_matrix.index == [1, 2, 3, 4, 5]).all()
+    assert (feature_matrix_2.index == [1, 2, 3, 4]).all()
+    assert (feature_matrix_3.index == [2, 3, 4]).all()
+    assert (feature_matrix_4.index == [2, 3, 4]).all()
+    assert (feature_matrix_5.index == [1, 2]).all()
 
 
 def test_accepts_pandas_training_window(datetime_es):
-    feature_matrix_3, features_3 = dfs(entityset=datetime_es,
-                                       target_entity="transactions",
-                                       cutoff_time=pd.Timestamp("2012-4-1 04:00"),
-                                       training_window=pd.Timedelta(90, "D"))
+    feature_matrix, features = dfs(entityset=datetime_es,
+                                   target_entity="transactions",
+                                   cutoff_time=pd.Timestamp("2012-4-1 04:00"),
+                                   training_window=pd.Timedelta(90, "D"))
 
-    assert feature_matrix_3.index.all([2, 3, 4])
+    assert (feature_matrix.index == [2, 3, 4]).all()


### PR DESCRIPTION
- Updated the error assertion for query_by_values so that an error is asserted only when the training window is in observations #719
- Added a test case for when a relative unit is used for the training window #618 
- Updated test_calcuate_feature_matrix.py for new error assertion message