### PR TITLE
Update linting packages

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r test-requirements.txt
 codecov==2.0.15
 flake8==3.7.8
-autopep8==1.4.3
+autopep8==1.4.4
 ipython==7.2.0; python_version>'3.4'
 ipython==5.8.0; python_version<'3'
 isort==4.3.21

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
 -r test-requirements.txt
 codecov==2.0.15
-flake8==3.7.0
+flake8==3.7.8
 autopep8==1.4.3
 ipython==7.2.0; python_version>'3.4'
 ipython==5.8.0; python_version<'3'
-isort==4.3.4
+isort==4.3.21
 jupyter==1.0.0
 matplotlib==3.0.2; python_version>'3.4'
 matplotlib==2.2.3; python_version<'3'

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Changelog
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes
-        * Update dependencies (:pr:`738`, :pr:`741`)
+        * Update dependencies (:pr:`738`, :pr:`741`, :pr:`747`)
 
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`chidauri`, :user:`christopherbunn`, :user:`kmax12`, :user:`MarcoGorelli`, :user:`angela97lin`, :user:`frances-h`, :user:`rwedge`

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,6 @@ exclude = docs/*
 ignore = E501,W504 # line too long error, line break after binary operator
 [isort]
 forced_separate=featuretools
+skip=__init__.py
 # vertical hanging indent
 multi_line_output=3


### PR DESCRIPTION
Our linting-related dependencies were out of date, and this was causing some errors if users were trying run `make lint` using the latest versions of these packages ([example](https://github.com/Featuretools/featuretools/pull/688#issuecomment-516934745)).

This PR updates our dependencies to the latest versions and fixes the error encountered when using the new versions.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
