### PR TITLE
Remove pytest-runner and setup.py test support

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ Changelog
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes
-        * Update dependencies (:pr:`738`)
+        * Update dependencies (:pr:`738`, :pr:`741`)
 
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`chidauri`, :user:`christopherbunn`, :user:`kmax12`, :user:`MarcoGorelli`, :user:`angela97lin`, :user:`frances-h`, :user:`rwedge`

--- a/setup-requirements.txt
+++ b/setup-requirements.txt
@@ -1,1 +1,0 @@
-pytest-runner==4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [metadata]
 description-file = README.md
-[aliases]
-test=pytest
 [tool:pytest]
 addopts = --doctest-modules
 python_files = featuretools/tests/*

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,7 @@ setup(
          'Programming Language :: Python :: 3.7'
     ],
     install_requires=open('requirements.txt').readlines(),
-    setup_requires=open('setup-requirements.txt').readlines(),
     python_requires='>=2.7, <4',
-    test_suite='featuretools/tests',
-    tests_require=open('test-requirements.txt').readlines(),
     extras_require=extras_require,
     keywords='feature engineering data science machine learning',
     include_package_data=True,


### PR DESCRIPTION
### Pull Request Description
Removes our configuration files for `setup.py test` and drops `pytest-runner` as a setup requirement.  To run the unit tests call `make lint` or pytest.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
