### PR TITLE
Adding progress_callback parameter to dfs() and calculate_feature_matrix(), removing time remaining

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
         * Improve how files are copied and written (:pr:`721`)
         * Add number of rows to graph in entityset.plot (:pr:`727`)
         * Enable feature-specific top_n value using a dictionary in encode_features (:pr:`735`)
+        * Added progress_callback parameter to dfs() and calculate_feature_matrix() (:pr:`739`)
     * Fixes
         * Fixed entity set deserialization (:pr:`720`)
         * Added error message when DateTimeIndex is a variable but not set as the time_index (:pr:`723`)
@@ -14,6 +15,7 @@ Changelog
 	* Updated training_window error assertion to only check against observations (:pr:`728`)
     * Changes
         * Raise warning and not error on schema version mismatch (:pr:`718`)
+        * Removed time remaining from displayed progress bar in dfs() and calculate_feature_matrix() (:pr:`739`)
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -238,10 +238,10 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     chunk_size = _handle_chunk_size(chunk_size, cutoff_time.shape[0])
     tqdm_options = {'total': (cutoff_time.shape[0] / .95),  # make total 5% higher to allot time for wrapping up at end
                     'smoothing': .05,  # arbitrary selection close to 0, which would be no smoothing
-                    'bar_format': PBAR_FORMAT
-                    }
+                    'bar_format': PBAR_FORMAT}
     if progress_callback is not None:
         if not verbose:
+            # allows us to utilize progress_bar updates without printing to anywhere
             tqdm_options.update({'file': open(os.devnull, 'w')})
     else:
         tqdm_options.update({'disable': (not verbose)})
@@ -285,16 +285,17 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     if save_progress and os.path.exists(os.path.join(save_progress, 'temp')):
         shutil.rmtree(os.path.join(save_progress, 'temp'))
 
-    # force to 100% since we saved last 5 percent
     if progress_callback is not None:
         update = (progress_bar.total - progress_bar.n) / progress_bar.total * 100
         progress_percent = 100.0
         time_elapsed = progress_bar.format_dict["elapsed"]
         progress_callback(update, progress_percent, time_elapsed)
-
+    
+    # force to 100% since we saved last 5 percent
     progress_bar.update(progress_bar.total - progress_bar.n)
     progress_bar.refresh()
     progress_bar.close()
+    
     return feature_matrix
 
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -332,7 +332,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
         def calc_results(time_last, ids, precalculated_features=None, training_window=None):
 
             update_progress_callback = None
-     
+
             if progress_bar is not None:
                 def update_progress_callback(done):
                     previous_progress = progress_bar.n

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -118,7 +118,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
         progress_callback (callable): function to be called with incremental progress updates.
             Has the following parameters:
-            
+
                 update: percentage change in progress since last call
                 progress_percent: percentage of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -290,12 +290,12 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
         progress_percent = 100.0
         time_elapsed = progress_bar.format_dict["elapsed"]
         progress_callback(update, progress_percent, time_elapsed)
-    
+
     # force to 100% since we saved last 5 percent
     progress_bar.update(progress_bar.total - progress_bar.n)
     progress_bar.refresh()
     progress_bar.close()
-    
+
     return feature_matrix
 
 
@@ -327,7 +327,9 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
 
         @save_csv_decorator(save_progress)
         def calc_results(time_last, ids, precalculated_features=None, training_window=None):
+
             update_progress_callback = None
+
             if progress_bar is not None:
                 def update_progress_callback(done):
                     previous_progress = progress_bar.n

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -115,6 +115,12 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
             Valid keyword arguments for LocalCluster will also be accepted.
 
         save_progress (str, optional): path to save intermediate computational results.
+
+        progress_callback (callable): function to be called with incremental progress updates.
+            Has the following parameters:
+                update: percentage change in progress since last call
+                progress_percent: percentage of total computation completed
+                time_elapsed: total time in seconds that has elapsed since start of call
     """
     assert (isinstance(features, list) and features != [] and
             all([isinstance(feature, FeatureBase) for feature in features])), \

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -41,12 +41,22 @@ PBAR_FORMAT = "Elapsed: {elapsed} | Progress: {l_bar}{bar}"
 PBAR_FORMAT_REMAINING = PBAR_FORMAT + "| Remaining: {remaining}"
 
 
+def progress_callback_dummy(update, progress_percentage, time_elapsed):
+    """
+    update: change in progress since last call
+    progress_percent: percentage of total computation completed
+    time_elapsed: featuretools estimate of time remaining in seconds. None if no estimate
+    """
+    print("update: ", update, "progress_percent %: ", progress_percentage, "time_elapsed: ", time_elapsed)
+
+
 def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instance_ids=None,
                              entities=None, relationships=None,
                              cutoff_time_in_index=False,
                              training_window=None, approximate=None,
                              save_progress=None, verbose=False,
-                             chunk_size=None, n_jobs=1, dask_kwargs=None):
+                             chunk_size=None, n_jobs=1,
+                             dask_kwargs=None, progress_callback=progress_callback_dummy):
     """Calculates a matrix for a given set of instance ids and calculation times.
 
     Args:
@@ -230,14 +240,16 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
         cutoff_time_to_pass = cutoff_time
 
     chunk_size = _handle_chunk_size(chunk_size, cutoff_time.shape[0])
-
-    # make total 5% higher to allot time for wrapping up at end
-    progress_bar = make_tqdm_iterator(
-        total=cutoff_time.shape[0] / .95,
-        smoothing=.05,  # arbitrary selection close to 0, which would be no smoothing
-        bar_format=PBAR_FORMAT,
-        disable=(not verbose)
-    )
+    tqdm_options = {'total': (cutoff_time.shape[0] / .95),  # make total 5% higher to allot time for wrapping up at end
+                    'smoothing': .05,  # arbitrary selection close to 0, which would be no smoothing
+                    'bar_format': PBAR_FORMAT
+                    }
+    if progress_callback is not None:
+        if not verbose:
+            make_tqdm_iterator.update({'file': open(os.devnull, 'w')})
+    else:
+        make_tqdm_iterator.update({'disable': (not verbose)})
+    progress_bar = make_tqdm_iterator(**tqdm_options)
 
     if n_jobs != 1 or dask_kwargs is not None:
         feature_matrix = parallel_calculate_chunks(cutoff_time=cutoff_time_to_pass,
@@ -266,7 +278,8 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                                          cutoff_df_time_var=cutoff_df_time_var,
                                          target_time=target_time,
                                          pass_columns=pass_columns,
-                                         progress_bar=progress_bar)
+                                         progress_bar=progress_bar,
+                                         progress_callback_function=progress_callback)
 
     feature_matrix.sort_index(level='time', kind='mergesort', inplace=True)
     if not cutoff_time_in_index:
@@ -276,16 +289,17 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
         shutil.rmtree(os.path.join(save_progress, 'temp'))
 
     # force to 100% since we saved last 5 percent
+    print("ending:", "total:", progress_bar.total, "n:", progress_bar.n, cutoff_time.shape[0])
+
     progress_bar.update(progress_bar.total - progress_bar.n)
     progress_bar.refresh()
     progress_bar.close()
-
     return feature_matrix
 
 
 def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate, training_window,
                     save_progress, no_unapproximated_aggs, cutoff_df_time_var, target_time,
-                    pass_columns, progress_bar=None):
+                    pass_columns, progress_bar=None, progress_callback_function=None):
     if not isinstance(feature_set, FeatureSet):
         feature_set = cloudpickle.loads(feature_set)
 
@@ -311,20 +325,22 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
 
         @save_csv_decorator(save_progress)
         def calc_results(time_last, ids, precalculated_features=None, training_window=None):
-
-            progress_callback = None
-
+            update_progress_callback = None
             if progress_bar is not None:
-                def progress_callback(done):
+                def update_progress_callback(done):
+                    previous_progress = progress_bar.n
                     progress_bar.update(done * group.shape[0])
-
+                    if progress_callback_function is not None:
+                        update = (progress_bar.n - previous_progress) / progress_bar.total * 100
+                        progress_percent = (progress_bar.n / progress_bar.total) * 100
+                        time_elapsed = progress_bar.format_dict["elapsed"]
+                        progress_callback_function(update, progress_percent, time_elapsed)
             calculator = FeatureSetCalculator(entityset,
                                               feature_set,
                                               time_last,
                                               training_window=training_window,
                                               precalculated_features=precalculated_features)
-
-            matrix = calculator.run(ids, progress_callback=progress_callback)
+            matrix = calculator.run(ids, update_progress_callback=update_progress_callback)
             return matrix
 
         # if all aggregations have been approximated, can calculate all together

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -119,8 +119,8 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
         progress_callback (callable): function to be called with incremental progress updates.
             Has the following parameters:
 
-                update: percentage change in progress since last call
-                progress_percent: percentage of total computation completed
+                update: percentage change (float between 0 and 100) in progress since last call
+                progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
     """
@@ -239,14 +239,15 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     chunk_size = _handle_chunk_size(chunk_size, cutoff_time.shape[0])
     tqdm_options = {'total': (cutoff_time.shape[0] / .95),  # make total 5% higher to allot time for wrapping up at end
-                    'smoothing': .05,  # arbitrary selection close to 0, which would be no smoothing
                     'bar_format': PBAR_FORMAT}
-    if progress_callback is not None:
-        if not verbose:
+
+    if not verbose:
+        if progress_callback is not None:
             # allows us to utilize progress_bar updates without printing to anywhere
             tqdm_options.update({'file': open(os.devnull, 'w')})
-    else:
-        tqdm_options.update({'disable': (not verbose)})
+        else:
+            tqdm_options.update({'disable': True})
+
     progress_bar = make_tqdm_iterator(**tqdm_options)
 
     if n_jobs != 1 or dask_kwargs is not None:
@@ -346,7 +347,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
                                               time_last,
                                               training_window=training_window,
                                               precalculated_features=precalculated_features)
-            matrix = calculator.run(ids, update_progress_callback=update_progress_callback)
+            matrix = calculator.run(ids, progress_callback=update_progress_callback)
             return matrix
 
         # if all aggregations have been approximated, can calculate all together

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -118,9 +118,11 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
         progress_callback (callable): function to be called with incremental progress updates.
             Has the following parameters:
+            
                 update: percentage change in progress since last call
                 progress_percent: percentage of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
+
     """
     assert (isinstance(features, list) and features != [] and
             all([isinstance(feature, FeatureBase) for feature in features])), \

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -239,14 +239,14 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     chunk_size = _handle_chunk_size(chunk_size, cutoff_time.shape[0])
     tqdm_options = {'total': (cutoff_time.shape[0] / .95),  # make total 5% higher to allot time for wrapping up at end
-                    'bar_format': PBAR_FORMAT}
+                    'bar_format': PBAR_FORMAT,
+                    'disable': True}
 
-    if not verbose:
-        if progress_callback is not None:
-            # allows us to utilize progress_bar updates without printing to anywhere
-            tqdm_options.update({'file': open(os.devnull, 'w')})
-        else:
-            tqdm_options.update({'disable': True})
+    if verbose:
+        tqdm_options.update({'disable': False})
+    elif progress_callback is not None:
+        # allows us to utilize progress_bar updates without printing to anywhere
+        tqdm_options.update({'file': open(os.devnull, 'w'), 'disable': False})
 
     progress_bar = make_tqdm_iterator(**tqdm_options)
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -61,7 +61,7 @@ class FeatureSetCalculator(object):
         # total number of features (including dependencies) to be calculate
         self.num_features = len(feature_set.features_by_name.values())
 
-    def run(self, instance_ids, progress_callback=None):
+    def run(self, instance_ids, update_progress_callback=None):
         """
         Calculate values of features for the given instances of the target
         entity.
@@ -82,7 +82,7 @@ class FeatureSetCalculator(object):
             instance_ids (np.ndarray or pd.Categorical): Instance ids for which
                 to build features.
 
-            progress_callback (callable): function to be called with incremental progress updates
+            update_progress_callback (callable): function to be called with incremental progress updates
 
         Returns:
             pd.DataFrame : Pandas DataFrame of calculated feature values.
@@ -91,11 +91,10 @@ class FeatureSetCalculator(object):
         """
         assert len(instance_ids) > 0, "0 instance ids provided"
 
-        if progress_callback is None:
+        if update_progress_callback is None:
             # do nothing for the progress call back if not provided
-            def progress_callback(*args):
+            def update_progress_callback(*args):
                 pass
-
         feature_trie = self.feature_set.feature_trie
 
         df_trie = Trie(path_constructor=RelationshipPath)
@@ -109,7 +108,7 @@ class FeatureSetCalculator(object):
                                             precalculated_trie=self.precalculated_features,
                                             filter_variable=target_entity.index,
                                             filter_values=instance_ids,
-                                            progress_callback=progress_callback)
+                                            update_progress_callback=update_progress_callback)
 
         # The dataframe for the target entity should be stored at the root of
         # df_trie.
@@ -144,7 +143,7 @@ class FeatureSetCalculator(object):
                                        precalculated_trie,
                                        filter_variable, filter_values,
                                        parent_data=None,
-                                       progress_callback=None):
+                                       update_progress_callback=None):
         """
         Generate dataframes with features calculated for this node of the trie,
         and all descendant nodes. The dataframes will be stored in df_trie.
@@ -203,7 +202,7 @@ class FeatureSetCalculator(object):
                                     training_window=self.training_window)
 
         # call to update timer
-        progress_callback(0)
+        update_progress_callback(0)
 
         # Step 2: Add variables to the dataframe linking it to all ancestors.
         new_ancestor_relationship_variables = []
@@ -220,7 +219,7 @@ class FeatureSetCalculator(object):
             new_ancestor_relationship_variables.append(parent_relationship.child_variable.id)
 
         # call to update timer
-        progress_callback(0)
+        update_progress_callback(0)
 
         # Step 3: Recurse on children.
 
@@ -258,7 +257,7 @@ class FeatureSetCalculator(object):
                 filter_variable=sub_filter_variable,
                 filter_values=sub_filter_values,
                 parent_data=parent_data,
-                progress_callback=progress_callback)
+                update_progress_callback=update_progress_callback)
 
         # Step 4: Calculate the features for this entity.
         #
@@ -276,13 +275,13 @@ class FeatureSetCalculator(object):
                           suffixes=('', '_precalculated'))
 
         # call to update timer
-        progress_callback(0)
+        update_progress_callback(0)
 
         # First, calculate any features that require the full entity. These can
         # be calculated first because all of their dependents are included in
         # full_entity_features.
         if need_full_entity:
-            df = self._calculate_features(df, full_entity_df_trie, full_entity_features, progress_callback)
+            df = self._calculate_features(df, full_entity_df_trie, full_entity_features, update_progress_callback)
 
             # Store full entity df.
             full_entity_df_trie.value = df
@@ -292,13 +291,13 @@ class FeatureSetCalculator(object):
             df = df[df[filter_variable].isin(filter_values)]
 
         # Calculate all features that don't require the full entity.
-        df = self._calculate_features(df, df_trie, not_full_entity_features, progress_callback)
+        df = self._calculate_features(df, df_trie, not_full_entity_features, update_progress_callback)
 
         # Step 5: Store the dataframe for this entity at the root of df_trie, so
         # that it can be accessed by the caller.
         df_trie.value = df
 
-    def _calculate_features(self, df, df_trie, features, progress_callback):
+    def _calculate_features(self, df, df_trie, features, update_progress_callback):
         # Group the features so that each group can be calculated together.
         # The groups must also be in topological order (if A is a transform of B
         # then B must be in a group before A).
@@ -307,7 +306,7 @@ class FeatureSetCalculator(object):
         for group in feature_groups:
             representative_feature = group[0]
             handler = self._feature_type_handler(representative_feature)
-            df = handler(group, df, df_trie, progress_callback)
+            df = handler(group, df, df_trie, update_progress_callback)
 
         return df
 
@@ -395,9 +394,7 @@ class FeatureSetCalculator(object):
         for f in features:
             assert f.get_name() in df, (
                 'Column "%s" missing frome dataframe' % f.get_name())
-
         progress_callback(len(features) / float(self.num_features))
-
         return df
 
     def _calculate_transform_features(self, features, frame, _df_trie, progress_callback):
@@ -405,9 +402,7 @@ class FeatureSetCalculator(object):
             # handle when no data
             if frame.shape[0] == 0:
                 set_default_column(frame, f)
-
                 progress_callback(1 / float(self.num_features))
-
                 continue
 
             # collect only the variables we need for this transformation
@@ -428,7 +423,6 @@ class FeatureSetCalculator(object):
             else:
                 values = [strip_values_if_series(values)]
             update_feature_columns(f, frame, values)
-
             progress_callback(1 / float(self.num_features))
 
         return frame

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -394,7 +394,9 @@ class FeatureSetCalculator(object):
         for f in features:
             assert f.get_name() in df, (
                 'Column "%s" missing frome dataframe' % f.get_name())
+
         progress_callback(len(features) / float(self.num_features))
+
         return df
 
     def _calculate_transform_features(self, features, frame, _df_trie, progress_callback):
@@ -402,7 +404,9 @@ class FeatureSetCalculator(object):
             # handle when no data
             if frame.shape[0] == 0:
                 set_default_column(frame, f)
+
                 progress_callback(1 / float(self.num_features))
+
                 continue
 
             # collect only the variables we need for this transformation
@@ -423,6 +427,7 @@ class FeatureSetCalculator(object):
             else:
                 values = [strip_values_if_series(values)]
             update_feature_columns(f, frame, values)
+
             progress_callback(1 / float(self.num_features))
 
         return frame

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -163,8 +163,8 @@ def dfs(entities=None,
         progress_callback (callable): function to be called with incremental progress updates.
             Has the following parameters:
 
-                update: percentage change in progress since last call
-                progress_percent: percentage of total computation completed
+                update: percentage change (float between 0 and 100) in progress since last call
+                progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
     Examples:

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -162,9 +162,11 @@ def dfs(entities=None,
 
         progress_callback (callable): function to be called with incremental progress updates.
             Has the following parameters:
+
                 update: percentage change in progress since last call
                 progress_percent: percentage of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
+
     Examples:
         .. code-block:: python
 

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -34,7 +34,8 @@ def dfs(entities=None,
         n_jobs=1,
         dask_kwargs=None,
         verbose=False,
-        return_variable_types=None):
+        return_variable_types=None,
+        progress_callback=None):
     '''Calculates a feature matrix and features given a dictionary of entities
     and a list of relationships.
 
@@ -159,6 +160,11 @@ def dfs(entities=None,
                 Numeric, Discrete, and Boolean. If given as
                 the string 'all', use all available variable types.
 
+        progress_callback (callable): function to be called with incremental progress updates.
+            Has the following parameters:
+                update: percentage change in progress since last call
+                progress_percent: percentage of total computation completed
+                time_elapsed: total time in seconds that has elapsed since start of call
     Examples:
         .. code-block:: python
 
@@ -214,7 +220,8 @@ def dfs(entities=None,
                                                   chunk_size=chunk_size,
                                                   n_jobs=n_jobs,
                                                   dask_kwargs=dask_kwargs,
-                                                  verbose=verbose)
+                                                  verbose=verbose,
+                                                  progress_callback=progress_callback)
     else:
         feature_matrix = calculate_feature_matrix(features,
                                                   entityset=entityset,
@@ -227,5 +234,6 @@ def dfs(entities=None,
                                                   chunk_size=chunk_size,
                                                   n_jobs=n_jobs,
                                                   dask_kwargs=dask_kwargs,
-                                                  verbose=verbose)
+                                                  verbose=verbose,
+                                                  progress_callback=progress_callback)
     return feature_matrix, features

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1216,11 +1216,11 @@ def test_chunk_dataframe_groups():
 
 
 def test_calls_progress_callback(es):
-    # call with all feature types. make sure progress callback calls sum to 1
     class MockProgressCallback:
         def __init__(self):
             self.total_update = 0
             self.total_progress_percent = 0
+
         def __call__(self, update, progress_percent, time_elapsed):
             self.total_update += update
             self.total_progress_percent = progress_percent
@@ -1230,14 +1230,14 @@ def test_calls_progress_callback(es):
     trans_per_session = ft.Feature(es["transactions"]["transaction_id"], parent_entity=es["sessions"], primitive=Count)
     trans_per_customer = ft.Feature(es["transactions"]["transaction_id"], parent_entity=es["customers"], primitive=Count)
     features = [trans_per_customer, ft.Feature(trans_per_session, parent_entity=es["customers"], primitive=Max)]
-    fm = ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback)
-    
+    ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback)
+
     assert np.isclose(mock_progress_callback.total_update, 100.0)
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
-    
-    # test again with multiple jobs
+
+    # test with multiple jobs
     mock_progress_callback = MockProgressCallback()
-    fm = ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback, n_jobs=3)
+    ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback, n_jobs=3)
 
     assert np.isclose(mock_progress_callback.total_update, 100.0)
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1213,3 +1213,31 @@ def test_chunk_dataframe_groups():
     assert third[0] == 2 and third[1].shape[0] == 2
     fourth = next(chunked_grouped)
     assert fourth[0] == 3 and fourth[1].shape[0] == 1
+
+
+def test_calls_progress_callback(es):
+    # call with all feature types. make sure progress callback calls sum to 1
+    class MockProgressCallback:
+        def __init__(self):
+            self.total_update = 0
+            self.total_progress_percent = 0
+        def __call__(self, update, progress_percent, time_elapsed):
+            self.total_update += update
+            self.total_progress_percent = progress_percent
+
+    mock_progress_callback = MockProgressCallback()
+    es = ft.demo.load_mock_customer(return_entityset=True, random_seed=0)
+    trans_per_session = ft.Feature(es["transactions"]["transaction_id"], parent_entity=es["sessions"], primitive=Count)
+    trans_per_customer = ft.Feature(es["transactions"]["transaction_id"], parent_entity=es["customers"], primitive=Count)
+    features = [trans_per_customer, ft.Feature(trans_per_session, parent_entity=es["customers"], primitive=Max)]
+    fm = ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback)
+    
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+    
+    # test again with multiple jobs
+    mock_progress_callback = MockProgressCallback()
+    fm = ft.calculate_feature_matrix(features, entityset=es, progress_callback=mock_progress_callback, n_jobs=3)
+
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -814,6 +814,9 @@ def test_returns_order_of_instance_ids(es):
     assert list(df.index) == instance_ids
 
 
+
+
+
 def test_calls_progress_callback(es):
     # call with all feature types. make sure progress callback calls sum to 1
     identity = ft.Feature(es['customers']['age'])
@@ -829,19 +832,19 @@ def test_calls_progress_callback(es):
                                       time_last=None,
                                       feature_set=feature_set)
 
-    class MockProgressCallback:
+    class MockUpdateProgressCallback:
         def __init__(self):
             self.total = 0
 
         def __call__(self, update):
             self.total += update
 
-    mock_progress_callback = MockProgressCallback()
+    mock_update_progress_callback = MockUpdateProgressCallback()
 
     instance_ids = [0, 1, 2]
-    calculator.run(np.array(instance_ids), mock_progress_callback)
+    calculator.run(np.array(instance_ids), mock_update_progress_callback)
 
-    assert np.isclose(mock_progress_callback.total, 1)
+    assert np.isclose(mock_update_progress_callback.total, 1)
 
     # testing again with a time_last with no data
     feature_set = FeatureSet(all_features)
@@ -849,12 +852,12 @@ def test_calls_progress_callback(es):
                                       time_last=pd.Timestamp("1950"),
                                       feature_set=feature_set)
 
-    mock_progress_callback = MockProgressCallback()
-    calculator.run(np.array(instance_ids), mock_progress_callback)
+    mock_update_progress_callback = MockUpdateProgressCallback()
+    calculator.run(np.array(instance_ids), mock_update_progress_callback)
 
-    assert np.isclose(mock_progress_callback.total, 1)
-
-
+    assert np.isclose(mock_update_progress_callback.total, 1)
+    
+    
 def test_precalculated_features(es):
     error_msg = 'This primitive should never be used because the features are precalculated'
 

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -814,9 +814,6 @@ def test_returns_order_of_instance_ids(es):
     assert list(df.index) == instance_ids
 
 
-
-
-
 def test_calls_progress_callback(es):
     # call with all feature types. make sure progress callback calls sum to 1
     identity = ft.Feature(es['customers']['age'])
@@ -856,8 +853,8 @@ def test_calls_progress_callback(es):
     calculator.run(np.array(instance_ids), mock_update_progress_callback)
 
     assert np.isclose(mock_update_progress_callback.total, 1)
-    
-    
+
+
 def test_precalculated_features(es):
     error_msg = 'This primitive should never be used because the features are precalculated'
 

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -829,19 +829,19 @@ def test_calls_progress_callback(es):
                                       time_last=None,
                                       feature_set=feature_set)
 
-    class MockUpdateProgressCallback:
+    class MockProgressCallback:
         def __init__(self):
             self.total = 0
 
         def __call__(self, update):
             self.total += update
 
-    mock_update_progress_callback = MockUpdateProgressCallback()
+    mock_progress_callback = MockProgressCallback()
 
     instance_ids = [0, 1, 2]
-    calculator.run(np.array(instance_ids), mock_update_progress_callback)
+    calculator.run(np.array(instance_ids), mock_progress_callback)
 
-    assert np.isclose(mock_update_progress_callback.total, 1)
+    assert np.isclose(mock_progress_callback.total, 1)
 
     # testing again with a time_last with no data
     feature_set = FeatureSet(all_features)
@@ -849,10 +849,10 @@ def test_calls_progress_callback(es):
                                       time_last=pd.Timestamp("1950"),
                                       feature_set=feature_set)
 
-    mock_update_progress_callback = MockUpdateProgressCallback()
-    calculator.run(np.array(instance_ids), mock_update_progress_callback)
+    mock_progress_callback = MockProgressCallback()
+    calculator.run(np.array(instance_ids), mock_progress_callback)
 
-    assert np.isclose(mock_update_progress_callback.total, 1)
+    assert np.isclose(mock_progress_callback.total, 1)
 
 
 def test_precalculated_features(es):

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import numpy as np
 import pandas as pd
 import pytest
 from distributed.utils_test import cluster
-import numpy as np
 
 from featuretools.entityset import EntitySet, Relationship, Timedelta
 from featuretools.primitives import Max, Mean, Min, Sum

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import numpy as np
 import pandas as pd
 import pytest
 from distributed.utils_test import cluster
@@ -207,3 +207,35 @@ def test_accepts_pandas_training_window(datetime_es):
                                    training_window=pd.Timedelta(90, "D"))
 
     assert (feature_matrix.index == [2, 3, 4]).all()
+
+
+def test_calls_progress_callback(entities, relationships):
+    class MockProgressCallback:
+        def __init__(self):
+            self.total_update = 0
+            self.total_progress_percent = 0
+
+        def __call__(self, update, progress_percent, time_elapsed):
+            self.total_update += update
+            self.total_progress_percent = progress_percent
+
+    mock_progress_callback = MockProgressCallback()
+
+    feature_matrix, features = dfs(entities=entities,
+                                   relationships=relationships,
+                                   target_entity="transactions",
+                                   progress_callback=mock_progress_callback)
+
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+
+    # test with multiple jobs
+    mock_progress_callback = MockProgressCallback()
+    feature_matrix, features = dfs(entities=entities,
+                                   relationships=relationships,
+                                   target_entity="transactions",
+                                   n_jobs=3,
+                                   progress_callback=mock_progress_callback)
+
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import pandas as pd
 import pytest
 from distributed.utils_test import cluster
+import numpy as np
 
 from featuretools.entityset import EntitySet, Relationship, Timedelta
 from featuretools.primitives import Max, Mean, Min, Sum


### PR DESCRIPTION
Addresses #705 and #736 by adding `progress_callback` parameter to `dfs()` and `calculate_feature_matrix(`) and removing time remaining field from the progress bar in `verbose=True` mode.