### PR TITLE
Remove toolz direct dependency

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,7 @@ Changelog
         * Raise warning and not error on schema version mismatch (:pr:`718`)
         * Removed time remaining from displayed progress bar in dfs() and calculate_feature_matrix() (:pr:`739`)
         * Raise warning in normalize_entity() when time_index of base_entity has an invalid type (:pr:`749`)
+        * Remove toolz as a direct dependency (:pr:`755`)
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes

--- a/featuretools/tests/entityset_tests/test_timedelta.py
+++ b/featuretools/tests/entityset_tests/test_timedelta.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 from dateutil.relativedelta import relativedelta
-from toolz import merge
 
 import featuretools as ft
 from featuretools.entityset import Timedelta
@@ -68,7 +67,9 @@ def test_check_timedelta(es):
     exp_to_standard_unit = {e: t for e, t in zip(expanded_units, time_units)}
     singular_units = [u[:-1] for u in expanded_units]
     sing_to_standard_unit = {s: t for s, t in zip(singular_units, time_units)}
-    to_standard_unit = merge(exp_to_standard_unit, sing_to_standard_unit)
+    to_standard_unit = {}
+    to_standard_unit.update(exp_to_standard_unit)
+    to_standard_unit.update(sing_to_standard_unit)
     full_units = singular_units + expanded_units + time_units + time_units
 
     strings = ["2 {}".format(u) for u in singular_units + expanded_units +

--- a/featuretools/tests/utils_tests/test_cli_utils.py
+++ b/featuretools/tests/utils_tests/test_cli_utils.py
@@ -25,7 +25,7 @@ def test_sys_info():
 
 def test_installed_packages():
     installed_packages = get_installed_packages()
-    requirements = ["pandas", "numpy", "tqdm", "toolz",
+    requirements = ["pandas", "numpy", "tqdm",
                     "PyYAML", "cloudpickle", "future",
                     "dask", "distributed", "psutil",
                     "Click", "scikit-learn"]

--- a/featuretools/utils/cli_utils.py
+++ b/featuretools/utils/cli_utils.py
@@ -9,7 +9,7 @@ import pkg_resources
 
 import featuretools
 
-deps = ["numpy", "pandas", "tqdm", "toolz", "PyYAML", "cloudpickle",
+deps = ["numpy", "pandas", "tqdm", "PyYAML", "cloudpickle",
         "future", "dask", "distributed", "psutil", "Click",
         "scikit-learn", "pip", "setuptools"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy>=1.13.3
 pandas>=0.23.0
 tqdm>=4.32.0
-toolz>=0.8.2
 pyyaml>=3.12
 cloudpickle>=0.4.0
 future>=0.16.0


### PR DESCRIPTION
This pr removes the one place we directly import the toolz library.  It will still get installed due to other dependencies.
