### PR TITLE
Add support for boolean variable type in Multiply primitive

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,13 +19,14 @@ Changelog
         * Raise warning and not error on schema version mismatch (:pr:`718`)
         * Removed time remaining from displayed progress bar in dfs() and calculate_feature_matrix() (:pr:`739`)
         * Raise warning in normalize_entity() when time_index of base_entity has an invalid type (:pr:`749`)
+        * Allow boolean variable types to be used in the Multiply primivite (:pr:`756`)
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes
         * Update dependencies (:pr:`738`, :pr:`741`, :pr:`747`)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`chidauri`, :user:`christopherbunn`, :user:`kmax12`, :user:`MarcoGorelli`, :user:`angela97lin`, :user:`frances-h`, :user:`rwedge`
+    :user:`jeff-hernandez`, :user:`chidauri`, :user:`christopherbunn`, :user:`kmax12`, :user:`MarcoGorelli`, :user:`angela97lin`, :user:`frances-h`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 
 **v0.10.1 Aug 25, 2019**

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,7 +21,7 @@ Changelog
         * Removed time remaining from displayed progress bar in dfs() and calculate_feature_matrix() (:pr:`739`)
         * Raise warning in normalize_entity() when time_index of base_entity has an invalid type (:pr:`749`)
         * Remove toolz as a direct dependency (:pr:`755`)
-        * Allow boolean variable types to be used in the Multiply primivite (:pr:`756`)
+        * Allow boolean variable types to be used in the Multiply primitive (:pr:`756`)
     * Documentation Changes
         * Updated URL for Compose (:pr:`716`)
     * Testing Changes

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -13,6 +13,7 @@ from featuretools.utils.wrangle import (
     _check_timedelta
 )
 from featuretools.variable_types import (
+    Boolean,
     Categorical,
     Datetime,
     DatetimeTimeIndex,
@@ -286,6 +287,9 @@ class FeatureBase(object):
 
     def __mul__(self, other):
         """Multiply by other"""
+        if isinstance(other, FeatureBase):
+            if self.variable_type == Boolean and other.variable_type == Boolean:
+                return Feature([self, other], primitive=primitives.MultiplyBoolean)
         return self._handle_binary_comparision(other, primitives.MultiplyNumeric, primitives.MultiplyNumericScalar)
 
     def __rmul__(self, other):

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -495,7 +495,11 @@ class MultiplyNumeric(TransformPrimitive):
         [2, 2, 4]
     """
     name = "multiply_numeric"
-    input_types = [Numeric, Numeric]
+    input_types = [
+        [Numeric, Numeric],
+        [Numeric, Boolean],
+        [Boolean, Numeric]
+    ]
     return_type = Numeric
     commutative = True
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -498,7 +498,7 @@ class MultiplyNumeric(TransformPrimitive):
     input_types = [
         [Numeric, Numeric],
         [Numeric, Boolean],
-        [Boolean, Numeric]
+        [Boolean, Numeric],
     ]
     return_type = Numeric
     commutative = True
@@ -536,6 +536,32 @@ class MultiplyNumericScalar(TransformPrimitive):
 
     def generate_name(self, base_feature_names):
         return "%s * %s" % (base_feature_names[0], str(self.value))
+
+
+class MultiplyBoolean(TransformPrimitive):
+    """Element-wise multiplication of two lists of boolean values.
+
+    Description:
+        Given a list of boolean values X and a list of boolean
+        values Y, determine the product of each value in X
+        with its corresponding value in Y.
+
+    Examples:
+        >>> multiply_boolean = MultiplyBoolean()
+        >>> multiply_boolean([True, True, False], [True, False, True]).tolist()
+        [True, False, False]
+    """
+    name = "multiply_boolean"
+    input_types = [[Boolean, Boolean]]
+
+    return_type = Boolean
+    commutative = True
+
+    def get_function(self):
+        return np.bitwise_and
+
+    def generate_name(self, base_feature_names):
+        return "%s * %s" % (base_feature_names[0], base_feature_names[1])
 
 
 class DivideNumeric(TransformPrimitive):

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -333,12 +333,14 @@ def test_arithmetic_of_direct(es):
 
 def test_boolean_multiply():
     es = ft.EntitySet()
-    df = pd.DataFrame({"index":[0,1,2], "bool": [True, False, True], "numeric": [2, 3, np.nan]})
-    
+    df = pd.DataFrame({"index": [0, 1, 2],
+                       "bool": [True, False, True],
+                       "numeric": [2, 3, np.nan]})
+
     es.entity_from_dataframe(entity_id="test",
                              dataframe=df,
                              index="index")
-    
+
     to_test = [
         ('numeric', 'numeric'),
         ('numeric', 'bool'),
@@ -347,9 +349,9 @@ def test_boolean_multiply():
     features = []
     for row in to_test:
         features.append(ft.Feature(es["test"][row[0]]) * ft.Feature(es["test"][row[1]]))
-    
+
     fm = ft.calculate_feature_matrix(entityset=es, features=features)
-    
+
     for row in to_test:
         assert fm[f'{row[0]} * {row[1]}'].equals(df[row[0]] * df[row[1]])
 

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -350,7 +350,6 @@ def test_boolean_multiply():
     for row in to_test:
         features.append(ft.Feature(es["test"][row[0]]) * ft.Feature(es["test"][row[1]]))
 
-    features.append(ft.Feature(es["test"]['numeric']) * 3)
     fm = ft.calculate_feature_matrix(entityset=es, features=features)
 
     for row in to_test:

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -352,7 +352,8 @@ def test_boolean_multiply():
     fm = ft.calculate_feature_matrix(entityset=es, features=features)
 
     for row in to_test:
-        assert fm[f'{row[0]} * {row[1]}'].equals(df[row[0]] * df[row[1]])
+        col_name = '{} * {}'.format(row[0], row[1])
+        assert fm[col_name].equals(df[row[0]] * df[row[1]])
 
 
 # P TODO: rewrite this  test

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -323,9 +323,8 @@ def test_arithmetic_of_direct(es):
     features = []
     for test in to_test:
         features.append(ft.Feature([log_age, log_rating], primitive=test[0]))
-    features += [log_rating, log_age]
-    df = ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 3, 5, 7])
 
+    df = ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 3, 5, 7])
     for i, test in enumerate(to_test):
         v = df[features[i].get_name()].values.tolist()
         assert v == test[1]

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -344,16 +344,21 @@ def test_boolean_multiply():
         ('numeric', 'numeric'),
         ('numeric', 'bool'),
         ('bool', 'numeric'),
+        ('bool', 'bool')
     ]
     features = []
     for row in to_test:
         features.append(ft.Feature(es["test"][row[0]]) * ft.Feature(es["test"][row[1]]))
 
+    features.append(ft.Feature(es["test"]['numeric']) * 3)
     fm = ft.calculate_feature_matrix(entityset=es, features=features)
 
     for row in to_test:
         col_name = '{} * {}'.format(row[0], row[1])
-        assert fm[col_name].equals(df[row[0]] * df[row[1]])
+        if row[0] == 'bool' and row[1] == 'bool':
+            assert fm[col_name].equals(df[row[0]] & df[row[1]])
+        else:
+            assert fm[col_name].equals(df[row[0]] * df[row[1]])
 
 
 # P TODO: rewrite this  test

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -323,11 +323,35 @@ def test_arithmetic_of_direct(es):
     features = []
     for test in to_test:
         features.append(ft.Feature([log_age, log_rating], primitive=test[0]))
-
+    features += [log_rating, log_age]
     df = ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 3, 5, 7])
+
     for i, test in enumerate(to_test):
         v = df[features[i].get_name()].values.tolist()
         assert v == test[1]
+
+
+def test_boolean_multiply():
+    es = ft.EntitySet()
+    df = pd.DataFrame({"index":[0,1,2], "bool": [True, False, True], "numeric": [2, 3, np.nan]})
+    
+    es.entity_from_dataframe(entity_id="test",
+                             dataframe=df,
+                             index="index")
+    
+    to_test = [
+        ('numeric', 'numeric'),
+        ('numeric', 'bool'),
+        ('bool', 'numeric'),
+    ]
+    features = []
+    for row in to_test:
+        features.append(ft.Feature(es["test"][row[0]]) * ft.Feature(es["test"][row[1]]))
+    
+    fm = ft.calculate_feature_matrix(entityset=es, features=features)
+    
+    for row in to_test:
+        assert fm[f'{row[0]} * {row[1]}'].equals(df[row[0]] * df[row[1]])
 
 
 # P TODO: rewrite this  test


### PR DESCRIPTION
### Pull Request Description
Update `binary_transform.py` to include support for boolean variable types in the `Multiply` primitive. Also, added a test in `test_transform_features.py` to confirm this works properly when multiplying numeric by numeric, bool by numeric, and numeric by bool.

This PR closes issue #752 
