### PR TITLE
Remove mock dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 pytest==4.1.1
-mock==2.0.0
 pympler==0.5
 pytest-xdist==1.26.1
 pytest-cov==2.6.1


### PR DESCRIPTION
This PR removes mock as a dependency to run the tests. Featuretools doesn't import mock directly.  Another testing dependency, moto, also has mock as a dependency, so mock will still be installed in order to run the tests.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
